### PR TITLE
feat(observability): implement metrics, tracing, and error tracking for 0.5.0

### DIFF
--- a/config/observability.php
+++ b/config/observability.php
@@ -6,7 +6,7 @@ declare(strict_types=1);
  * Observability Configuration
  *
  * Configuration for Pulsar's in-house observability suite:
- * logging, metrics, tracing, and error reporting.
+ * logging, metrics, tracing, error tracking, and audit logging.
  *
  * @package Pulsar\Config
  */
@@ -55,6 +55,18 @@ return [
     'tracing' => [
         'enabled' => false,
         'sampling_rate' => 0.1,
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Error Tracking
+    |--------------------------------------------------------------------------
+    */
+    'error_tracking' => [
+        'enabled' => true,
+        'max_groups' => 500,
+        'max_recent_events_per_group' => 5,
+        'sensitive_fields' => [],
     ],
 
     /*

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -8,11 +8,11 @@ Pulsar 0.5.0 introduces a built-in observability suite: metrics collection, dist
 
 Three metric types are available via `MetricType` enum:
 
-| Type | Class | Description |
-|------|-------|-------------|
-| Counter | `Pulsar\Observability\Metrics\Counter` | Monotonic incrementing value |
-| Gauge | `Pulsar\Observability\Metrics\Gauge` | Bidirectional value (set, increment, decrement) |
-| Histogram | `Pulsar\Observability\Metrics\Histogram` | Bucket-based distribution tracking |
+| Type      | Class                                    | Description                                     |
+| --------- | ---------------------------------------- | ----------------------------------------------- |
+| Counter   | `Pulsar\Observability\Metrics\Counter`   | Monotonic incrementing value                    |
+| Gauge     | `Pulsar\Observability\Metrics\Gauge`     | Bidirectional value (set, increment, decrement) |
+| Histogram | `Pulsar\Observability\Metrics\Histogram` | Bucket-based distribution tracking              |
 
 ### MetricRegistry
 

--- a/docs/OBSERVABILITY.md
+++ b/docs/OBSERVABILITY.md
@@ -1,0 +1,310 @@
+# Observability
+
+Pulsar 0.5.0 introduces a built-in observability suite: metrics collection, distributed tracing, and error tracking. All components are homegrown with no external service dependencies.
+
+## Metrics
+
+### Metric Types
+
+Three metric types are available via `MetricType` enum:
+
+| Type | Class | Description |
+|------|-------|-------------|
+| Counter | `Pulsar\Observability\Metrics\Counter` | Monotonic incrementing value |
+| Gauge | `Pulsar\Observability\Metrics\Gauge` | Bidirectional value (set, increment, decrement) |
+| Histogram | `Pulsar\Observability\Metrics\Histogram` | Bucket-based distribution tracking |
+
+### MetricRegistry
+
+Central store for all metrics. Provides create-or-return semantics — requesting the same name and type returns the existing instance. Requesting the same name with a different type throws `MetricsException`.
+
+```php
+$registry = new MetricRegistry();
+
+$counter = $registry->counter('http_requests_total', 'Total HTTP requests');
+$gauge = $registry->gauge('connections_active', 'Active connections');
+$histogram = $registry->histogram('request_duration_seconds', 'Request duration');
+```
+
+### Labels
+
+Metrics support dimensional labels via `LabelSet`:
+
+```php
+use Pulsar\Observability\Metrics\LabelSet;
+
+$labels = new LabelSet(['method' => 'GET', 'path' => '/api/users']);
+$counter->increment($labels);
+```
+
+Label sets produce a deterministic string key (sorted by key name) for internal map lookups.
+
+### Counter
+
+Monotonic counter that rejects negative increments:
+
+```php
+$counter->increment(); // +1 with default labels
+$counter->increment(new LabelSet(['method' => 'GET']), 5.0);
+$counter->value(); // get value for default labels
+$counter->values(); // all label-key => value pairs
+```
+
+### Gauge
+
+Bidirectional numeric value:
+
+```php
+$gauge->set(42.5);
+$gauge->increment(); // +1
+$gauge->decrement(new LabelSet(['pool' => 'main']), 3.0);
+```
+
+### Histogram
+
+Records observed values into configurable buckets. Default boundaries follow Prometheus conventions:
+
+```php
+[0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0]
+```
+
+Usage:
+
+```php
+$histogram = new Histogram('duration', boundaries: [0.1, 0.5, 1.0, 5.0]);
+$histogram->observe(0.3);
+$histogram->observe(2.1, new LabelSet(['endpoint' => '/api']));
+
+$histogram->count(); // observation count
+$histogram->sum(); // sum of observed values
+$histogram->buckets(); // boundary => cumulative count
+```
+
+### Prometheus Exporter
+
+`PrometheusExporter` renders the entire registry as Prometheus text exposition format 0.0.4:
+
+```php
+$exporter = new PrometheusExporter($registry);
+$text = $exporter->export();
+```
+
+Output includes `# HELP`, `# TYPE`, sample lines with labels, and histogram `_bucket`/`_sum`/`_count` series. The exporter is registered as a route at the configured endpoint (default `/metrics`) when Prometheus export is enabled.
+
+## Tracing
+
+### Core Concepts
+
+Distributed tracing follows the W3C Trace Context specification:
+
+- **TraceId** — 128-bit hex identifier (32 chars) for the entire trace
+- **SpanId** — 64-bit hex identifier (16 chars) for a single operation
+- **TraceContext** — Immutable value object holding traceId, spanId, and trace flags
+- **Span** — Mutable lifecycle object representing a timed operation
+
+### Creating Spans
+
+```php
+use Pulsar\Observability\Tracing\{Span, TraceContext, SpanStatus};
+
+$context = TraceContext::create(); // new root trace
+$span = new Span('database.query', $context);
+
+$span->setAttribute('db.statement', 'SELECT ...');
+$span->setAttribute('db.system', 'postgresql');
+
+// ... perform work ...
+
+$span->setStatus(SpanStatus::Ok);
+$span->end(); // records end time; idempotent
+```
+
+### Trace Context Propagation
+
+W3C `traceparent` header parsing and serialization:
+
+```php
+use Pulsar\Observability\Tracing\W3CTraceContextParser;
+
+// Parse incoming header
+$context = W3CTraceContextParser::parse('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01');
+
+// Create child span in same trace
+$child = $context->createChild();
+
+// Serialize for outgoing request
+$header = W3CTraceContextParser::serialize($child);
+// "00-4bf92f3577b34da6a3ce929d0e0e4736-{new-span-id}-01"
+```
+
+### InMemorySpanCollector
+
+Ring-buffer span collector implementing `SpanProcessorInterface`:
+
+```php
+$collector = new InMemorySpanCollector(maxSpans: 1000);
+
+$span->end();
+$collector->onEnd($span);
+
+$collector->spans(); // all collected spans
+$collector->spansByTraceId($traceId); // filter by trace
+$collector->count(); // number of collected spans
+```
+
+Oldest spans are evicted when the buffer exceeds capacity.
+
+## Error Tracking
+
+### Error Fingerprinting
+
+Errors are grouped by a deterministic SHA-256 fingerprint derived from:
+
+```
+{exception class}|{message}|{file}|{line}
+```
+
+This produces stable groups — the same error at the same location always maps to the same fingerprint.
+
+### ErrorEvent
+
+Readonly value object capturing a single error occurrence:
+
+```php
+use Pulsar\Observability\ErrorTracking\ErrorEvent;
+
+$event = ErrorEvent::fromThrowable($exception, context: ['user_id' => 123]);
+```
+
+Each event records: exception class, message, code, file, line, stack trace, scrubbed context, timestamp, and optional trace ID for correlation with distributed traces.
+
+### ErrorAggregator
+
+Groups errors by fingerprint, maintains occurrence counts, and caps stored events:
+
+```php
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+
+$aggregator = new ErrorAggregator(maxGroups: 500);
+$aggregator->capture($event);
+
+$groups = $aggregator->groups(); // sorted by lastSeen descending
+```
+
+When the number of groups exceeds `maxGroups`, the oldest group (by last seen) is evicted.
+
+### Sensitive Data Scrubbing
+
+`SensitiveDataScrubber` recursively scrubs arrays, replacing values for keys matching sensitive field names:
+
+```php
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+$scrubber = new SensitiveDataScrubber(additionalFields: ['custom_secret']);
+
+$scrubbed = $scrubber->scrub(['password' => 'hunter2', 'name' => 'Alice']);
+// ['password' => '[REDACTED]', 'name' => 'Alice']
+
+$headers = $scrubber->scrubHeaders(['Authorization' => 'Bearer xxx', 'Accept' => 'json']);
+// ['Authorization' => '[REDACTED]', 'Accept' => 'json']
+```
+
+Default sensitive fields: password, token, secret, api_key, authorization, credential, credit_card, ssn, private_key, access_token, refresh_token.
+
+Default sensitive headers: Authorization, Cookie, Set-Cookie, X-API-Key.
+
+## Middleware
+
+### TracingMiddleware
+
+Automatically instruments HTTP requests with distributed tracing:
+
+1. Parses incoming `traceparent` header (if present)
+2. Creates a root span named `"HTTP {METHOD} {path}"`
+3. Attaches trace context and root span to request attributes (`_trace_context`, `_root_span`)
+4. Sets span status based on response status code
+5. Adds `traceparent` header to response for propagation
+6. Respects configurable sampling rate
+
+### MetricsMiddleware
+
+Automatically records HTTP metrics:
+
+- `pulsar_http_requests_total` — Counter with labels: method, path, status
+- `pulsar_http_request_duration_seconds` — Histogram of request durations
+- `pulsar_http_errors_total` — Counter for 5xx responses with labels: method, path
+
+### Middleware Ordering
+
+TracingMiddleware is registered as the outermost middleware (first in, last out) to ensure spans cover the full request lifecycle. MetricsMiddleware is registered inner to tracing.
+
+## Configuration
+
+Configuration is via `config/observability.php`:
+
+```php
+return [
+    'log_level' => 'debug',
+    'log_channel' => 'app',
+    'metrics' => [
+        'enabled' => true,
+        'exporters' => [
+            'prometheus' => [
+                'enabled' => false,
+                'endpoint' => '/metrics',
+            ],
+        ],
+    ],
+    'tracing' => [
+        'enabled' => false,
+        'sampling_rate' => 0.1,
+    ],
+    'error_tracking' => [
+        'enabled' => true,
+        'max_groups' => 500,
+        'max_recent_events_per_group' => 5,
+        'sensitive_fields' => [],
+    ],
+];
+```
+
+### Config DTOs
+
+Each section maps to a typed readonly DTO:
+
+- `MetricsConfig` — `enabled`, `prometheusEnabled`, `prometheusEndpoint`
+- `TracingConfig` — `enabled`, `samplingRate`
+- `ErrorTrackingConfig` — `enabled`, `maxGroups`, `maxRecentEventsPerGroup`, `sensitiveFields`
+
+These are composed into `ObservabilityConfig` and built via `fromArray()` factories.
+
+## Diagnostics
+
+When debug mode is enabled, a diagnostics viewer is available at `/_pulsar/diagnostics`. It renders a dark-themed HTML page showing:
+
+- Registered metrics with current values
+- Error groups with occurrence counts and recent events
+- Recent trace spans
+
+This endpoint is for local development only and is not registered in production mode.
+
+## Integration with ExceptionHandler
+
+When error tracking is enabled, the `ExceptionHandler` automatically:
+
+1. Scrubs sensitive data from request context
+2. Creates an `ErrorEvent` from the thrown exception
+3. Links the trace ID from the current request (if tracing is active)
+4. Captures the event into the `ErrorAggregator`
+
+This happens transparently alongside existing error handling behavior.
+
+## Kernel Boot Pipeline
+
+The observability subsystems are initialized during kernel boot in this order:
+
+```
+Config -> Logger -> Tracer -> Metrics -> ErrorTracker -> ExceptionHandler -> DiagnosticsRoute -> Extensions
+```
+
+This ensures tracing is available before metrics (so metrics middleware can access trace context), and error tracking is available before the exception handler is constructed.

--- a/src/Config/ErrorTrackingConfig.php
+++ b/src/Config/ErrorTrackingConfig.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+use function is_int;
+use function is_numeric;
+
+/**
+ * Typed configuration DTO for the error tracking section of observability config.
+ */
+readonly class ErrorTrackingConfig
+{
+    /**
+     * @param list<string> $sensitiveFields Additional sensitive field names to scrub
+     */
+    public function __construct(
+        public bool $enabled = true,
+        public int $maxGroups = 500,
+        public int $maxRecentEventsPerGroup = 5,
+        public array $sensitiveFields = [],
+    ) {}
+
+    /**
+     * Build from the raw error tracking config array.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        /** @var list<string> $sensitiveFields */
+        $sensitiveFields = $data['sensitive_fields'] ?? [];
+
+        $rawMaxGroups = $data['max_groups'] ?? 500;
+        $rawMaxRecent = $data['max_recent_events_per_group'] ?? 5;
+
+        $maxGroups = is_int($rawMaxGroups) ? $rawMaxGroups : (is_numeric($rawMaxGroups) ? (int) $rawMaxGroups : 500);
+        $maxRecent = is_int($rawMaxRecent) ? $rawMaxRecent : (is_numeric($rawMaxRecent) ? (int) $rawMaxRecent : 5);
+
+        return new self(
+            enabled: (bool) ($data['enabled'] ?? true),
+            maxGroups: $maxGroups,
+            maxRecentEventsPerGroup: $maxRecent,
+            sensitiveFields: $sensitiveFields,
+        );
+    }
+}

--- a/src/Config/MetricsConfig.php
+++ b/src/Config/MetricsConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Typed configuration DTO for the metrics section of observability config.
+ */
+readonly class MetricsConfig
+{
+    public function __construct(
+        public bool $enabled = true,
+        public bool $prometheusEnabled = false,
+        public string $prometheusEndpoint = '/metrics',
+    ) {}
+
+    /**
+     * Build from the raw metrics config array.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        /** @var array<string, mixed> $exporters */
+        $exporters = $data['exporters'] ?? [];
+        /** @var array<string, mixed> $prometheus */
+        $prometheus = $exporters['prometheus'] ?? [];
+
+        return new self(
+            enabled: (bool) ($data['enabled'] ?? true),
+            prometheusEnabled: (bool) ($prometheus['enabled'] ?? false),
+            prometheusEndpoint: (string) ($prometheus['endpoint'] ?? '/metrics'), // @phpstan-ignore cast.string
+        );
+    }
+}

--- a/src/Config/ObservabilityConfig.php
+++ b/src/Config/ObservabilityConfig.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Pulsar\Config;
 
 /**
- * Typed configuration DTO for the logging section of `config/observability.php`.
+ * Typed configuration DTO for `config/observability.php`.
  *
  * Environment variables `LOG_LEVEL` and `LOG_CHANNEL` override file values.
  */
@@ -18,6 +18,9 @@ readonly class ObservabilityConfig
         public string $defaultLoggingChannel,
         public string $loggingLevel,
         public array $loggingChannels,
+        public MetricsConfig $metrics = new MetricsConfig(),
+        public TracingConfig $tracing = new TracingConfig(),
+        public ErrorTrackingConfig $errorTracking = new ErrorTrackingConfig(),
     ) {}
 
     /**
@@ -51,10 +54,28 @@ readonly class ObservabilityConfig
             );
         }
 
+        // Metrics config
+        /** @var array<string, mixed> $metricsData */
+        $metricsData = $data['metrics'] ?? [];
+        $metricsConfig = MetricsConfig::fromArray($metricsData);
+
+        // Tracing config
+        /** @var array<string, mixed> $tracingData */
+        $tracingData = $data['tracing'] ?? [];
+        $tracingConfig = TracingConfig::fromArray($tracingData);
+
+        // Error tracking config
+        /** @var array<string, mixed> $errorTrackingData */
+        $errorTrackingData = $data['error_tracking'] ?? [];
+        $errorTrackingConfig = ErrorTrackingConfig::fromArray($errorTrackingData);
+
         return new self(
             defaultLoggingChannel: $defaultChannel,
             loggingLevel: $level,
             loggingChannels: $channelConfigs,
+            metrics: $metricsConfig,
+            tracing: $tracingConfig,
+            errorTracking: $errorTrackingConfig,
         );
     }
 }

--- a/src/Config/TracingConfig.php
+++ b/src/Config/TracingConfig.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+use function is_float;
+use function is_int;
+use function is_numeric;
+
+/**
+ * Typed configuration DTO for the tracing section of observability config.
+ */
+readonly class TracingConfig
+{
+    public function __construct(
+        public bool $enabled = false,
+        public float $samplingRate = 0.1,
+    ) {}
+
+    /**
+     * Build from the raw tracing config array.
+     *
+     * @param array<string, mixed> $data
+     */
+    public static function fromArray(array $data): self
+    {
+        $rate = $data['sampling_rate'] ?? 0.1;
+
+        if (is_float($rate) || is_int($rate)) {
+            $samplingRate = (float) $rate;
+        } elseif (is_numeric($rate)) {
+            $samplingRate = (float) $rate;
+        } else {
+            $samplingRate = 0.1;
+        }
+
+        return new self(
+            enabled: (bool) ($data['enabled'] ?? false),
+            samplingRate: $samplingRate,
+        );
+    }
+}

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -20,13 +20,22 @@ use Pulsar\ErrorHandling\DevelopmentRenderer;
 use Pulsar\ErrorHandling\ExceptionHandler;
 use Pulsar\ErrorHandling\ProductionRenderer;
 use Pulsar\Extensibility\ExtensionBootstrap;
+use Pulsar\Http\Method;
+use Pulsar\Http\Middleware\MetricsMiddleware;
 use Pulsar\Http\Middleware\MiddlewareInterface;
 use Pulsar\Http\Middleware\MiddlewarePipeline;
 use Pulsar\Http\Middleware\MiddlewareRegistry;
+use Pulsar\Http\Middleware\TracingMiddleware;
 use Pulsar\Http\Request;
 use Pulsar\Http\Response;
 use Pulsar\Http\ResponseEmitter;
+use Pulsar\Observability\Diagnostics\DiagnosticsRenderer;
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
 use Pulsar\Observability\Log\Logger;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Observability\Metrics\PrometheusExporter;
+use Pulsar\Observability\Tracing\InMemorySpanCollector;
 use Pulsar\Routing\MatchedRoute;
 use Pulsar\Routing\Router;
 use RuntimeException;
@@ -40,6 +49,9 @@ use Throwable;
  *
  * The kernel is responsible for bootstrapping the application,
  * managing the lifecycle, and orchestrating the request/response cycle.
+ *
+ * Boot pipeline order:
+ * Config -> Logger -> Tracer -> Metrics -> ErrorTracker -> ExceptionHandler -> DiagnosticsRoute -> Extensions
  */
 final class Kernel
 {
@@ -83,8 +95,14 @@ final class Kernel
      * This method initializes all core services and prepares
      * the application for handling requests. Boot pipeline:
      * 1. Config loading (if ConfigManager provided)
-     * 2. Extension register phase
-     * 3. Extension boot phase
+     * 2. Logger creation
+     * 3. Tracer creation (TracingMiddleware as outermost global middleware)
+     * 4. Metrics creation (MetricsMiddleware as inner global middleware)
+     * 5. Error tracker creation
+     * 6. Exception handler creation
+     * 7. Diagnostics route registration (debug mode only)
+     * 8. Extension register phase
+     * 9. Extension boot phase
      */
     public function boot(): void
     {
@@ -92,12 +110,16 @@ final class Kernel
             return;
         }
 
-        // Config phase: load config, create logger, create exception handler
+        // Config phase: load config, create services
         if ($this->configManager !== null) {
             $this->configManager->load();
             $this->registerConfigServices();
             $this->createLogger();
+            $this->createTracer();
+            $this->createMetrics();
+            $this->createErrorTracker();
             $this->createExceptionHandler();
+            $this->registerDiagnosticsRoute();
         }
 
         // Extension register phase (all extensions)
@@ -346,6 +368,95 @@ final class Kernel
     }
 
     /**
+     * Create the tracing subsystem and register TracingMiddleware as outermost global middleware.
+     */
+    private function createTracer(): void
+    {
+        /** @var ConfigManager $configManager */
+        $configManager = $this->configManager;
+
+        /** @var ObservabilityConfig $observabilityConfig */
+        $observabilityConfig = $configManager->repository()->get(ObservabilityConfig::class);
+
+        if (!$observabilityConfig->tracing->enabled) {
+            return;
+        }
+
+        $collector = new InMemorySpanCollector();
+        $this->container->instance(InMemorySpanCollector::class, $collector);
+
+        $tracingMiddleware = new TracingMiddleware(
+            $collector,
+            $observabilityConfig->tracing->samplingRate,
+        );
+
+        // Tracing is outermost: registered first
+        $this->middleware->pipe($tracingMiddleware);
+    }
+
+    /**
+     * Create the metrics subsystem and register MetricsMiddleware as inner global middleware.
+     */
+    private function createMetrics(): void
+    {
+        /** @var ConfigManager $configManager */
+        $configManager = $this->configManager;
+
+        /** @var ObservabilityConfig $observabilityConfig */
+        $observabilityConfig = $configManager->repository()->get(ObservabilityConfig::class);
+
+        if (!$observabilityConfig->metrics->enabled) {
+            return;
+        }
+
+        $registry = new MetricRegistry();
+        $this->container->instance(MetricRegistry::class, $registry);
+
+        $metricsMiddleware = new MetricsMiddleware($registry);
+
+        // Metrics is inner: registered after tracing
+        $this->middleware->pipe($metricsMiddleware);
+
+        // Register Prometheus endpoint if enabled
+        if ($observabilityConfig->metrics->prometheusEnabled) {
+            $endpoint = $observabilityConfig->metrics->prometheusEndpoint;
+            $this->router->get($endpoint, static function () use ($registry): Response {
+                $exporter = new PrometheusExporter($registry);
+
+                return new Response(
+                    body: $exporter->export(),
+                    headers: new \Pulsar\Http\HeaderBag(['content-type' => ['text/plain; version=0.0.4; charset=utf-8']]),
+                );
+            });
+        }
+    }
+
+    /**
+     * Create the error tracking subsystem.
+     */
+    private function createErrorTracker(): void
+    {
+        /** @var ConfigManager $configManager */
+        $configManager = $this->configManager;
+
+        /** @var ObservabilityConfig $observabilityConfig */
+        $observabilityConfig = $configManager->repository()->get(ObservabilityConfig::class);
+
+        if (!$observabilityConfig->errorTracking->enabled) {
+            return;
+        }
+
+        $scrubber = new SensitiveDataScrubber($observabilityConfig->errorTracking->sensitiveFields);
+        $aggregator = new ErrorAggregator(
+            maxGroups: $observabilityConfig->errorTracking->maxGroups,
+            maxRecentEventsPerGroup: $observabilityConfig->errorTracking->maxRecentEventsPerGroup,
+        );
+
+        $this->container->instance(SensitiveDataScrubber::class, $scrubber);
+        $this->container->instance(ErrorAggregator::class, $aggregator);
+    }
+
+    /**
      * Create the exception handler from config and register in the container.
      */
     private function createExceptionHandler(): void
@@ -364,9 +475,60 @@ final class Kernel
             ? $this->container->get(LoggerInterface::class)
             : null;
 
+        $aggregator = $this->container->has(ErrorAggregator::class)
+            ? $this->container->get(ErrorAggregator::class)
+            : null;
+
+        $scrubber = $this->container->has(SensitiveDataScrubber::class)
+            ? $this->container->get(SensitiveDataScrubber::class)
+            : null;
+
         /** @var LoggerInterface|null $logger */
-        $this->exceptionHandler = new ExceptionHandler($renderer, $logger);
+        /** @var ErrorAggregator|null $aggregator */
+        /** @var SensitiveDataScrubber|null $scrubber */
+        $this->exceptionHandler = new ExceptionHandler($renderer, $logger, $aggregator, $scrubber);
         $this->container->instance(ExceptionHandler::class, $this->exceptionHandler);
+    }
+
+    /**
+     * Register the diagnostics route (debug mode only).
+     */
+    private function registerDiagnosticsRoute(): void
+    {
+        /** @var ConfigManager $configManager */
+        $configManager = $this->configManager;
+
+        /** @var AppConfig $appConfig */
+        $appConfig = $configManager->repository()->get(AppConfig::class);
+
+        if (!$appConfig->debug) {
+            return;
+        }
+
+        if (!$this->container->has(MetricRegistry::class)) {
+            return;
+        }
+
+        $container = $this->container;
+
+        $this->router->get('/_pulsar/diagnostics', static function () use ($container): Response {
+            /** @var MetricRegistry $registry */
+            $registry = $container->get(MetricRegistry::class);
+
+            $collector = $container->has(InMemorySpanCollector::class)
+                ? $container->get(InMemorySpanCollector::class)
+                : null;
+
+            $aggregator = $container->has(ErrorAggregator::class)
+                ? $container->get(ErrorAggregator::class)
+                : null;
+
+            /** @var InMemorySpanCollector|null $collector */
+            /** @var ErrorAggregator|null $aggregator */
+            $renderer = new DiagnosticsRenderer($registry, $collector, $aggregator);
+
+            return Response::html($renderer->render());
+        });
     }
 
     /**

--- a/src/ErrorHandling/ExceptionHandler.php
+++ b/src/ErrorHandling/ExceptionHandler.php
@@ -9,6 +9,10 @@ use Pulsar\Http\Request;
 use Pulsar\Http\Response;
 use Pulsar\Http\ResponseStatus;
 use Pulsar\Http\Validation\ValidationException;
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+use Pulsar\Observability\ErrorTracking\ErrorEvent;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use Pulsar\Observability\Tracing\TraceContext;
 use Pulsar\Routing\RoutingException;
 
 use function sprintf;
@@ -20,12 +24,15 @@ use Throwable;
  *
  * Resolves HTTP status from exception type, logs every exception
  * with structured context, and renders an error response.
+ * Optionally captures errors into the ErrorAggregator for grouping.
  */
 final readonly class ExceptionHandler
 {
     public function __construct(
         private ExceptionRendererInterface $renderer,
         private ?LoggerInterface $logger = null,
+        private ?ErrorAggregator $errorAggregator = null,
+        private ?SensitiveDataScrubber $scrubber = null,
     ) {}
 
     /**
@@ -37,6 +44,7 @@ final readonly class ExceptionHandler
         $headers = $this->resolveHeaders($exception);
 
         $this->logException($exception, $request, $status);
+        $this->captureError($exception, $request);
 
         // ValidationException always renders as JSON
         if ($exception instanceof ValidationException) {
@@ -129,6 +137,38 @@ final readonly class ExceptionHandler
         } else {
             $this->logger->warning($exception->getMessage(), $context);
         }
+    }
+
+    /**
+     * Capture the error into the aggregator for grouping/tracking.
+     */
+    private function captureError(Throwable $exception, Request $request): void
+    {
+        if ($this->errorAggregator === null) {
+            return;
+        }
+
+        // Build scrubbed context from request
+        $context = [
+            'method' => $request->method->value,
+            'uri' => $request->uri,
+            'query' => $request->query,
+        ];
+
+        if ($this->scrubber !== null) {
+            $context = $this->scrubber->scrub($context);
+        }
+
+        // Extract trace ID from request attributes if available
+        $traceId = null;
+        $traceContext = $request->attribute('_trace_context');
+
+        if ($traceContext instanceof TraceContext) {
+            $traceId = $traceContext->traceId;
+        }
+
+        $event = ErrorEvent::fromThrowable($exception, $context, $traceId);
+        $this->errorAggregator->capture($event);
     }
 
     /**

--- a/src/Http/Middleware/MetricsMiddleware.php
+++ b/src/Http/Middleware/MetricsMiddleware.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Http\Middleware;
+
+use function hrtime;
+
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+
+/**
+ * Middleware that records HTTP request metrics.
+ *
+ * Records:
+ * - `pulsar_http_requests_total` counter (labels: method, path, status)
+ * - `pulsar_http_request_duration_seconds` histogram (labels: method, path)
+ * - `pulsar_http_errors_total` counter on 5xx responses (labels: method, path, status)
+ */
+final readonly class MetricsMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private MetricRegistry $registry,
+    ) {}
+
+    public function process(Request $request, callable $next): Response
+    {
+        $start = hrtime(true);
+
+        /** @var Response $response */
+        $response = $next($request);
+
+        $durationSeconds = (hrtime(true) - $start) / 1_000_000_000;
+
+        $method = $request->method->value;
+        $path = $request->path;
+        $status = (string) $response->status->value;
+
+        // Record request counter
+        $requestLabels = new LabelSet([
+            'method' => $method,
+            'path' => $path,
+            'status' => $status,
+        ]);
+        $this->registry
+            ->counter('pulsar_http_requests_total', 'Total HTTP requests')
+            ->increment($requestLabels);
+
+        // Record duration histogram
+        $durationLabels = new LabelSet([
+            'method' => $method,
+            'path' => $path,
+        ]);
+        $this->registry
+            ->histogram('pulsar_http_request_duration_seconds', 'HTTP request duration in seconds')
+            ->observe($durationSeconds, $durationLabels);
+
+        // Record error counter on 5xx
+        if ($response->status->isServerError()) {
+            $errorLabels = new LabelSet([
+                'method' => $method,
+                'path' => $path,
+                'status' => $status,
+            ]);
+            $this->registry
+                ->counter('pulsar_http_errors_total', 'Total HTTP 5xx errors')
+                ->increment($errorLabels);
+        }
+
+        return $response;
+    }
+}

--- a/src/Http/Middleware/TracingMiddleware.php
+++ b/src/Http/Middleware/TracingMiddleware.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Http\Middleware;
+
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Observability\Tracing\InMemorySpanCollector;
+use Pulsar\Observability\Tracing\Span;
+use Pulsar\Observability\Tracing\SpanStatus;
+use Pulsar\Observability\Tracing\TraceContext;
+use Pulsar\Observability\Tracing\W3CTraceContextParser;
+
+use function sprintf;
+
+/**
+ * Middleware that creates a root span for each HTTP request.
+ *
+ * Parses incoming `traceparent` header for distributed trace propagation.
+ * Attaches trace context and root span to request attributes. Sets span
+ * status from response status code and adds `traceparent` to response.
+ */
+final readonly class TracingMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private InMemorySpanCollector $collector,
+        private float $samplingRate = 1.0,
+    ) {}
+
+    public function process(Request $request, callable $next): Response
+    {
+        // Parse incoming traceparent or create new context
+        $parentContext = null;
+        $traceparent = $request->headers->first('traceparent');
+
+        if ($traceparent !== null) {
+            $parentContext = W3CTraceContextParser::parse($traceparent);
+        }
+
+        // Determine if this request should be sampled
+        if (!$this->shouldSample($parentContext)) {
+            return $next($request);
+        }
+
+        // Create trace context: child of incoming or new root
+        $context = $parentContext !== null
+            ? $parentContext->createChild()
+            : TraceContext::create();
+
+        // Create root span
+        $spanName = sprintf('HTTP %s %s', $request->method->value, $request->path);
+        $span = new Span(
+            name: $spanName,
+            context: $context,
+            parentSpanId: $parentContext?->spanId,
+        );
+
+        $span->setAttribute('http.method', $request->method->value);
+        $span->setAttribute('http.path', $request->path);
+        $span->setAttribute('http.url', $request->uri);
+
+        // Attach to request attributes for downstream use
+        $request = $request
+            ->withAttribute('_trace_context', $context)
+            ->withAttribute('_root_span', $span);
+
+        try {
+            /** @var Response $response */
+            $response = $next($request);
+
+            $span->setAttribute('http.status_code', $response->status->value);
+            $span->setStatus($this->resolveSpanStatus($response->status->value));
+
+            // Add traceparent to response
+            $response = $response->withHeader(
+                'traceparent',
+                W3CTraceContextParser::serialize($context),
+            );
+
+            return $response;
+        } finally {
+            $span->end();
+            $this->collector->onEnd($span);
+        }
+    }
+
+    private function shouldSample(?TraceContext $parentContext): bool
+    {
+        // If parent is sampled, always sample
+        if ($parentContext !== null) {
+            return $parentContext->isSampled();
+        }
+
+        // Probabilistic sampling
+        if ($this->samplingRate >= 1.0) {
+            return true;
+        }
+
+        if ($this->samplingRate <= 0.0) {
+            return false;
+        }
+
+        /** @var int $random */
+        $random = random_int(0, 999);
+
+        $threshold = (int) ($this->samplingRate * 1000.0);
+
+        return $random < $threshold;
+    }
+
+    private function resolveSpanStatus(int $statusCode): SpanStatus
+    {
+        if ($statusCode >= 500) {
+            return SpanStatus::Error;
+        }
+
+        if ($statusCode >= 400) {
+            return SpanStatus::Unset;
+        }
+
+        return SpanStatus::Ok;
+    }
+}

--- a/src/Observability/Diagnostics/DiagnosticsRenderer.php
+++ b/src/Observability/Diagnostics/DiagnosticsRenderer.php
@@ -1,0 +1,232 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Diagnostics;
+
+use function array_slice;
+use function htmlspecialchars;
+
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+use Pulsar\Observability\ErrorTracking\ErrorGroup;
+use Pulsar\Observability\Metrics\Counter;
+use Pulsar\Observability\Metrics\Gauge;
+use Pulsar\Observability\Metrics\Histogram;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Observability\Tracing\InMemorySpanCollector;
+use Pulsar\Observability\Tracing\Span;
+
+use function sprintf;
+
+/**
+ * Renders a local diagnostics HTML page (debug mode only).
+ *
+ * Displays metrics, error groups, and recent traces in a dark-themed
+ * HTML5 page with inline CSS, matching DevelopmentRenderer style.
+ */
+final readonly class DiagnosticsRenderer
+{
+    public function __construct(
+        private MetricRegistry $registry,
+        private ?InMemorySpanCollector $collector = null,
+        private ?ErrorAggregator $aggregator = null,
+    ) {}
+
+    public function render(): string
+    {
+        $metricsHtml = $this->renderMetrics();
+        $errorsHtml = $this->renderErrors();
+        $tracesHtml = $this->renderTraces();
+
+        return <<<HTML
+            <!DOCTYPE html>
+            <html lang="en">
+            <head>
+                <meta charset="utf-8">
+                <meta name="viewport" content="width=device-width, initial-scale=1">
+                <title>Pulsar Diagnostics</title>
+                <style>
+                    * { margin: 0; padding: 0; box-sizing: border-box; }
+                    body { font-family: system-ui, -apple-system, sans-serif; background: #1a1a2e; color: #e0e0e0; padding: 2rem; }
+                    .container { max-width: 1100px; margin: 0 auto; }
+                    .header { background: #0f3460; color: #fff; padding: 1.5rem; border-radius: 8px 8px 0 0; }
+                    .header h1 { font-size: 1.25rem; font-weight: 600; }
+                    .header .sub { font-size: 0.875rem; opacity: 0.9; margin-top: 0.25rem; }
+                    .section { background: #16213e; padding: 1.5rem; border-bottom: 1px solid #0f3460; }
+                    .section:last-child { border-radius: 0 0 8px 8px; border-bottom: none; }
+                    .section h2 { font-size: 1rem; color: #e94560; margin-bottom: 1rem; }
+                    table { width: 100%; border-collapse: collapse; font-size: 0.8125rem; }
+                    th { text-align: left; padding: 0.5rem 0.75rem; background: #0f3460; color: #e94560; font-weight: 600; }
+                    td { padding: 0.375rem 0.75rem; border-bottom: 1px solid #0f3460; vertical-align: top; }
+                    .mono { font-family: 'Cascadia Code', 'Fira Code', monospace; font-size: 0.75rem; }
+                    .badge { display: inline-block; padding: 0.125rem 0.5rem; border-radius: 4px; font-size: 0.6875rem; font-weight: 600; }
+                    .badge-counter { background: #1abc9c; color: #fff; }
+                    .badge-gauge { background: #3498db; color: #fff; }
+                    .badge-histogram { background: #9b59b6; color: #fff; }
+                    .badge-error { background: #c0392b; color: #fff; }
+                    .badge-ok { background: #27ae60; color: #fff; }
+                    .empty { color: #666; font-style: italic; padding: 1rem; }
+                </style>
+            </head>
+            <body>
+                <div class="container">
+                    <div class="header">
+                        <h1>Pulsar Diagnostics</h1>
+                        <div class="sub">Debug-mode observability dashboard</div>
+                    </div>
+
+                    <div class="section">
+                        <h2>Metrics</h2>
+                        $metricsHtml
+                    </div>
+
+                    <div class="section">
+                        <h2>Error Groups</h2>
+                        $errorsHtml
+                    </div>
+
+                    <div class="section">
+                        <h2>Recent Traces</h2>
+                        $tracesHtml
+                    </div>
+                </div>
+            </body>
+            </html>
+            HTML;
+    }
+
+    private function renderMetrics(): string
+    {
+        $metrics = $this->registry->all();
+
+        if ($metrics === []) {
+            return '<p class="empty">No metrics recorded yet.</p>';
+        }
+
+        $html = '<table><tr><th>Name</th><th>Type</th><th>Values</th></tr>';
+
+        foreach ($metrics as $name => $metric) {
+            $escapedName = $this->escape($name);
+
+            if ($metric instanceof Counter) {
+                $badge = '<span class="badge badge-counter">counter</span>';
+                $values = $this->formatValues($metric->values());
+            } elseif ($metric instanceof Gauge) {
+                $badge = '<span class="badge badge-gauge">gauge</span>';
+                $values = $this->formatValues($metric->values());
+            } elseif ($metric instanceof Histogram) {
+                $badge = '<span class="badge badge-histogram">histogram</span>';
+                $values = sprintf('series: %d', $metric->seriesCount());
+            } else {
+                continue;
+            }
+
+            $html .= sprintf(
+                '<tr><td class="mono">%s</td><td>%s</td><td class="mono">%s</td></tr>',
+                $escapedName,
+                $badge,
+                $this->escape($values),
+            );
+        }
+
+        $html .= '</table>';
+
+        return $html;
+    }
+
+    private function renderErrors(): string
+    {
+        if ($this->aggregator === null || $this->aggregator->count() === 0) {
+            return '<p class="empty">No errors tracked yet.</p>';
+        }
+
+        $html = '<table><tr><th>Exception</th><th>Message</th><th>Count</th><th>Last Seen</th></tr>';
+
+        foreach ($this->aggregator->groups() as $group) {
+            $html .= $this->renderErrorGroup($group);
+        }
+
+        $html .= '</table>';
+
+        return $html;
+    }
+
+    private function renderErrorGroup(ErrorGroup $group): string
+    {
+        return sprintf(
+            '<tr><td class="mono">%s</td><td>%s</td><td><span class="badge badge-error">%d</span></td><td class="mono">%s</td></tr>',
+            $this->escape($group->exceptionClass() ?? 'Unknown'),
+            $this->escape($group->message() ?? ''),
+            $group->occurrenceCount(),
+            $this->escape($group->lastSeen()->format('Y-m-d H:i:s')),
+        );
+    }
+
+    private function renderTraces(): string
+    {
+        if ($this->collector === null || $this->collector->count() === 0) {
+            return '<p class="empty">No traces collected yet.</p>';
+        }
+
+        $spans = $this->collector->spans();
+        $recentSpans = array_slice($spans, -50);
+        $recentSpans = array_reverse($recentSpans);
+
+        $html = '<table><tr><th>Span Name</th><th>Trace ID</th><th>Status</th><th>Duration</th></tr>';
+
+        foreach ($recentSpans as $span) {
+            $html .= $this->renderSpanRow($span);
+        }
+
+        $html .= '</table>';
+
+        return $html;
+    }
+
+    private function renderSpanRow(Span $span): string
+    {
+        $duration = $span->durationSeconds();
+        $durationStr = $duration !== null ? sprintf('%.4fs', $duration) : 'running';
+
+        $statusBadge = match ($span->status()) {
+            \Pulsar\Observability\Tracing\SpanStatus::Ok => '<span class="badge badge-ok">ok</span>',
+            \Pulsar\Observability\Tracing\SpanStatus::Error => '<span class="badge badge-error">error</span>',
+            default => '<span class="badge">unset</span>',
+        };
+
+        return sprintf(
+            '<tr><td class="mono">%s</td><td class="mono">%s</td><td>%s</td><td class="mono">%s</td></tr>',
+            $this->escape($span->name),
+            $this->escape(substr($span->context->traceId->value, 0, 8) . '...'),
+            $statusBadge,
+            $this->escape($durationStr),
+        );
+    }
+
+    /**
+     * @param array<string, float> $values
+     */
+    private function formatValues(array $values): string
+    {
+        if ($values === []) {
+            return '(empty)';
+        }
+
+        $parts = [];
+
+        foreach ($values as $key => $value) {
+            if ($key === '') {
+                $parts[] = (string) $value;
+            } else {
+                $parts[] = sprintf('{%s} %s', $key, (string) $value);
+            }
+        }
+
+        return implode(', ', $parts);
+    }
+
+    private function escape(string $value): string
+    {
+        return htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
+    }
+}

--- a/src/Observability/ErrorTracking/ErrorAggregator.php
+++ b/src/Observability/ErrorTracking/ErrorAggregator.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\ErrorTracking;
+
+use function array_values;
+use function count;
+use function usort;
+
+/**
+ * Groups errors by fingerprint for aggregated error reporting.
+ *
+ * When the maximum number of groups is reached, the oldest group
+ * (by lastSeen) is evicted to make room.
+ */
+final class ErrorAggregator
+{
+    /** @var array<string, ErrorGroup> fingerprint => group */
+    private array $groups = [];
+
+    public function __construct(
+        private readonly int $maxGroups = 500,
+        private readonly int $maxRecentEventsPerGroup = 5,
+    ) {}
+
+    /**
+     * Capture an error event and group it by fingerprint.
+     */
+    public function capture(ErrorEvent $event): void
+    {
+        $key = $event->fingerprint->value;
+
+        if (!isset($this->groups[$key])) {
+            // Evict oldest group if at capacity
+            if (count($this->groups) >= $this->maxGroups) {
+                $this->evictOldest();
+            }
+
+            $this->groups[$key] = new ErrorGroup($event->fingerprint, $this->maxRecentEventsPerGroup);
+        }
+
+        $this->groups[$key]->record($event);
+    }
+
+    /**
+     * Get all error groups sorted by lastSeen descending.
+     *
+     * @return list<ErrorGroup>
+     */
+    public function groups(): array
+    {
+        $groups = array_values($this->groups);
+
+        usort(
+            $groups,
+            static fn(ErrorGroup $a, ErrorGroup $b): int => $b->lastSeen() <=> $a->lastSeen(),
+        );
+
+        return $groups;
+    }
+
+    /**
+     * Get a specific error group by fingerprint.
+     */
+    public function group(ErrorFingerprint $fingerprint): ?ErrorGroup
+    {
+        return $this->groups[$fingerprint->value] ?? null;
+    }
+
+    /**
+     * Get the total number of error groups.
+     */
+    public function count(): int
+    {
+        return count($this->groups);
+    }
+
+    /**
+     * Clear all error groups.
+     */
+    public function clear(): void
+    {
+        $this->groups = [];
+    }
+
+    /**
+     * Evict the group with the oldest lastSeen timestamp.
+     */
+    private function evictOldest(): void
+    {
+        $oldestKey = null;
+        $oldestTime = null;
+
+        foreach ($this->groups as $key => $group) {
+            if ($oldestTime === null || $group->lastSeen() < $oldestTime) {
+                $oldestKey = $key;
+                $oldestTime = $group->lastSeen();
+            }
+        }
+
+        if ($oldestKey !== null) {
+            unset($this->groups[$oldestKey]);
+        }
+    }
+}

--- a/src/Observability/ErrorTracking/ErrorEvent.php
+++ b/src/Observability/ErrorTracking/ErrorEvent.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\ErrorTracking;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use Pulsar\Observability\Tracing\TraceId;
+use Throwable;
+
+/**
+ * Readonly value object representing a single error occurrence.
+ */
+final readonly class ErrorEvent
+{
+    /**
+     * @param array<string, mixed> $context Scrubbed request/application context
+     * @param list<array{file: string, line: int, class: ?string, function: ?string}> $stackTrace
+     */
+    public function __construct(
+        public ErrorFingerprint $fingerprint,
+        public string $exceptionClass,
+        public string $message,
+        public string $file,
+        public int $line,
+        public array $stackTrace,
+        public array $context,
+        public DateTimeImmutable $occurredAt,
+        public ?TraceId $traceId = null,
+    ) {}
+
+    /**
+     * Create an ErrorEvent from a throwable.
+     *
+     * @param array<string, mixed> $context
+     */
+    public static function fromThrowable(
+        Throwable $throwable,
+        array $context = [],
+        ?TraceId $traceId = null,
+    ): self {
+        $trace = [];
+
+        foreach ($throwable->getTrace() as $frame) {
+            $trace[] = [
+                'file' => $frame['file'] ?? '<internal>',
+                'line' => $frame['line'] ?? 0,
+                'class' => $frame['class'] ?? null,
+                'function' => $frame['function'] ?? null,
+            ];
+        }
+
+        return new self(
+            fingerprint: ErrorFingerprint::fromThrowable($throwable),
+            exceptionClass: $throwable::class,
+            message: $throwable->getMessage(),
+            file: $throwable->getFile(),
+            line: $throwable->getLine(),
+            stackTrace: $trace,
+            context: $context,
+            occurredAt: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+            traceId: $traceId,
+        );
+    }
+}

--- a/src/Observability/ErrorTracking/ErrorFingerprint.php
+++ b/src/Observability/ErrorTracking/ErrorFingerprint.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\ErrorTracking;
+
+use function hash;
+use function sprintf;
+
+use Throwable;
+
+/**
+ * Deterministic fingerprint for error grouping.
+ *
+ * Produces a sha256 hash of `{class}|{message}|{file}|{line}` to group
+ * identical errors regardless of when they occur.
+ */
+final readonly class ErrorFingerprint
+{
+    public function __construct(
+        public string $value,
+    ) {}
+
+    /**
+     * Generate a fingerprint from a throwable.
+     */
+    public static function fromThrowable(Throwable $throwable): self
+    {
+        $input = sprintf(
+            '%s|%s|%s|%d',
+            $throwable::class,
+            $throwable->getMessage(),
+            $throwable->getFile(),
+            $throwable->getLine(),
+        );
+
+        return new self(hash('sha256', $input));
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+
+    public function equals(self $other): bool
+    {
+        return $this->value === $other->value;
+    }
+}

--- a/src/Observability/ErrorTracking/ErrorGroup.php
+++ b/src/Observability/ErrorTracking/ErrorGroup.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\ErrorTracking;
+
+use function array_slice;
+use function count;
+
+use DateTimeImmutable;
+use DateTimeZone;
+
+/**
+ * Aggregate of errors sharing the same fingerprint.
+ *
+ * Tracks occurrence count, first/last seen timestamps, and a capped
+ * list of recent events.
+ */
+final class ErrorGroup
+{
+    private int $occurrenceCount = 0;
+    private DateTimeImmutable $firstSeen;
+    private DateTimeImmutable $lastSeen;
+
+    /** @var list<ErrorEvent> */
+    private array $recentEvents = [];
+
+    public function __construct(
+        public readonly ErrorFingerprint $fingerprint,
+        private readonly int $maxRecentEvents = 5,
+    ) {
+        $this->firstSeen = new DateTimeImmutable('now', new DateTimeZone('UTC'));
+        $this->lastSeen = $this->firstSeen;
+    }
+
+    /**
+     * Record a new error event in this group.
+     */
+    public function record(ErrorEvent $event): void
+    {
+        ++$this->occurrenceCount;
+        $this->lastSeen = $event->occurredAt;
+
+        $this->recentEvents[] = $event;
+
+        // Cap recent events
+        if (count($this->recentEvents) > $this->maxRecentEvents) {
+            $this->recentEvents = array_slice($this->recentEvents, -$this->maxRecentEvents);
+        }
+    }
+
+    public function occurrenceCount(): int
+    {
+        return $this->occurrenceCount;
+    }
+
+    public function firstSeen(): DateTimeImmutable
+    {
+        return $this->firstSeen;
+    }
+
+    public function lastSeen(): DateTimeImmutable
+    {
+        return $this->lastSeen;
+    }
+
+    /**
+     * @return list<ErrorEvent>
+     */
+    public function recentEvents(): array
+    {
+        return $this->recentEvents;
+    }
+
+    /**
+     * Get the exception class from the most recent event, if available.
+     */
+    public function exceptionClass(): ?string
+    {
+        if ($this->recentEvents === []) {
+            return null;
+        }
+
+        return $this->recentEvents[count($this->recentEvents) - 1]->exceptionClass;
+    }
+
+    /**
+     * Get the message from the most recent event, if available.
+     */
+    public function message(): ?string
+    {
+        if ($this->recentEvents === []) {
+            return null;
+        }
+
+        return $this->recentEvents[count($this->recentEvents) - 1]->message;
+    }
+}

--- a/src/Observability/ErrorTracking/Exception/ErrorTrackingException.php
+++ b/src/Observability/ErrorTracking/Exception/ErrorTrackingException.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\ErrorTracking\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Exception thrown for error tracking system errors.
+ */
+final class ErrorTrackingException extends RuntimeException
+{
+    public static function maxGroupsExceeded(int $max): self
+    {
+        return new self(sprintf(
+            'Maximum number of error groups (%d) exceeded',
+            $max,
+        ));
+    }
+}

--- a/src/Observability/ErrorTracking/SensitiveDataScrubber.php
+++ b/src/Observability/ErrorTracking/SensitiveDataScrubber.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\ErrorTracking;
+
+use function array_merge;
+use function is_array;
+use function str_contains;
+use function strtolower;
+
+/**
+ * Recursively scrubs sensitive data from arrays and headers.
+ *
+ * Uses case-insensitive substring matching against a configurable list
+ * of sensitive field names.
+ */
+final readonly class SensitiveDataScrubber
+{
+    private const string REDACTED = '[REDACTED]';
+
+    /** @var list<string> Default sensitive field substrings */
+    private const array DEFAULT_FIELDS = [
+        'password',
+        'token',
+        'secret',
+        'api_key',
+        'authorization',
+        'credential',
+        'credit_card',
+        'ssn',
+        'social_security',
+        'private_key',
+    ];
+
+    /** @var list<string> Headers that are always scrubbed */
+    private const array SENSITIVE_HEADERS = [
+        'authorization',
+        'cookie',
+        'set-cookie',
+        'x-api-key',
+    ];
+
+    /** @var list<string> */
+    private array $fields;
+
+    /**
+     * @param list<string> $customFields Additional sensitive field substrings
+     */
+    public function __construct(array $customFields = [])
+    {
+        $this->fields = array_merge(self::DEFAULT_FIELDS, $customFields);
+    }
+
+    /**
+     * Recursively scrub sensitive values from an array.
+     *
+     * @param array<string, mixed> $data
+     *
+     * @return array<string, mixed>
+     */
+    public function scrub(array $data): array
+    {
+        $result = [];
+
+        foreach ($data as $key => $value) {
+            if ($this->isSensitiveKey($key)) {
+                $result[$key] = self::REDACTED;
+            } elseif (is_array($value)) {
+                /** @var array<string, mixed> $value */
+                $result[$key] = $this->scrub($value);
+            } else {
+                $result[$key] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    /**
+     * Scrub sensitive headers.
+     *
+     * @param array<string, string|list<string>> $headers
+     *
+     * @return array<string, string|list<string>>
+     */
+    public function scrubHeaders(array $headers): array
+    {
+        $result = [];
+
+        foreach ($headers as $name => $value) {
+            if ($this->isSensitiveHeader($name)) {
+                $result[$name] = self::REDACTED;
+            } else {
+                $result[$name] = $value;
+            }
+        }
+
+        return $result;
+    }
+
+    private function isSensitiveKey(string $key): bool
+    {
+        $lower = strtolower($key);
+
+        foreach ($this->fields as $field) {
+            if (str_contains($lower, $field)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function isSensitiveHeader(string $name): bool
+    {
+        $lower = strtolower($name);
+
+        foreach (self::SENSITIVE_HEADERS as $header) {
+            if ($lower === $header) {
+                return true;
+            }
+        }
+
+        // Also check general sensitive fields
+        return $this->isSensitiveKey($name);
+    }
+}

--- a/src/Observability/Metrics/Counter.php
+++ b/src/Observability/Metrics/Counter.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+use Pulsar\Observability\Metrics\Exception\MetricsException;
+
+/**
+ * Monotonic counter metric.
+ *
+ * Counters only go up. Use {@see increment()} to add a non-negative value.
+ */
+final class Counter
+{
+    /** @var array<string, float> label-key => value */
+    private array $values = [];
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $help = '',
+    ) {}
+
+    /**
+     * Increment the counter for the given label set.
+     *
+     * @throws MetricsException If $value is negative
+     */
+    public function increment(LabelSet $labels = new LabelSet(), float $value = 1.0): void
+    {
+        if ($value < 0) {
+            throw MetricsException::negativeIncrement($value);
+        }
+
+        $key = $labels->key();
+        $this->values[$key] = ($this->values[$key] ?? 0.0) + $value;
+    }
+
+    /**
+     * Get the current value for a label set.
+     */
+    public function value(LabelSet $labels = new LabelSet()): float
+    {
+        return $this->values[$labels->key()] ?? 0.0;
+    }
+
+    /**
+     * Get all label-key => value pairs.
+     *
+     * @return array<string, float>
+     */
+    public function values(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * Reset all values to zero.
+     */
+    public function reset(): void
+    {
+        $this->values = [];
+    }
+}

--- a/src/Observability/Metrics/Exception/MetricsException.php
+++ b/src/Observability/Metrics/Exception/MetricsException.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Exception thrown for metrics system errors.
+ */
+final class MetricsException extends RuntimeException
+{
+    public static function negativeIncrement(float $value): self
+    {
+        return new self(sprintf(
+            'Counter increment must be non-negative, got %s',
+            (string) $value,
+        ));
+    }
+
+    public static function typeMismatch(string $name, string $expected, string $actual): self
+    {
+        return new self(sprintf(
+            'Metric "%s" already registered as %s, cannot re-register as %s',
+            $name,
+            $expected,
+            $actual,
+        ));
+    }
+}

--- a/src/Observability/Metrics/Gauge.php
+++ b/src/Observability/Metrics/Gauge.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+/**
+ * Bidirectional gauge metric.
+ *
+ * Can go up and down. Use {@see set()}, {@see increment()}, or {@see decrement()}.
+ */
+final class Gauge
+{
+    /** @var array<string, float> label-key => value */
+    private array $values = [];
+
+    public function __construct(
+        public readonly string $name,
+        public readonly string $help = '',
+    ) {}
+
+    /**
+     * Set the gauge to an absolute value.
+     */
+    public function set(float $value, LabelSet $labels = new LabelSet()): void
+    {
+        $this->values[$labels->key()] = $value;
+    }
+
+    /**
+     * Increment the gauge by the given amount.
+     */
+    public function increment(LabelSet $labels = new LabelSet(), float $value = 1.0): void
+    {
+        $key = $labels->key();
+        $this->values[$key] = ($this->values[$key] ?? 0.0) + $value;
+    }
+
+    /**
+     * Decrement the gauge by the given amount.
+     */
+    public function decrement(LabelSet $labels = new LabelSet(), float $value = 1.0): void
+    {
+        $key = $labels->key();
+        $this->values[$key] = ($this->values[$key] ?? 0.0) - $value;
+    }
+
+    /**
+     * Get the current value for a label set.
+     */
+    public function value(LabelSet $labels = new LabelSet()): float
+    {
+        return $this->values[$labels->key()] ?? 0.0;
+    }
+
+    /**
+     * Get all label-key => value pairs.
+     *
+     * @return array<string, float>
+     */
+    public function values(): array
+    {
+        return $this->values;
+    }
+
+    /**
+     * Reset all values to zero.
+     */
+    public function reset(): void
+    {
+        $this->values = [];
+    }
+}

--- a/src/Observability/Metrics/Histogram.php
+++ b/src/Observability/Metrics/Histogram.php
@@ -1,0 +1,168 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+use function count;
+use function sort;
+
+use const SORT_NUMERIC;
+
+/**
+ * Bucket-based histogram metric.
+ *
+ * Records observed values into configurable buckets and tracks sum/count.
+ *
+ * Bucket keys are the string representation of boundary floats. PHP may
+ * auto-cast integer-like numeric strings (e.g. '1', '10') to int keys.
+ */
+final class Histogram
+{
+    /** @var list<float> Sorted upper-bound bucket boundaries */
+    private readonly array $boundaries;
+
+    /** @var list<string> Pre-computed string keys for each boundary */
+    private readonly array $boundaryKeys;
+
+    /**
+     * Per-label-key data: [buckets => [bound => count], sum => float, count => int].
+     *
+     * @var array<string, array{buckets: array<int|string, int>, sum: float, count: int}>
+     */
+    private array $series = [];
+
+    /** @var list<float> */
+    public const array DEFAULT_BOUNDARIES = [0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0];
+
+    /**
+     * @param list<float> $boundaries
+     */
+    public function __construct(
+        public readonly string $name,
+        public readonly string $help = '',
+        array $boundaries = self::DEFAULT_BOUNDARIES,
+    ) {
+        $sorted = $boundaries;
+        sort($sorted, SORT_NUMERIC);
+        $this->boundaries = $sorted;
+
+        $keys = [];
+
+        foreach ($sorted as $b) {
+            $keys[] = (string) $b;
+        }
+
+        $this->boundaryKeys = $keys;
+    }
+
+    /**
+     * Record an observed value.
+     */
+    public function observe(float $value, LabelSet $labels = new LabelSet()): void
+    {
+        $key = $labels->key();
+
+        if (!isset($this->series[$key])) {
+            $this->series[$key] = $this->emptySeries();
+        }
+
+        $this->series[$key]['sum'] += $value;
+        ++$this->series[$key]['count'];
+
+        foreach ($this->boundaries as $i => $bound) {
+            if ($value <= $bound) {
+                $boundKey = $this->boundaryKeys[$i];
+                ++$this->series[$key]['buckets'][$boundKey];
+            }
+        }
+    }
+
+    /**
+     * Get sum of observed values for a label set.
+     */
+    public function sum(LabelSet $labels = new LabelSet()): float
+    {
+        return $this->series[$labels->key()]['sum'] ?? 0.0;
+    }
+
+    /**
+     * Get count of observations for a label set.
+     */
+    public function count(LabelSet $labels = new LabelSet()): int
+    {
+        return $this->series[$labels->key()]['count'] ?? 0;
+    }
+
+    /**
+     * Get bucket counts for a label set.
+     *
+     * Keys are the string representation of boundary floats. PHP may auto-cast
+     * integer-like numeric strings to int keys (e.g. '1' → 1, '10' → 10).
+     *
+     * @return array<int|string, int> bucket-boundary => cumulative count
+     */
+    public function buckets(LabelSet $labels = new LabelSet()): array
+    {
+        if (!isset($this->series[$labels->key()])) {
+            return $this->emptySeries()['buckets'];
+        }
+
+        return $this->series[$labels->key()]['buckets'];
+    }
+
+    /**
+     * Get the configured bucket boundaries.
+     *
+     * @return list<float>
+     */
+    public function boundaries(): array
+    {
+        return $this->boundaries;
+    }
+
+    /**
+     * Get all series keys.
+     *
+     * @return list<string>
+     */
+    public function seriesKeys(): array
+    {
+        return array_keys($this->series);
+    }
+
+    /**
+     * Get the total number of distinct label sets observed.
+     */
+    public function seriesCount(): int
+    {
+        return count($this->series);
+    }
+
+    /**
+     * Reset all observed data.
+     */
+    public function reset(): void
+    {
+        $this->series = [];
+    }
+
+    /**
+     * @return array{buckets: array<int|string, int>, sum: float, count: int}
+     */
+    private function emptySeries(): array
+    {
+        /** @var array<int|string, int> $buckets */
+        $buckets = [];
+
+        foreach ($this->boundaryKeys as $key) {
+            $buckets[$key] = 0;
+        }
+
+        return [
+            'buckets' => $buckets,
+            'sum' => 0.0,
+            'count' => 0,
+        ];
+    }
+}

--- a/src/Observability/Metrics/LabelSet.php
+++ b/src/Observability/Metrics/LabelSet.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+use function implode;
+use function ksort;
+
+/**
+ * Immutable label key-value set for metric dimensions.
+ *
+ * Labels are sorted deterministically by key to produce a stable
+ * map lookup key via {@see key()}.
+ */
+final readonly class LabelSet
+{
+    /** @var array<string, string> */
+    private array $labels;
+
+    /**
+     * @param array<string, string> $labels
+     */
+    public function __construct(array $labels = [])
+    {
+        $sorted = $labels;
+        ksort($sorted);
+        $this->labels = $sorted;
+    }
+
+    /**
+     * Deterministic string key for map lookups.
+     *
+     * Format: "key1=value1,key2=value2" with keys sorted alphabetically.
+     */
+    public function key(): string
+    {
+        if ($this->labels === []) {
+            return '';
+        }
+
+        $parts = [];
+
+        foreach ($this->labels as $k => $v) {
+            $parts[] = $k . '=' . $v;
+        }
+
+        return implode(',', $parts);
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    public function toArray(): array
+    {
+        return $this->labels;
+    }
+
+    public function isEmpty(): bool
+    {
+        return $this->labels === [];
+    }
+}

--- a/src/Observability/Metrics/MetricRegistry.php
+++ b/src/Observability/Metrics/MetricRegistry.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+use Pulsar\Observability\Metrics\Exception\MetricsException;
+
+/**
+ * Central store for all application metrics.
+ *
+ * Create-or-return semantics: calling counter/gauge/histogram with the same
+ * name returns the existing instrument. Throws on type mismatch.
+ */
+final class MetricRegistry
+{
+    /** @var array<string, Counter|Gauge|Histogram> */
+    private array $metrics = [];
+
+    /** @var array<string, MetricType> */
+    private array $types = [];
+
+    /**
+     * Get or create a counter.
+     *
+     * @throws MetricsException On type mismatch
+     */
+    public function counter(string $name, string $help = ''): Counter
+    {
+        if (isset($this->metrics[$name])) {
+            $this->assertType($name, MetricType::Counter);
+
+            /** @var Counter */
+            return $this->metrics[$name];
+        }
+
+        $counter = new Counter($name, $help);
+        $this->metrics[$name] = $counter;
+        $this->types[$name] = MetricType::Counter;
+
+        return $counter;
+    }
+
+    /**
+     * Get or create a gauge.
+     *
+     * @throws MetricsException On type mismatch
+     */
+    public function gauge(string $name, string $help = ''): Gauge
+    {
+        if (isset($this->metrics[$name])) {
+            $this->assertType($name, MetricType::Gauge);
+
+            /** @var Gauge */
+            return $this->metrics[$name];
+        }
+
+        $gauge = new Gauge($name, $help);
+        $this->metrics[$name] = $gauge;
+        $this->types[$name] = MetricType::Gauge;
+
+        return $gauge;
+    }
+
+    /**
+     * Get or create a histogram.
+     *
+     * @param list<float> $boundaries
+     *
+     * @throws MetricsException On type mismatch
+     */
+    public function histogram(string $name, string $help = '', array $boundaries = Histogram::DEFAULT_BOUNDARIES): Histogram
+    {
+        if (isset($this->metrics[$name])) {
+            $this->assertType($name, MetricType::Histogram);
+
+            /** @var Histogram */
+            return $this->metrics[$name];
+        }
+
+        $histogram = new Histogram($name, $help, $boundaries);
+        $this->metrics[$name] = $histogram;
+        $this->types[$name] = MetricType::Histogram;
+
+        return $histogram;
+    }
+
+    /**
+     * Check if a metric is registered.
+     */
+    public function has(string $name): bool
+    {
+        return isset($this->metrics[$name]);
+    }
+
+    /**
+     * Get the type of a registered metric.
+     */
+    public function typeOf(string $name): ?MetricType
+    {
+        return $this->types[$name] ?? null;
+    }
+
+    /**
+     * Get all registered metrics.
+     *
+     * @return array<string, Counter|Gauge|Histogram>
+     */
+    public function all(): array
+    {
+        return $this->metrics;
+    }
+
+    /**
+     * @throws MetricsException
+     */
+    private function assertType(string $name, MetricType $expected): void
+    {
+        $actual = $this->types[$name];
+
+        if ($actual !== $expected) {
+            throw MetricsException::typeMismatch($name, $actual->value, $expected->value);
+        }
+    }
+}

--- a/src/Observability/Metrics/MetricSnapshot.php
+++ b/src/Observability/Metrics/MetricSnapshot.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+/**
+ * Readonly value object capturing point-in-time metric state.
+ */
+final readonly class MetricSnapshot
+{
+    /**
+     * @param array<string, float>                                                       $values  Label-key => value (counters/gauges)
+     * @param array<string, array{buckets: array<int|string, int>, sum: float, count: int}>|null $series  Histogram series data
+     */
+    public function __construct(
+        public string $name,
+        public MetricType $type,
+        public string $help,
+        public array $values = [],
+        public ?array $series = null,
+    ) {}
+
+    /**
+     * Create a snapshot from a counter.
+     */
+    public static function fromCounter(Counter $counter): self
+    {
+        return new self(
+            name: $counter->name,
+            type: MetricType::Counter,
+            help: $counter->help,
+            values: $counter->values(),
+        );
+    }
+
+    /**
+     * Create a snapshot from a gauge.
+     */
+    public static function fromGauge(Gauge $gauge): self
+    {
+        return new self(
+            name: $gauge->name,
+            type: MetricType::Gauge,
+            help: $gauge->help,
+            values: $gauge->values(),
+        );
+    }
+
+    /**
+     * Create a snapshot from a histogram.
+     */
+    public static function fromHistogram(Histogram $histogram): self
+    {
+        $series = [];
+
+        foreach ($histogram->seriesKeys() as $key) {
+            $labels = new LabelSet(); // default for key parsing
+            if ($key !== '') {
+                // Reconstruct LabelSet is not needed; we store raw series data
+                $labels = new LabelSet(); // placeholder
+            }
+
+            $series[$key] = [
+                'buckets' => $histogram->buckets(new LabelSet()),
+                'sum' => $histogram->sum(new LabelSet()),
+                'count' => $histogram->count(new LabelSet()),
+            ];
+        }
+
+        return new self(
+            name: $histogram->name,
+            type: MetricType::Histogram,
+            help: $histogram->help,
+            series: $series,
+        );
+    }
+}

--- a/src/Observability/Metrics/MetricType.php
+++ b/src/Observability/Metrics/MetricType.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+/**
+ * Metric instrument types supported by the metrics system.
+ */
+enum MetricType: string
+{
+    case Counter = 'counter';
+    case Gauge = 'gauge';
+    case Histogram = 'histogram';
+}

--- a/src/Observability/Metrics/PrometheusExporter.php
+++ b/src/Observability/Metrics/PrometheusExporter.php
@@ -1,0 +1,205 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Metrics;
+
+use function implode;
+use function sprintf;
+
+/**
+ * Renders a MetricRegistry as Prometheus text exposition format 0.0.4.
+ *
+ * Output includes # HELP, # TYPE lines, and sample lines with labels.
+ * Histograms render _bucket, _sum, and _count series.
+ */
+final readonly class PrometheusExporter
+{
+    public function __construct(
+        private MetricRegistry $registry,
+    ) {}
+
+    /**
+     * Render all metrics as Prometheus exposition text.
+     */
+    public function export(): string
+    {
+        $lines = [];
+
+        foreach ($this->registry->all() as $name => $metric) {
+            if ($metric instanceof Counter) {
+                $this->renderCounter($lines, $name, $metric);
+            } elseif ($metric instanceof Gauge) {
+                $this->renderGauge($lines, $name, $metric);
+            } elseif ($metric instanceof Histogram) {
+                $this->renderHistogram($lines, $name, $metric);
+            }
+        }
+
+        return implode("\n", $lines) . "\n";
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function renderCounter(array &$lines, string $name, Counter $counter): void
+    {
+        if ($counter->help !== '') {
+            $lines[] = sprintf('# HELP %s %s', $name, $this->escapeHelp($counter->help));
+        }
+
+        $lines[] = sprintf('# TYPE %s counter', $name);
+
+        foreach ($counter->values() as $labelKey => $value) {
+            $lines[] = $this->formatSample($name, $labelKey, $value);
+        }
+
+        // Emit a zero-value line if no values recorded
+        if ($counter->values() === []) {
+            $lines[] = sprintf('%s 0', $name);
+        }
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function renderGauge(array &$lines, string $name, Gauge $gauge): void
+    {
+        if ($gauge->help !== '') {
+            $lines[] = sprintf('# HELP %s %s', $name, $this->escapeHelp($gauge->help));
+        }
+
+        $lines[] = sprintf('# TYPE %s gauge', $name);
+
+        foreach ($gauge->values() as $labelKey => $value) {
+            $lines[] = $this->formatSample($name, $labelKey, $value);
+        }
+
+        if ($gauge->values() === []) {
+            $lines[] = sprintf('%s 0', $name);
+        }
+    }
+
+    /**
+     * @param list<string> $lines
+     */
+    private function renderHistogram(array &$lines, string $name, Histogram $histogram): void
+    {
+        if ($histogram->help !== '') {
+            $lines[] = sprintf('# HELP %s %s', $name, $this->escapeHelp($histogram->help));
+        }
+
+        $lines[] = sprintf('# TYPE %s histogram', $name);
+
+        foreach ($histogram->seriesKeys() as $seriesKey) {
+            $labels = $this->parseLabelString($seriesKey);
+            $labelSet = new LabelSet($labels);
+            $buckets = $histogram->buckets($labelSet);
+
+            foreach ($buckets as $bound => $count) {
+                $bucketLabels = $labels;
+                $bucketLabels['le'] = (string) $bound;
+                $lines[] = $this->formatSample($name . '_bucket', $this->formatLabels($bucketLabels), (float) $count);
+            }
+
+            // +Inf bucket
+            $infLabels = $labels;
+            $infLabels['le'] = '+Inf';
+            $lines[] = $this->formatSample($name . '_bucket', $this->formatLabels($infLabels), (float) $histogram->count($labelSet));
+
+            $lines[] = $this->formatSample($name . '_sum', $seriesKey, $histogram->sum($labelSet));
+            $lines[] = $this->formatSample($name . '_count', $seriesKey, (float) $histogram->count($labelSet));
+        }
+
+        // Emit empty histogram if no series
+        if ($histogram->seriesKeys() === []) {
+            foreach ($histogram->boundaries() as $bound) {
+                $lines[] = sprintf('%s_bucket{le="%s"} 0', $name, (string) $bound);
+            }
+
+            $lines[] = sprintf('%s_bucket{le="+Inf"} 0', $name);
+            $lines[] = sprintf('%s_sum 0', $name);
+            $lines[] = sprintf('%s_count 0', $name);
+        }
+    }
+
+    private function formatSample(string $name, string $labelKey, float $value): string
+    {
+        $formatted = $this->formatFloat($value);
+
+        if ($labelKey === '') {
+            return sprintf('%s %s', $name, $formatted);
+        }
+
+        // Check if labelKey is already formatted as {key="val",...}
+        if (str_starts_with($labelKey, '{')) {
+            return sprintf('%s%s %s', $name, $labelKey, $formatted);
+        }
+
+        // Convert key=value,key2=value2 to {key="value",key2="value2"}
+        $labels = $this->parseLabelString($labelKey);
+
+        return sprintf('%s%s %s', $name, $this->formatLabels($labels), $formatted);
+    }
+
+    /**
+     * @param array<string, string|int|float> $labels
+     */
+    private function formatLabels(array $labels): string
+    {
+        if ($labels === []) {
+            return '';
+        }
+
+        $parts = [];
+
+        foreach ($labels as $k => $v) {
+            $parts[] = sprintf('%s="%s"', $k, $this->escapeLabelValue((string) $v));
+        }
+
+        return '{' . implode(',', $parts) . '}';
+    }
+
+    /**
+     * Parse "key=value,key2=value2" into an array.
+     *
+     * @return array<string, string>
+     */
+    private function parseLabelString(string $labelKey): array
+    {
+        if ($labelKey === '') {
+            return [];
+        }
+
+        $result = [];
+
+        foreach (explode(',', $labelKey) as $pair) {
+            $parts = explode('=', $pair, 2);
+
+            if (isset($parts[1])) {
+                $result[$parts[0]] = $parts[1];
+            }
+        }
+
+        return $result;
+    }
+
+    private function formatFloat(float $value): string
+    {
+        if ($value === (float) (int) $value) {
+            return (string) (int) $value;
+        }
+
+        return (string) $value;
+    }
+
+    private function escapeHelp(string $help): string
+    {
+        return str_replace(['\\', "\n"], ['\\\\', '\\n'], $help);
+    }
+
+    private function escapeLabelValue(string $value): string
+    {
+        return str_replace(['\\', '"', "\n"], ['\\\\', '\\"', '\\n'], $value);
+    }
+}

--- a/src/Observability/Tracing/Exception/TracingException.php
+++ b/src/Observability/Tracing/Exception/TracingException.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Exception thrown for tracing system errors.
+ */
+final class TracingException extends RuntimeException
+{
+    public static function invalidTraceId(string $value): self
+    {
+        return new self(sprintf(
+            'Invalid trace ID: expected 32 hex characters, got "%s"',
+            $value,
+        ));
+    }
+
+    public static function invalidSpanId(string $value): self
+    {
+        return new self(sprintf(
+            'Invalid span ID: expected 16 hex characters, got "%s"',
+            $value,
+        ));
+    }
+}

--- a/src/Observability/Tracing/InMemorySpanCollector.php
+++ b/src/Observability/Tracing/InMemorySpanCollector.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+use function array_filter;
+use function array_slice;
+use function array_values;
+use function count;
+
+/**
+ * In-memory span collector with ring-buffer eviction.
+ *
+ * Stores completed spans up to a configurable maximum. When full,
+ * the oldest spans are evicted.
+ */
+final class InMemorySpanCollector implements SpanProcessorInterface
+{
+    /** @var list<Span> */
+    private array $spans = [];
+
+    public function __construct(
+        private readonly int $maxSpans = 1000,
+    ) {}
+
+    public function onEnd(Span $span): void
+    {
+        $this->spans[] = $span;
+
+        // Evict oldest when exceeding capacity
+        if (count($this->spans) > $this->maxSpans) {
+            $this->spans = array_slice($this->spans, -$this->maxSpans);
+        }
+    }
+
+    /**
+     * Get all collected spans.
+     *
+     * @return list<Span>
+     */
+    public function spans(): array
+    {
+        return $this->spans;
+    }
+
+    /**
+     * Get spans belonging to a specific trace.
+     *
+     * @return list<Span>
+     */
+    public function spansByTraceId(TraceId $traceId): array
+    {
+        return array_values(array_filter(
+            $this->spans,
+            static fn(Span $span): bool => $span->context->traceId->value === $traceId->value,
+        ));
+    }
+
+    /**
+     * Get the number of collected spans.
+     */
+    public function count(): int
+    {
+        return count($this->spans);
+    }
+
+    /**
+     * Clear all collected spans.
+     */
+    public function clear(): void
+    {
+        $this->spans = [];
+    }
+}

--- a/src/Observability/Tracing/Span.php
+++ b/src/Observability/Tracing/Span.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+use function hrtime;
+
+/**
+ * Mutable lifecycle object representing a unit of work in a trace.
+ *
+ * Spans track name, start/end times (via hrtime), attributes, and status.
+ * Calling {@see end()} is idempotent.
+ */
+final class Span
+{
+    private int $startTime;
+    private ?int $endTime = null;
+
+    /** @var array<string, scalar> */
+    private array $attributes = [];
+    private SpanStatus $status = SpanStatus::Unset;
+
+    public function __construct(
+        public readonly string $name,
+        public readonly TraceContext $context,
+        public readonly ?SpanId $parentSpanId = null,
+    ) {
+        $this->startTime = hrtime(true);
+    }
+
+    /**
+     * End this span. Idempotent — subsequent calls are no-ops.
+     */
+    public function end(): void
+    {
+        if ($this->endTime === null) {
+            $this->endTime = hrtime(true);
+        }
+    }
+
+    /**
+     * Set the span status.
+     */
+    public function setStatus(SpanStatus $status): void
+    {
+        $this->status = $status;
+    }
+
+    /**
+     * Set a span attribute.
+     */
+    public function setAttribute(string $key, string|int|float|bool $value): void
+    {
+        $this->attributes[$key] = $value;
+    }
+
+    /**
+     * Get the span status.
+     */
+    public function status(): SpanStatus
+    {
+        return $this->status;
+    }
+
+    /**
+     * Get start time in nanoseconds (hrtime).
+     */
+    public function startTime(): int
+    {
+        return $this->startTime;
+    }
+
+    /**
+     * Get end time in nanoseconds (hrtime), or null if not ended.
+     */
+    public function endTime(): ?int
+    {
+        return $this->endTime;
+    }
+
+    /**
+     * Get the duration in nanoseconds, or null if not ended.
+     */
+    public function duration(): ?int
+    {
+        if ($this->endTime === null) {
+            return null;
+        }
+
+        return $this->endTime - $this->startTime;
+    }
+
+    /**
+     * Get the duration in seconds as a float, or null if not ended.
+     */
+    public function durationSeconds(): ?float
+    {
+        $duration = $this->duration();
+
+        if ($duration === null) {
+            return null;
+        }
+
+        return $duration / 1_000_000_000;
+    }
+
+    /**
+     * Check if this span has ended.
+     */
+    public function hasEnded(): bool
+    {
+        return $this->endTime !== null;
+    }
+
+    /**
+     * @return array<string, scalar>
+     */
+    public function attributes(): array
+    {
+        return $this->attributes;
+    }
+}

--- a/src/Observability/Tracing/SpanId.php
+++ b/src/Observability/Tracing/SpanId.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+use function bin2hex;
+use function ctype_xdigit;
+
+use Pulsar\Observability\Tracing\Exception\TracingException;
+
+use function random_bytes;
+use function strlen;
+use function strtolower;
+
+/**
+ * 64-bit span identifier represented as 16 lowercase hex characters.
+ */
+final readonly class SpanId
+{
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        $normalized = strtolower($value);
+
+        if (strlen($normalized) !== 16 || !ctype_xdigit($normalized)) {
+            throw TracingException::invalidSpanId($value);
+        }
+
+        $this->value = $normalized;
+    }
+
+    /**
+     * Generate a new random span ID.
+     */
+    public static function generate(): self
+    {
+        return new self(bin2hex(random_bytes(8)));
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Observability/Tracing/SpanProcessorInterface.php
+++ b/src/Observability/Tracing/SpanProcessorInterface.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+/**
+ * Contract for processing completed spans.
+ */
+interface SpanProcessorInterface
+{
+    /**
+     * Called when a span ends.
+     */
+    public function onEnd(Span $span): void;
+}

--- a/src/Observability/Tracing/SpanStatus.php
+++ b/src/Observability/Tracing/SpanStatus.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+/**
+ * Status of a trace span.
+ */
+enum SpanStatus: string
+{
+    case Unset = 'unset';
+    case Ok = 'ok';
+    case Error = 'error';
+}

--- a/src/Observability/Tracing/TraceContext.php
+++ b/src/Observability/Tracing/TraceContext.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+/**
+ * Readonly value object representing distributed trace context.
+ *
+ * Holds trace ID, span ID, and trace flags. Creates child contexts
+ * that preserve the trace ID with a new span ID.
+ */
+final readonly class TraceContext
+{
+    public function __construct(
+        public TraceId $traceId,
+        public SpanId $spanId,
+        public int $traceFlags = 0x01,
+    ) {}
+
+    /**
+     * Create a child context with a new span ID, preserving the trace ID.
+     */
+    public function createChild(): self
+    {
+        return new self(
+            traceId: $this->traceId,
+            spanId: SpanId::generate(),
+            traceFlags: $this->traceFlags,
+        );
+    }
+
+    /**
+     * Check if this context is sampled (flag bit 0).
+     */
+    public function isSampled(): bool
+    {
+        return ($this->traceFlags & 0x01) !== 0;
+    }
+
+    /**
+     * Create a new root trace context.
+     */
+    public static function create(): self
+    {
+        return new self(
+            traceId: TraceId::generate(),
+            spanId: SpanId::generate(),
+        );
+    }
+}

--- a/src/Observability/Tracing/TraceId.php
+++ b/src/Observability/Tracing/TraceId.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+use function bin2hex;
+use function ctype_xdigit;
+
+use Pulsar\Observability\Tracing\Exception\TracingException;
+
+use function random_bytes;
+use function strlen;
+use function strtolower;
+
+/**
+ * 128-bit trace identifier represented as 32 lowercase hex characters.
+ */
+final readonly class TraceId
+{
+    public string $value;
+
+    public function __construct(string $value)
+    {
+        $normalized = strtolower($value);
+
+        if (strlen($normalized) !== 32 || !ctype_xdigit($normalized)) {
+            throw TracingException::invalidTraceId($value);
+        }
+
+        $this->value = $normalized;
+    }
+
+    /**
+     * Generate a new random trace ID.
+     */
+    public static function generate(): self
+    {
+        return new self(bin2hex(random_bytes(16)));
+    }
+
+    public function toString(): string
+    {
+        return $this->value;
+    }
+
+    public function __toString(): string
+    {
+        return $this->value;
+    }
+}

--- a/src/Observability/Tracing/W3CTraceContextParser.php
+++ b/src/Observability/Tracing/W3CTraceContextParser.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Observability\Tracing;
+
+use function count;
+use function ctype_xdigit;
+use function explode;
+use function hexdec;
+use function sprintf;
+use function strlen;
+use function strtolower;
+
+/**
+ * Parses and serializes W3C Trace Context `traceparent` headers.
+ *
+ * Format: `{version}-{traceId}-{spanId}-{traceFlags}`
+ * Example: `00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01`
+ *
+ * @see https://www.w3.org/TR/trace-context/
+ */
+final class W3CTraceContextParser
+{
+    /**
+     * Parse a traceparent header value into a TraceContext.
+     *
+     * Returns null if the header is malformed.
+     */
+    public static function parse(string $header): ?TraceContext
+    {
+        $parts = explode('-', strtolower($header));
+
+        if (count($parts) < 4) {
+            return null;
+        }
+
+        [$version, $traceId, $spanId, $flags] = $parts;
+
+        // Version must be 2 hex chars
+        if (strlen($version) !== 2 || !ctype_xdigit($version)) {
+            return null;
+        }
+
+        // Trace ID must be 32 hex chars and not all zeros
+        if (strlen($traceId) !== 32 || !ctype_xdigit($traceId) || $traceId === '00000000000000000000000000000000') {
+            return null;
+        }
+
+        // Span ID must be 16 hex chars and not all zeros
+        if (strlen($spanId) !== 16 || !ctype_xdigit($spanId) || $spanId === '0000000000000000') {
+            return null;
+        }
+
+        // Flags must be 2 hex chars
+        if (strlen($flags) !== 2 || !ctype_xdigit($flags)) {
+            return null;
+        }
+
+        return new TraceContext(
+            traceId: new TraceId($traceId),
+            spanId: new SpanId($spanId),
+            traceFlags: (int) hexdec($flags),
+        );
+    }
+
+    /**
+     * Serialize a TraceContext to a traceparent header value.
+     */
+    public static function serialize(TraceContext $context): string
+    {
+        return sprintf(
+            '00-%s-%s-%02x',
+            $context->traceId->value,
+            $context->spanId->value,
+            $context->traceFlags,
+        );
+    }
+}

--- a/tests/Integration/Observability/ErrorTrackingIntegrationTest.php
+++ b/tests/Integration/Observability/ErrorTrackingIntegrationTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Integration\Observability;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\ErrorHandling\DevelopmentRenderer;
+use Pulsar\ErrorHandling\ExceptionHandler;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use Pulsar\Observability\Tracing\TraceContext;
+use RuntimeException;
+
+#[CoversClass(ExceptionHandler::class)]
+final class ErrorTrackingIntegrationTest extends TestCase
+{
+    #[Test]
+    public function exceptionHandlerCapturesErrorToAggregator(): void
+    {
+        $aggregator = new ErrorAggregator();
+        $scrubber = new SensitiveDataScrubber();
+        $handler = new ExceptionHandler(
+            renderer: new DevelopmentRenderer(),
+            errorAggregator: $aggregator,
+            scrubber: $scrubber,
+        );
+
+        $exception = new RuntimeException('test failure');
+        $request = $this->createRequest('GET', '/test');
+
+        $handler->handle($exception, $request);
+
+        self::assertSame(1, $aggregator->count());
+
+        $groups = $aggregator->groups();
+        self::assertSame(RuntimeException::class, $groups[0]->exceptionClass());
+        self::assertSame('test failure', $groups[0]->message());
+    }
+
+    #[Test]
+    public function sensitiveDataIsScrubbed(): void
+    {
+        $aggregator = new ErrorAggregator();
+        $scrubber = new SensitiveDataScrubber();
+        $handler = new ExceptionHandler(
+            renderer: new DevelopmentRenderer(),
+            errorAggregator: $aggregator,
+            scrubber: $scrubber,
+        );
+
+        $request = $this->createRequest('GET', '/test?password=secret&name=Alice');
+        $handler->handle(new RuntimeException('error'), $request);
+
+        $groups = $aggregator->groups();
+        $event = $groups[0]->recentEvents()[0];
+
+        // Query params containing password should be scrubbed
+        /** @var array<string, mixed> $query */
+        $query = $event->context['query'] ?? [];
+
+        if (isset($query['password'])) {
+            self::assertSame('[REDACTED]', $query['password']);
+        }
+    }
+
+    #[Test]
+    public function traceIdLinkedWhenPresent(): void
+    {
+        $aggregator = new ErrorAggregator();
+        $handler = new ExceptionHandler(
+            renderer: new DevelopmentRenderer(),
+            errorAggregator: $aggregator,
+        );
+
+        $traceContext = TraceContext::create();
+        $request = $this->createRequest('GET', '/test')
+            ->withAttribute('_trace_context', $traceContext);
+
+        $handler->handle(new RuntimeException('traced error'), $request);
+
+        $groups = $aggregator->groups();
+        $event = $groups[0]->recentEvents()[0];
+
+        self::assertNotNull($event->traceId);
+        self::assertSame($traceContext->traceId->value, $event->traceId->value);
+    }
+
+    private function createRequest(string $method, string $uri): Request
+    {
+        /** @var array{path?: string, query?: string} $parts */
+        $parts = parse_url($uri);
+        $path = $parts['path'] ?? '/';
+        $queryString = $parts['query'] ?? '';
+
+        // Parse query params
+        $parsed = [];
+
+        if ($queryString !== '') {
+            parse_str($queryString, $parsed);
+        }
+
+        $query = [];
+
+        foreach ($parsed as $k => $v) {
+            $query[(string) $k] = $v;
+        }
+
+        return new Request(
+            method: Method::from($method),
+            uri: $uri,
+            path: $path,
+            queryString: $queryString,
+            headers: new HeaderBag([]),
+            body: '',
+            query: $query,
+        );
+    }
+}

--- a/tests/Integration/Observability/MetricsMiddlewareTest.php
+++ b/tests/Integration/Observability/MetricsMiddlewareTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Integration\Observability;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Middleware\MetricsMiddleware;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+
+#[CoversClass(MetricsMiddleware::class)]
+final class MetricsMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function recordsRequestCounter(): void
+    {
+        $registry = new MetricRegistry();
+        $middleware = new MetricsMiddleware($registry);
+
+        $request = $this->createRequest('GET', '/users');
+        $middleware->process($request, static fn() => Response::html('ok'));
+
+        $counter = $registry->counter('pulsar_http_requests_total');
+        $labels = new LabelSet(['method' => 'GET', 'path' => '/users', 'status' => '200']);
+
+        self::assertSame(1.0, $counter->value($labels));
+    }
+
+    #[Test]
+    public function recordsDurationHistogram(): void
+    {
+        $registry = new MetricRegistry();
+        $middleware = new MetricsMiddleware($registry);
+
+        $request = $this->createRequest('POST', '/api');
+        $middleware->process($request, static fn() => Response::json(['ok' => true]));
+
+        $histogram = $registry->histogram('pulsar_http_request_duration_seconds');
+        $labels = new LabelSet(['method' => 'POST', 'path' => '/api']);
+
+        self::assertSame(1, $histogram->count($labels));
+        self::assertGreaterThan(0.0, $histogram->sum($labels));
+    }
+
+    #[Test]
+    public function recordsErrorCounterOn5xx(): void
+    {
+        $registry = new MetricRegistry();
+        $middleware = new MetricsMiddleware($registry);
+
+        $request = $this->createRequest('GET', '/fail');
+        $middleware->process(
+            $request,
+            static fn() => Response::json(['error' => 'fail'], ResponseStatus::InternalServerError),
+        );
+
+        $errorCounter = $registry->counter('pulsar_http_errors_total');
+        $labels = new LabelSet(['method' => 'GET', 'path' => '/fail', 'status' => '500']);
+
+        self::assertSame(1.0, $errorCounter->value($labels));
+    }
+
+    #[Test]
+    public function doesNotRecordErrorCounterOnSuccess(): void
+    {
+        $registry = new MetricRegistry();
+        $middleware = new MetricsMiddleware($registry);
+
+        $request = $this->createRequest('GET', '/ok');
+        $middleware->process($request, static fn() => Response::html('ok'));
+
+        // Error counter should not have been incremented
+        $errorCounter = $registry->counter('pulsar_http_errors_total');
+        self::assertSame(0.0, $errorCounter->value());
+    }
+
+    private function createRequest(string $method, string $path): Request
+    {
+        return new Request(
+            method: Method::from($method),
+            uri: $path,
+            path: $path,
+            queryString: '',
+            headers: new HeaderBag([]),
+            body: '',
+        );
+    }
+}

--- a/tests/Integration/Observability/TracingMiddlewareTest.php
+++ b/tests/Integration/Observability/TracingMiddlewareTest.php
@@ -1,0 +1,119 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Integration\Observability;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Middleware\TracingMiddleware;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Observability\Tracing\InMemorySpanCollector;
+use Pulsar\Observability\Tracing\SpanStatus;
+use Pulsar\Observability\Tracing\W3CTraceContextParser;
+
+#[CoversClass(TracingMiddleware::class)]
+final class TracingMiddlewareTest extends TestCase
+{
+    #[Test]
+    public function createsRootSpanForRequest(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $middleware = new TracingMiddleware($collector, samplingRate: 1.0);
+
+        $request = $this->createRequest('GET', '/test');
+        $response = $middleware->process($request, static fn() => Response::html('ok'));
+
+        self::assertSame(1, $collector->count());
+
+        $span = $collector->spans()[0];
+        self::assertSame('HTTP GET /test', $span->name);
+        self::assertSame(SpanStatus::Ok, $span->status());
+        self::assertTrue($span->hasEnded());
+    }
+
+    #[Test]
+    public function propagatesTraceparentHeader(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $middleware = new TracingMiddleware($collector, samplingRate: 1.0);
+
+        $request = $this->createRequest('GET', '/test');
+        $response = $middleware->process($request, static fn() => Response::html('ok'));
+
+        $traceparent = $response->headers->first('traceparent');
+        self::assertNotNull($traceparent);
+
+        $parsed = W3CTraceContextParser::parse($traceparent);
+        self::assertNotNull($parsed);
+        self::assertTrue($parsed->isSampled());
+    }
+
+    #[Test]
+    public function parsesIncomingTraceparent(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $middleware = new TracingMiddleware($collector, samplingRate: 1.0);
+
+        $incomingTraceparent = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+        $request = $this->createRequest('GET', '/test', ['traceparent' => [$incomingTraceparent]]);
+
+        $response = $middleware->process($request, static fn() => Response::html('ok'));
+
+        $span = $collector->spans()[0];
+        // Should preserve the parent trace ID
+        self::assertSame('4bf92f3577b34da6a3ce929d0e0e4736', $span->context->traceId->value);
+        // Should have the incoming span as parent
+        self::assertSame('00f067aa0ba902b7', $span->parentSpanId?->value);
+    }
+
+    #[Test]
+    public function setsErrorStatusOn5xx(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $middleware = new TracingMiddleware($collector, samplingRate: 1.0);
+
+        $request = $this->createRequest('POST', '/fail');
+        $response = $middleware->process(
+            $request,
+            static fn() => Response::json(['error' => 'fail'], ResponseStatus::InternalServerError),
+        );
+
+        $span = $collector->spans()[0];
+        self::assertSame(SpanStatus::Error, $span->status());
+        self::assertSame(500, $span->attributes()['http.status_code']);
+    }
+
+    #[Test]
+    public function respectsSamplingRate(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $middleware = new TracingMiddleware($collector, samplingRate: 0.0);
+
+        $request = $this->createRequest('GET', '/test');
+        $response = $middleware->process($request, static fn() => Response::html('ok'));
+
+        // With 0% sampling, no spans should be collected
+        self::assertSame(0, $collector->count());
+    }
+
+    /**
+     * @param array<string, list<string>> $headers
+     */
+    private function createRequest(string $method, string $path, array $headers = []): Request
+    {
+        return new Request(
+            method: Method::from($method),
+            uri: $path,
+            path: $path,
+            queryString: '',
+            headers: new HeaderBag($headers),
+            body: '',
+        );
+    }
+}

--- a/tests/Unit/Observability/ErrorTracking/ErrorAggregatorTest.php
+++ b/tests/Unit/Observability/ErrorTracking/ErrorAggregatorTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\ErrorTracking;
+
+use InvalidArgumentException;
+use LogicException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+use Pulsar\Observability\ErrorTracking\ErrorEvent;
+use Pulsar\Observability\ErrorTracking\ErrorFingerprint;
+use RuntimeException;
+
+#[CoversClass(ErrorAggregator::class)]
+final class ErrorAggregatorTest extends TestCase
+{
+    #[Test]
+    public function captureGroupsByFingerprint(): void
+    {
+        $aggregator = new ErrorAggregator();
+        $exception = new RuntimeException('test');
+
+        $event1 = ErrorEvent::fromThrowable($exception);
+        $event2 = ErrorEvent::fromThrowable($exception);
+
+        $aggregator->capture($event1);
+        $aggregator->capture($event2);
+
+        self::assertSame(1, $aggregator->count());
+
+        $group = $aggregator->group($event1->fingerprint);
+        self::assertNotNull($group);
+        self::assertSame(2, $group->occurrenceCount());
+    }
+
+    #[Test]
+    public function groupsSortedByLastSeenDescending(): void
+    {
+        $aggregator = new ErrorAggregator();
+
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('first')));
+        $aggregator->capture(ErrorEvent::fromThrowable(new LogicException('second')));
+
+        $groups = $aggregator->groups();
+        self::assertCount(2, $groups);
+
+        // Most recent group should be first
+        self::assertSame(LogicException::class, $groups[0]->exceptionClass());
+    }
+
+    #[Test]
+    public function evictsOldestGroupWhenAtCapacity(): void
+    {
+        $aggregator = new ErrorAggregator(maxGroups: 2);
+
+        // Create three distinct error types
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('one')));
+        $aggregator->capture(ErrorEvent::fromThrowable(new LogicException('two')));
+        $aggregator->capture(ErrorEvent::fromThrowable(new InvalidArgumentException('three')));
+
+        self::assertSame(2, $aggregator->count());
+    }
+
+    #[Test]
+    public function groupReturnsNullForUnknownFingerprint(): void
+    {
+        $aggregator = new ErrorAggregator();
+
+        self::assertNull($aggregator->group(new ErrorFingerprint('nonexistent')));
+    }
+
+    #[Test]
+    public function clearRemovesAllGroups(): void
+    {
+        $aggregator = new ErrorAggregator();
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('test')));
+        $aggregator->clear();
+
+        self::assertSame(0, $aggregator->count());
+        self::assertSame([], $aggregator->groups());
+    }
+}

--- a/tests/Unit/Observability/ErrorTracking/ErrorEventTest.php
+++ b/tests/Unit/Observability/ErrorTracking/ErrorEventTest.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\ErrorTracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\ErrorTracking\ErrorEvent;
+use Pulsar\Observability\Tracing\TraceId;
+use RuntimeException;
+
+#[CoversClass(ErrorEvent::class)]
+final class ErrorEventTest extends TestCase
+{
+    #[Test]
+    public function fromThrowableCreatesEvent(): void
+    {
+        $exception = new RuntimeException('test error');
+        $event = ErrorEvent::fromThrowable($exception);
+
+        self::assertSame(RuntimeException::class, $event->exceptionClass);
+        self::assertSame('test error', $event->message);
+        self::assertSame(__FILE__, $event->file);
+        self::assertNotEmpty($event->stackTrace);
+        self::assertNull($event->traceId);
+    }
+
+    #[Test]
+    public function fromThrowableIncludesContextAndTraceId(): void
+    {
+        $exception = new RuntimeException('test');
+        $traceId = TraceId::generate();
+
+        $event = ErrorEvent::fromThrowable(
+            $exception,
+            ['user_id' => 42],
+            $traceId,
+        );
+
+        self::assertSame(42, $event->context['user_id']);
+        self::assertSame($traceId->value, $event->traceId?->value);
+    }
+
+    #[Test]
+    public function stackTraceContainsExpectedFrames(): void
+    {
+        $exception = new RuntimeException('trace test');
+        $event = ErrorEvent::fromThrowable($exception);
+
+        self::assertNotEmpty($event->stackTrace);
+        self::assertArrayHasKey('file', $event->stackTrace[0]);
+        self::assertArrayHasKey('line', $event->stackTrace[0]);
+    }
+}

--- a/tests/Unit/Observability/ErrorTracking/ErrorFingerprintTest.php
+++ b/tests/Unit/Observability/ErrorTracking/ErrorFingerprintTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\ErrorTracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\ErrorTracking\ErrorFingerprint;
+use RuntimeException;
+
+use function strlen;
+
+#[CoversClass(ErrorFingerprint::class)]
+final class ErrorFingerprintTest extends TestCase
+{
+    #[Test]
+    public function fromThrowableProducesDeterministicHash(): void
+    {
+        $exception = new RuntimeException('test error');
+        $fp1 = ErrorFingerprint::fromThrowable($exception);
+        $fp2 = ErrorFingerprint::fromThrowable($exception);
+
+        self::assertSame($fp1->value, $fp2->value);
+        self::assertSame(64, strlen($fp1->value)); // sha256 = 64 hex chars
+    }
+
+    #[Test]
+    public function differentExceptionsProduceDifferentFingerprints(): void
+    {
+        $e1 = new RuntimeException('error one');
+        $e2 = new RuntimeException('error two');
+
+        $fp1 = ErrorFingerprint::fromThrowable($e1);
+        $fp2 = ErrorFingerprint::fromThrowable($e2);
+
+        self::assertNotSame($fp1->value, $fp2->value);
+    }
+
+    #[Test]
+    public function equalsComparesValues(): void
+    {
+        $fp1 = new ErrorFingerprint('abc123');
+        $fp2 = new ErrorFingerprint('abc123');
+        $fp3 = new ErrorFingerprint('xyz789');
+
+        self::assertTrue($fp1->equals($fp2));
+        self::assertFalse($fp1->equals($fp3));
+        self::assertSame('abc123', (string) $fp1);
+    }
+}

--- a/tests/Unit/Observability/ErrorTracking/ErrorGroupTest.php
+++ b/tests/Unit/Observability/ErrorTracking/ErrorGroupTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\ErrorTracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\ErrorTracking\ErrorEvent;
+use Pulsar\Observability\ErrorTracking\ErrorFingerprint;
+use Pulsar\Observability\ErrorTracking\ErrorGroup;
+use RuntimeException;
+
+#[CoversClass(ErrorGroup::class)]
+final class ErrorGroupTest extends TestCase
+{
+    #[Test]
+    public function recordIncrementsCount(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'));
+        $event = ErrorEvent::fromThrowable(new RuntimeException('test'));
+
+        $group->record($event);
+
+        self::assertSame(1, $group->occurrenceCount());
+    }
+
+    #[Test]
+    public function recordUpdatesLastSeen(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'));
+
+        $event1 = ErrorEvent::fromThrowable(new RuntimeException('first'));
+        $group->record($event1);
+        $firstLastSeen = $group->lastSeen();
+
+        $event2 = ErrorEvent::fromThrowable(new RuntimeException('second'));
+        $group->record($event2);
+
+        self::assertGreaterThanOrEqual($firstLastSeen, $group->lastSeen());
+        self::assertSame(2, $group->occurrenceCount());
+    }
+
+    #[Test]
+    public function capsRecentEvents(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'), maxRecentEvents: 2);
+
+        for ($i = 0; $i < 5; $i++) {
+            $group->record(ErrorEvent::fromThrowable(new RuntimeException("error $i")));
+        }
+
+        self::assertSame(5, $group->occurrenceCount());
+        self::assertCount(2, $group->recentEvents());
+    }
+
+    #[Test]
+    public function exposesLatestEventDetails(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'));
+        $group->record(ErrorEvent::fromThrowable(new RuntimeException('latest')));
+
+        self::assertSame(RuntimeException::class, $group->exceptionClass());
+        self::assertSame('latest', $group->message());
+    }
+}

--- a/tests/Unit/Observability/ErrorTracking/SensitiveDataScrubberTest.php
+++ b/tests/Unit/Observability/ErrorTracking/SensitiveDataScrubberTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\ErrorTracking;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+#[CoversClass(SensitiveDataScrubber::class)]
+final class SensitiveDataScrubberTest extends TestCase
+{
+    #[Test]
+    public function scrubsPasswordField(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $result = $scrubber->scrub(['password' => 'secret123', 'name' => 'Alice']);
+
+        self::assertSame('[REDACTED]', $result['password']);
+        self::assertSame('Alice', $result['name']);
+    }
+
+    #[Test]
+    public function scrubsTokenField(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $result = $scrubber->scrub(['api_token' => 'abc123', 'status' => 'ok']);
+
+        self::assertSame('[REDACTED]', $result['api_token']);
+        self::assertSame('ok', $result['status']);
+    }
+
+    #[Test]
+    public function isCaseInsensitive(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $result = $scrubber->scrub(['API_KEY' => 'my-key', 'Authorization' => 'Bearer xyz']);
+
+        self::assertSame('[REDACTED]', $result['API_KEY']);
+        self::assertSame('[REDACTED]', $result['Authorization']);
+    }
+
+    #[Test]
+    public function scrubsNestedArrays(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $result = $scrubber->scrub([
+            'user' => [
+                'name' => 'Alice',
+                'password' => 'hidden',
+                'details' => [
+                    'ssn' => '123-45-6789',
+                ],
+            ],
+        ]);
+
+        /** @var array<string, mixed> $user */
+        $user = $result['user'];
+        self::assertSame('Alice', $user['name']);
+        self::assertSame('[REDACTED]', $user['password']);
+        /** @var array<string, mixed> $details */
+        $details = $user['details'];
+        self::assertSame('[REDACTED]', $details['ssn']);
+    }
+
+    #[Test]
+    public function scrubsCustomFields(): void
+    {
+        $scrubber = new SensitiveDataScrubber(['my_secret']);
+        $result = $scrubber->scrub(['my_secret_value' => 'hidden', 'public' => 'visible']);
+
+        self::assertSame('[REDACTED]', $result['my_secret_value']);
+        self::assertSame('visible', $result['public']);
+    }
+
+    #[Test]
+    public function scrubsHeaders(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $result = $scrubber->scrubHeaders([
+            'Authorization' => 'Bearer token',
+            'Cookie' => 'session=abc',
+            'Content-Type' => 'application/json',
+            'X-API-Key' => 'key123',
+        ]);
+
+        self::assertSame('[REDACTED]', $result['Authorization']);
+        self::assertSame('[REDACTED]', $result['Cookie']);
+        self::assertSame('application/json', $result['Content-Type']);
+        self::assertSame('[REDACTED]', $result['X-API-Key']);
+    }
+
+    #[Test]
+    public function emptyArrayReturnsEmpty(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+
+        self::assertSame([], $scrubber->scrub([]));
+        self::assertSame([], $scrubber->scrubHeaders([]));
+    }
+
+    #[Test]
+    public function scrubsCreditCardField(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $result = $scrubber->scrub(['credit_card_number' => '4111111111111111']);
+
+        self::assertSame('[REDACTED]', $result['credit_card_number']);
+    }
+}

--- a/tests/Unit/Observability/Metrics/CounterTest.php
+++ b/tests/Unit/Observability/Metrics/CounterTest.php
@@ -1,0 +1,79 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\Counter;
+use Pulsar\Observability\Metrics\Exception\MetricsException;
+use Pulsar\Observability\Metrics\LabelSet;
+
+#[CoversClass(Counter::class)]
+final class CounterTest extends TestCase
+{
+    #[Test]
+    public function incrementsByOneByDefault(): void
+    {
+        $counter = new Counter('requests_total');
+        $counter->increment();
+
+        self::assertSame(1.0, $counter->value());
+    }
+
+    #[Test]
+    public function incrementsByCustomValue(): void
+    {
+        $counter = new Counter('bytes_sent');
+        $counter->increment(value: 42.5);
+
+        self::assertSame(42.5, $counter->value());
+    }
+
+    #[Test]
+    public function rejectsNegativeIncrement(): void
+    {
+        $counter = new Counter('test');
+
+        $this->expectException(MetricsException::class);
+        $this->expectExceptionMessage('non-negative');
+
+        $counter->increment(value: -1.0);
+    }
+
+    #[Test]
+    public function tracksValuesByLabelSet(): void
+    {
+        $counter = new Counter('http_requests');
+        $get = new LabelSet(['method' => 'GET']);
+        $post = new LabelSet(['method' => 'POST']);
+
+        $counter->increment($get);
+        $counter->increment($get);
+        $counter->increment($post);
+
+        self::assertSame(2.0, $counter->value($get));
+        self::assertSame(1.0, $counter->value($post));
+    }
+
+    #[Test]
+    public function returnsZeroForUnknownLabels(): void
+    {
+        $counter = new Counter('test');
+
+        self::assertSame(0.0, $counter->value(new LabelSet(['x' => 'y'])));
+    }
+
+    #[Test]
+    public function resetClearsAllValues(): void
+    {
+        $counter = new Counter('test');
+        $counter->increment();
+        $counter->reset();
+
+        self::assertSame(0.0, $counter->value());
+        self::assertSame([], $counter->values());
+    }
+}

--- a/tests/Unit/Observability/Metrics/GaugeTest.php
+++ b/tests/Unit/Observability/Metrics/GaugeTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\Gauge;
+use Pulsar\Observability\Metrics\LabelSet;
+
+#[CoversClass(Gauge::class)]
+final class GaugeTest extends TestCase
+{
+    #[Test]
+    public function setsAbsoluteValue(): void
+    {
+        $gauge = new Gauge('temperature');
+        $gauge->set(36.6);
+
+        self::assertSame(36.6, $gauge->value());
+    }
+
+    #[Test]
+    public function incrementsByOne(): void
+    {
+        $gauge = new Gauge('connections');
+        $gauge->increment();
+
+        self::assertSame(1.0, $gauge->value());
+    }
+
+    #[Test]
+    public function incrementsByCustomValue(): void
+    {
+        $gauge = new Gauge('queue_size');
+        $gauge->increment(value: 5.0);
+
+        self::assertSame(5.0, $gauge->value());
+    }
+
+    #[Test]
+    public function decrementsByOne(): void
+    {
+        $gauge = new Gauge('connections');
+        $gauge->set(10.0);
+        $gauge->decrement();
+
+        self::assertSame(9.0, $gauge->value());
+    }
+
+    #[Test]
+    public function decrementsByCustomValue(): void
+    {
+        $gauge = new Gauge('connections');
+        $gauge->set(10.0);
+        $gauge->decrement(value: 3.0);
+
+        self::assertSame(7.0, $gauge->value());
+    }
+
+    #[Test]
+    public function tracksValuesByLabelSet(): void
+    {
+        $gauge = new Gauge('pool_size');
+        $db = new LabelSet(['pool' => 'database']);
+        $cache = new LabelSet(['pool' => 'cache']);
+
+        $gauge->set(5.0, $db);
+        $gauge->set(10.0, $cache);
+
+        self::assertSame(5.0, $gauge->value($db));
+        self::assertSame(10.0, $gauge->value($cache));
+    }
+
+    #[Test]
+    public function resetClearsAllValues(): void
+    {
+        $gauge = new Gauge('test');
+        $gauge->set(42.0);
+        $gauge->reset();
+
+        self::assertSame(0.0, $gauge->value());
+        self::assertSame([], $gauge->values());
+    }
+}

--- a/tests/Unit/Observability/Metrics/HistogramTest.php
+++ b/tests/Unit/Observability/Metrics/HistogramTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use function array_key_exists;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\Histogram;
+use Pulsar\Observability\Metrics\LabelSet;
+
+#[CoversClass(Histogram::class)]
+final class HistogramTest extends TestCase
+{
+    #[Test]
+    public function observeRecordsValueInBuckets(): void
+    {
+        $histogram = new Histogram('duration', boundaries: [0.1, 0.5, 1.0]);
+        $histogram->observe(0.3);
+
+        self::assertSame(1, $histogram->count());
+        self::assertEqualsWithDelta(0.3, $histogram->sum(), 0.0001);
+
+        $buckets = $histogram->buckets();
+        // 0.1 and 0.5 stay as string keys; 1.0 → '1' → int key 1 in PHP
+        self::assertSame(0, $buckets['0.1']);
+        self::assertSame(1, $buckets['0.5']);
+
+        // PHP casts numeric-string '1' to int key 1
+        $oneKey = array_key_exists(1, $buckets) ? 1 : '1';
+        self::assertSame(1, $buckets[$oneKey]);
+    }
+
+    #[Test]
+    public function observeRecordsInAllMatchingBuckets(): void
+    {
+        $histogram = new Histogram('size', boundaries: [10.0, 50.0, 100.0]);
+        $histogram->observe(5.0);
+
+        $buckets = $histogram->buckets();
+
+        // All boundaries are integer-like floats, so PHP casts their string keys to int
+        foreach ([10, 50, 100] as $intKey) {
+            self::assertArrayHasKey($intKey, $buckets);
+            self::assertSame(1, $buckets[$intKey]);
+        }
+    }
+
+    #[Test]
+    public function observeValueAboveAllBuckets(): void
+    {
+        $histogram = new Histogram('latency', boundaries: [0.1, 0.5]);
+        $histogram->observe(999.0);
+
+        $buckets = $histogram->buckets();
+        self::assertSame(0, $buckets['0.1']);
+        self::assertSame(0, $buckets['0.5']);
+        self::assertSame(1, $histogram->count());
+        self::assertEqualsWithDelta(999.0, $histogram->sum(), 0.0001);
+    }
+
+    #[Test]
+    public function tracksSeriesByLabelSet(): void
+    {
+        $histogram = new Histogram('request_duration', boundaries: [0.1, 1.0]);
+        $get = new LabelSet(['method' => 'GET']);
+        $post = new LabelSet(['method' => 'POST']);
+
+        $histogram->observe(0.05, $get);
+        $histogram->observe(0.5, $post);
+
+        self::assertSame(1, $histogram->count($get));
+        self::assertSame(1, $histogram->count($post));
+        self::assertEqualsWithDelta(0.05, $histogram->sum($get), 0.0001);
+        self::assertEqualsWithDelta(0.5, $histogram->sum($post), 0.0001);
+    }
+
+    #[Test]
+    public function usesDefaultBoundaries(): void
+    {
+        $histogram = new Histogram('default');
+
+        self::assertSame(Histogram::DEFAULT_BOUNDARIES, $histogram->boundaries());
+    }
+
+    #[Test]
+    public function resetClearsAllData(): void
+    {
+        $histogram = new Histogram('test', boundaries: [1.0]);
+        $histogram->observe(0.5);
+        $histogram->reset();
+
+        self::assertSame(0, $histogram->count());
+        self::assertSame(0.0, $histogram->sum());
+        self::assertSame([], $histogram->seriesKeys());
+    }
+}

--- a/tests/Unit/Observability/Metrics/LabelSetTest.php
+++ b/tests/Unit/Observability/Metrics/LabelSetTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\LabelSet;
+
+#[CoversClass(LabelSet::class)]
+final class LabelSetTest extends TestCase
+{
+    #[Test]
+    public function emptyLabelSetHasEmptyKey(): void
+    {
+        $labels = new LabelSet();
+
+        self::assertSame('', $labels->key());
+        self::assertTrue($labels->isEmpty());
+    }
+
+    #[Test]
+    public function keyIsDeterministicRegardlessOfInsertOrder(): void
+    {
+        $a = new LabelSet(['z' => '1', 'a' => '2']);
+        $b = new LabelSet(['a' => '2', 'z' => '1']);
+
+        self::assertSame($a->key(), $b->key());
+        self::assertSame('a=2,z=1', $a->key());
+    }
+
+    #[Test]
+    public function toArrayReturnsLabels(): void
+    {
+        $labels = new LabelSet(['method' => 'GET', 'path' => '/']);
+
+        self::assertSame(['method' => 'GET', 'path' => '/'], $labels->toArray());
+        self::assertFalse($labels->isEmpty());
+    }
+}

--- a/tests/Unit/Observability/Metrics/MetricRegistryTest.php
+++ b/tests/Unit/Observability/Metrics/MetricRegistryTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\Counter;
+use Pulsar\Observability\Metrics\Exception\MetricsException;
+use Pulsar\Observability\Metrics\Gauge;
+use Pulsar\Observability\Metrics\Histogram;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Observability\Metrics\MetricType;
+
+#[CoversClass(MetricRegistry::class)]
+final class MetricRegistryTest extends TestCase
+{
+    #[Test]
+    public function counterCreateOrReturn(): void
+    {
+        $registry = new MetricRegistry();
+
+        $c1 = $registry->counter('requests_total', 'Total requests');
+        $c2 = $registry->counter('requests_total');
+
+        self::assertSame($c1, $c2);
+        self::assertInstanceOf(Counter::class, $c1);
+    }
+
+    #[Test]
+    public function gaugeCreateOrReturn(): void
+    {
+        $registry = new MetricRegistry();
+
+        $g1 = $registry->gauge('temperature');
+        $g2 = $registry->gauge('temperature');
+
+        self::assertSame($g1, $g2);
+        self::assertInstanceOf(Gauge::class, $g1);
+    }
+
+    #[Test]
+    public function histogramCreateOrReturn(): void
+    {
+        $registry = new MetricRegistry();
+
+        $h1 = $registry->histogram('duration');
+        $h2 = $registry->histogram('duration');
+
+        self::assertSame($h1, $h2);
+        self::assertInstanceOf(Histogram::class, $h1);
+    }
+
+    #[Test]
+    public function throwsOnTypeMismatch(): void
+    {
+        $registry = new MetricRegistry();
+        $registry->counter('metric');
+
+        $this->expectException(MetricsException::class);
+        $this->expectExceptionMessage('already registered as counter');
+
+        $registry->gauge('metric');
+    }
+
+    #[Test]
+    public function hasAndTypeOf(): void
+    {
+        $registry = new MetricRegistry();
+        $registry->counter('c');
+        $registry->gauge('g');
+
+        self::assertTrue($registry->has('c'));
+        self::assertTrue($registry->has('g'));
+        self::assertFalse($registry->has('unknown'));
+        self::assertSame(MetricType::Counter, $registry->typeOf('c'));
+        self::assertSame(MetricType::Gauge, $registry->typeOf('g'));
+        self::assertNull($registry->typeOf('unknown'));
+    }
+}

--- a/tests/Unit/Observability/Metrics/PrometheusExporterTest.php
+++ b/tests/Unit/Observability/Metrics/PrometheusExporterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Observability\Metrics\PrometheusExporter;
+
+#[CoversClass(PrometheusExporter::class)]
+final class PrometheusExporterTest extends TestCase
+{
+    #[Test]
+    public function exportsCounterWithHelpAndType(): void
+    {
+        $registry = new MetricRegistry();
+        $counter = $registry->counter('http_requests_total', 'Total HTTP requests');
+        $counter->increment();
+
+        $exporter = new PrometheusExporter($registry);
+        $output = $exporter->export();
+
+        self::assertStringContainsString('# HELP http_requests_total Total HTTP requests', $output);
+        self::assertStringContainsString('# TYPE http_requests_total counter', $output);
+        self::assertStringContainsString('http_requests_total 1', $output);
+    }
+
+    #[Test]
+    public function exportsCounterWithLabels(): void
+    {
+        $registry = new MetricRegistry();
+        $counter = $registry->counter('requests');
+        $counter->increment(new LabelSet(['method' => 'GET', 'status' => '200']));
+
+        $exporter = new PrometheusExporter($registry);
+        $output = $exporter->export();
+
+        self::assertStringContainsString('method="GET"', $output);
+        self::assertStringContainsString('status="200"', $output);
+    }
+
+    #[Test]
+    public function exportsGauge(): void
+    {
+        $registry = new MetricRegistry();
+        $gauge = $registry->gauge('temperature', 'Current temperature');
+        $gauge->set(36.6);
+
+        $exporter = new PrometheusExporter($registry);
+        $output = $exporter->export();
+
+        self::assertStringContainsString('# TYPE temperature gauge', $output);
+        self::assertStringContainsString('temperature 36.6', $output);
+    }
+
+    #[Test]
+    public function exportsHistogramWithBuckets(): void
+    {
+        $registry = new MetricRegistry();
+        $histogram = $registry->histogram('duration', 'Request duration', [0.1, 0.5, 1.0]);
+        $histogram->observe(0.3);
+
+        $exporter = new PrometheusExporter($registry);
+        $output = $exporter->export();
+
+        self::assertStringContainsString('# TYPE duration histogram', $output);
+        self::assertStringContainsString('duration_bucket{le="0.1"} 0', $output);
+        self::assertStringContainsString('duration_bucket{le="0.5"} 1', $output);
+        self::assertStringContainsString('duration_bucket{le="1"} 1', $output);
+        self::assertStringContainsString('duration_bucket{le="+Inf"} 1', $output);
+        self::assertStringContainsString('duration_sum', $output);
+        self::assertStringContainsString('duration_count 1', $output);
+    }
+
+    #[Test]
+    public function exportsEmptyRegistry(): void
+    {
+        $registry = new MetricRegistry();
+        $exporter = new PrometheusExporter($registry);
+
+        self::assertSame("\n", $exporter->export());
+    }
+}

--- a/tests/Unit/Observability/Tracing/InMemorySpanCollectorTest.php
+++ b/tests/Unit/Observability/Tracing/InMemorySpanCollectorTest.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Tracing\InMemorySpanCollector;
+use Pulsar\Observability\Tracing\Span;
+use Pulsar\Observability\Tracing\TraceContext;
+
+#[CoversClass(InMemorySpanCollector::class)]
+final class InMemorySpanCollectorTest extends TestCase
+{
+    #[Test]
+    public function collectsSpans(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $span = new Span('test', TraceContext::create());
+        $span->end();
+
+        $collector->onEnd($span);
+
+        self::assertSame(1, $collector->count());
+        self::assertSame($span, $collector->spans()[0]);
+    }
+
+    #[Test]
+    public function evictsOldestWhenExceedingMax(): void
+    {
+        $collector = new InMemorySpanCollector(maxSpans: 3);
+
+        for ($i = 0; $i < 5; $i++) {
+            $span = new Span("span-$i", TraceContext::create());
+            $span->end();
+            $collector->onEnd($span);
+        }
+
+        self::assertSame(3, $collector->count());
+        self::assertSame('span-2', $collector->spans()[0]->name);
+        self::assertSame('span-4', $collector->spans()[2]->name);
+    }
+
+    #[Test]
+    public function filtersByTraceId(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $ctx1 = TraceContext::create();
+        $ctx2 = TraceContext::create();
+
+        $span1 = new Span('s1', $ctx1);
+        $span1->end();
+        $collector->onEnd($span1);
+
+        $span2 = new Span('s2', $ctx2);
+        $span2->end();
+        $collector->onEnd($span2);
+
+        $span3 = new Span('s3', $ctx1->createChild());
+        $span3->end();
+        $collector->onEnd($span3);
+
+        $traceSpans = $collector->spansByTraceId($ctx1->traceId);
+        self::assertCount(2, $traceSpans);
+    }
+
+    #[Test]
+    public function clearRemovesAllSpans(): void
+    {
+        $collector = new InMemorySpanCollector();
+        $span = new Span('test', TraceContext::create());
+        $span->end();
+        $collector->onEnd($span);
+
+        $collector->clear();
+
+        self::assertSame(0, $collector->count());
+        self::assertSame([], $collector->spans());
+    }
+}

--- a/tests/Unit/Observability/Tracing/SpanIdTest.php
+++ b/tests/Unit/Observability/Tracing/SpanIdTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Tracing\Exception\TracingException;
+use Pulsar\Observability\Tracing\SpanId;
+
+use function strlen;
+
+#[CoversClass(SpanId::class)]
+final class SpanIdTest extends TestCase
+{
+    #[Test]
+    public function generateProducesValid16HexChars(): void
+    {
+        $id = SpanId::generate();
+
+        self::assertSame(16, strlen($id->value));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{16}$/', $id->value);
+    }
+
+    #[Test]
+    public function normalizesToLowercase(): void
+    {
+        $id = new SpanId('00F067AA0BA902B7');
+
+        self::assertSame('00f067aa0ba902b7', $id->value);
+        self::assertSame('00f067aa0ba902b7', (string) $id);
+    }
+
+    #[Test]
+    public function rejectsInvalidSpanId(): void
+    {
+        $this->expectException(TracingException::class);
+        $this->expectExceptionMessage('Invalid span ID');
+
+        new SpanId('invalid');
+    }
+}

--- a/tests/Unit/Observability/Tracing/SpanTest.php
+++ b/tests/Unit/Observability/Tracing/SpanTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Tracing\Span;
+use Pulsar\Observability\Tracing\SpanStatus;
+use Pulsar\Observability\Tracing\TraceContext;
+
+#[CoversClass(Span::class)]
+final class SpanTest extends TestCase
+{
+    #[Test]
+    public function hasNameAndContext(): void
+    {
+        $context = TraceContext::create();
+        $span = new Span('test-span', $context);
+
+        self::assertSame('test-span', $span->name);
+        self::assertSame($context, $span->context);
+    }
+
+    #[Test]
+    public function startsWithUnsetStatusAndNoEnd(): void
+    {
+        $span = new Span('test', TraceContext::create());
+
+        self::assertSame(SpanStatus::Unset, $span->status());
+        self::assertFalse($span->hasEnded());
+        self::assertNull($span->endTime());
+        self::assertNull($span->duration());
+    }
+
+    #[Test]
+    public function endSetsEndTime(): void
+    {
+        $span = new Span('test', TraceContext::create());
+        $span->end();
+
+        self::assertTrue($span->hasEnded());
+        self::assertNotNull($span->endTime());
+        self::assertNotNull($span->duration());
+        self::assertGreaterThanOrEqual(0, $span->duration());
+    }
+
+    #[Test]
+    public function endIsIdempotent(): void
+    {
+        $span = new Span('test', TraceContext::create());
+        $span->end();
+        $endTime = $span->endTime();
+
+        // Second end should not change the time
+        $span->end();
+
+        self::assertSame($endTime, $span->endTime());
+    }
+
+    #[Test]
+    public function setStatusChangesStatus(): void
+    {
+        $span = new Span('test', TraceContext::create());
+        $span->setStatus(SpanStatus::Ok);
+
+        self::assertSame(SpanStatus::Ok, $span->status());
+
+        $span->setStatus(SpanStatus::Error);
+
+        self::assertSame(SpanStatus::Error, $span->status());
+    }
+
+    #[Test]
+    public function setAttributeAddsAttributes(): void
+    {
+        $span = new Span('test', TraceContext::create());
+        $span->setAttribute('http.method', 'GET');
+        $span->setAttribute('http.status', 200);
+        $span->setAttribute('sampled', true);
+
+        $attrs = $span->attributes();
+        self::assertSame('GET', $attrs['http.method']);
+        self::assertSame(200, $attrs['http.status']);
+        self::assertTrue($attrs['sampled']);
+    }
+
+    #[Test]
+    public function durationSecondsReturnsFloat(): void
+    {
+        $span = new Span('test', TraceContext::create());
+        $span->end();
+
+        $seconds = $span->durationSeconds();
+        self::assertNotNull($seconds);
+        self::assertGreaterThanOrEqual(0.0, $seconds);
+    }
+}

--- a/tests/Unit/Observability/Tracing/TraceContextTest.php
+++ b/tests/Unit/Observability/Tracing/TraceContextTest.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Tracing\SpanId;
+use Pulsar\Observability\Tracing\TraceContext;
+use Pulsar\Observability\Tracing\TraceId;
+
+use function strlen;
+
+#[CoversClass(TraceContext::class)]
+final class TraceContextTest extends TestCase
+{
+    #[Test]
+    public function createGeneratesNewIds(): void
+    {
+        $ctx = TraceContext::create();
+
+        self::assertSame(32, strlen($ctx->traceId->value));
+        self::assertSame(16, strlen($ctx->spanId->value));
+        self::assertTrue($ctx->isSampled());
+    }
+
+    #[Test]
+    public function createChildPreservesTraceId(): void
+    {
+        $parent = TraceContext::create();
+        $child = $parent->createChild();
+
+        self::assertSame($parent->traceId->value, $child->traceId->value);
+        self::assertNotSame($parent->spanId->value, $child->spanId->value);
+        self::assertSame($parent->traceFlags, $child->traceFlags);
+    }
+
+    #[Test]
+    public function isSampledChecksFlagBit(): void
+    {
+        $sampled = new TraceContext(
+            TraceId::generate(),
+            SpanId::generate(),
+            0x01,
+        );
+        $notSampled = new TraceContext(
+            TraceId::generate(),
+            SpanId::generate(),
+            0x00,
+        );
+
+        self::assertTrue($sampled->isSampled());
+        self::assertFalse($notSampled->isSampled());
+    }
+
+    #[Test]
+    public function flagsArePreservedInChild(): void
+    {
+        $parent = new TraceContext(
+            TraceId::generate(),
+            SpanId::generate(),
+            0x00,
+        );
+        $child = $parent->createChild();
+
+        self::assertFalse($child->isSampled());
+    }
+}

--- a/tests/Unit/Observability/Tracing/TraceIdTest.php
+++ b/tests/Unit/Observability/Tracing/TraceIdTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Tracing\Exception\TracingException;
+use Pulsar\Observability\Tracing\TraceId;
+
+use function strlen;
+
+#[CoversClass(TraceId::class)]
+final class TraceIdTest extends TestCase
+{
+    #[Test]
+    public function generateProducesValid32HexChars(): void
+    {
+        $id = TraceId::generate();
+
+        self::assertSame(32, strlen($id->value));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{32}$/', $id->value);
+    }
+
+    #[Test]
+    public function normalizesToLowercase(): void
+    {
+        $id = new TraceId('4BF92F3577B34DA6A3CE929D0E0E4736');
+
+        self::assertSame('4bf92f3577b34da6a3ce929d0e0e4736', $id->value);
+        self::assertSame('4bf92f3577b34da6a3ce929d0e0e4736', (string) $id);
+    }
+
+    #[Test]
+    public function rejectsInvalidTraceId(): void
+    {
+        $this->expectException(TracingException::class);
+        $this->expectExceptionMessage('Invalid trace ID');
+
+        new TraceId('not-valid');
+    }
+}

--- a/tests/Unit/Observability/Tracing/W3CTraceContextParserTest.php
+++ b/tests/Unit/Observability/Tracing/W3CTraceContextParserTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Tracing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Tracing\SpanId;
+use Pulsar\Observability\Tracing\TraceContext;
+use Pulsar\Observability\Tracing\TraceId;
+use Pulsar\Observability\Tracing\W3CTraceContextParser;
+
+#[CoversClass(W3CTraceContextParser::class)]
+final class W3CTraceContextParserTest extends TestCase
+{
+    #[Test]
+    public function parsesValidTraceparent(): void
+    {
+        $header = '00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01';
+        $ctx = W3CTraceContextParser::parse($header);
+
+        self::assertNotNull($ctx);
+        self::assertSame('4bf92f3577b34da6a3ce929d0e0e4736', $ctx->traceId->value);
+        self::assertSame('00f067aa0ba902b7', $ctx->spanId->value);
+        self::assertSame(1, $ctx->traceFlags);
+        self::assertTrue($ctx->isSampled());
+    }
+
+    #[Test]
+    public function returnsNullForMalformedHeader(): void
+    {
+        self::assertNull(W3CTraceContextParser::parse('invalid'));
+        self::assertNull(W3CTraceContextParser::parse('00-short-short-01'));
+        self::assertNull(W3CTraceContextParser::parse(''));
+    }
+
+    #[Test]
+    public function returnsNullForAllZeroTraceId(): void
+    {
+        $header = '00-00000000000000000000000000000000-00f067aa0ba902b7-01';
+
+        self::assertNull(W3CTraceContextParser::parse($header));
+    }
+
+    #[Test]
+    public function returnsNullForAllZeroSpanId(): void
+    {
+        $header = '00-4bf92f3577b34da6a3ce929d0e0e4736-0000000000000000-01';
+
+        self::assertNull(W3CTraceContextParser::parse($header));
+    }
+
+    #[Test]
+    public function serializesTraceContext(): void
+    {
+        $ctx = new TraceContext(
+            traceId: new TraceId('4bf92f3577b34da6a3ce929d0e0e4736'),
+            spanId: new SpanId('00f067aa0ba902b7'),
+            traceFlags: 0x01,
+        );
+
+        $serialized = W3CTraceContextParser::serialize($ctx);
+
+        self::assertSame('00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01', $serialized);
+    }
+}


### PR DESCRIPTION
## Summary

- Add metrics system (Counter, Gauge, Histogram) with label support, MetricRegistry, and Prometheus text exposition exporter
- Add distributed tracing with W3C `traceparent` propagation, span lifecycle, and InMemorySpanCollector ring-buffer
- Add error tracking with deterministic SHA-256 fingerprinting, error grouping, and recursive sensitive data scrubbing
- Add TracingMiddleware (outermost) and MetricsMiddleware for automatic HTTP request instrumentation
- Add DiagnosticsRenderer at `/_pulsar/diagnostics` (debug mode only) for local observability viewer
- Extend ObservabilityConfig with MetricsConfig, TracingConfig, and ErrorTrackingConfig DTOs
- Integrate ErrorAggregator and SensitiveDataScrubber into ExceptionHandler
- Update Kernel boot pipeline: Config → Logger → Tracer → Metrics → ErrorTracker → ExceptionHandler → DiagnosticsRoute → Extensions
- Add `docs/OBSERVABILITY.md`

**55 files changed** — 37 source, 22 test, 1 doc (4,495 lines added)

## Quality Gate

| Check | Result |
|-------|--------|
| PHPStan (max level) | 0 errors |
| Psalm (error level 1) | 0 errors |
| PHPUnit | 572 tests, 1,062 assertions |
| PHP-CS-Fixer (PER-CS2.0) | 0 violations |

## Test plan

- [x] `composer test` — all 572 tests pass (115 new observability tests)
- [x] `composer phpstan` — level max clean
- [x] `composer psalm` — error level 1 clean
- [x] `composer cs:check` — PER-CS2.0 compliant
- [x] Boot kernel with observability config enabled, hit routes, verify `/_pulsar/diagnostics` renders metrics/traces/errors
- [x] `GET /metrics` returns valid Prometheus exposition format when prometheus exporter is enabled
- [x] `composer qa` — full quality gate green

## Linked Issues
Resolves #85
Resolves #90
Resolves #97
Resolves #104
