### PR TITLE
feat(security): implement security baseline v1 for 0.6.0

### DIFF
--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -57,7 +57,7 @@ Deliverables:
   Exit criteria:
 - No “magic” config; everything type-safe and discoverable
 
-### 0.4.0 — HTTP & Routing Advanced (CURRENT)
+### 0.4.0 — HTTP & Routing Advanced
 
 Deliverables:
 
@@ -83,13 +83,16 @@ Deliverables:
   Exit criteria:
 - Example app produces logs/metrics/traces and viewable report
 
-### 0.6.0 — Security Baseline v1
+### 0.6.0 — Security Baseline v1 (CURRENT)
 
 Deliverables:
 
-- Session hardening + CSRF + secure headers defaults
-- Crypto/key management primitives
-- Audit logging subsystem (domain events + immutable logs)
+- Session hardening + CSRF + secure headers defaults ✓
+- Crypto/key management primitives (libsodium: HMAC, KDF, secretbox) ✓
+- Audit logging subsystem (HMAC-chained tamper-evident entries) ✓
+- SecurityConfig DTO + SessionConfig + CsrfConfig + SecurityHeadersConfig ✓
+- SecurityException with factory methods for all security errors ✓
+- Kernel integration: createSecurityServices() in boot pipeline ✓
   Exit criteria:
 - Security checklist documented + tested
 

--- a/config/observability.php
+++ b/config/observability.php
@@ -76,6 +76,7 @@ return [
     */
     'audit' => [
         'enabled' => true,
+        'log_path' => 'var/logs/audit.jsonl',
         'events' => [
             'authentication',
             'authorization',

--- a/config/security.php
+++ b/config/security.php
@@ -18,6 +18,8 @@ return [
     |--------------------------------------------------------------------------
     */
     'session' => [
+        'cookie_name' => 'PULSAR_SESSION',
+        'lifetime' => 7200,
         'cookie_httponly' => true,
         'cookie_secure' => true,
         'cookie_samesite' => 'Strict',
@@ -33,6 +35,7 @@ return [
         'enabled' => true,
         'token_length' => 32,
         'header_name' => 'X-CSRF-Token',
+        'form_field_name' => '_csrf_token',
     ],
 
     /*

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -203,18 +203,18 @@ Immutable value object representing a single audit log entry.
 
 ### Fields
 
-| Field          | Type           | Description                              |
-| -------------- | -------------- | ---------------------------------------- |
-| `id`           | `string`       | UUIDv4 identifier                        |
-| `event`        | `AuditEvent`   | Category of the event                    |
-| `outcome`      | `AuditOutcome` | Result of the action                     |
+| Field          | Type           | Description                                |
+| -------------- | -------------- | ------------------------------------------ |
+| `id`           | `string`       | UUIDv4 identifier                          |
+| `event`        | `AuditEvent`   | Category of the event                      |
+| `outcome`      | `AuditOutcome` | Result of the action                       |
 | `actor`        | `string`       | Who performed the action (e.g., `user:42`) |
-| `action`       | `string`       | What was done (e.g., `login`, `export`)  |
-| `resource`     | `string`       | What was acted upon (e.g., `session`)    |
-| `timestamp`    | `string`       | ISO 8601 with microseconds              |
-| `metadata`     | `array`        | Additional context (key-value pairs)     |
-| `hmac`         | `string`       | HMAC-BLAKE2b hex covering all fields     |
-| `previousHmac` | `string`       | Previous entry's HMAC (chain link)       |
+| `action`       | `string`       | What was done (e.g., `login`, `export`)    |
+| `resource`     | `string`       | What was acted upon (e.g., `session`)      |
+| `timestamp`    | `string`       | ISO 8601 with microseconds                 |
+| `metadata`     | `array`        | Additional context (key-value pairs)       |
+| `hmac`         | `string`       | HMAC-BLAKE2b hex covering all fields       |
+| `previousHmac` | `string`       | Previous entry's HMAC (chain link)         |
 
 ### Serialization
 

--- a/docs/AUDIT_LOGGING.md
+++ b/docs/AUDIT_LOGGING.md
@@ -1,0 +1,297 @@
+# Audit Logging
+
+Pulsar provides a tamper-evident audit logging subsystem separate from general application logging. Audit logs record security-relevant events (authentication, authorization, data access) with HMAC-chained integrity guarantees.
+
+## Why Separate from General Logging?
+
+General logging (`Pulsar\Observability\Log\Logger`) records operational events: errors, warnings, debug information. Audit logging records **who did what, when, and why** for compliance and forensic purposes. The two have different:
+
+- **Schemas** — audit entries have structured fields (actor, action, resource, outcome)
+- **Integrity guarantees** — audit entries are HMAC-chained; tampering with any entry invalidates all subsequent entries
+- **Retention policies** — audit logs are typically retained longer and may have legal requirements
+- **Access controls** — audit logs should be write-once, append-only
+
+## Architecture
+
+```
+AuditLogger
+  ├── Creates AuditEntry (with HMAC chain)
+  ├── Writes to AuditSinkInterface
+  └── Advances previousHmac state
+
+AuditEntry (readonly VO)
+  ├── id, event, outcome, actor, action, resource, timestamp, metadata
+  ├── hmac (computed over all fields + previousHmac)
+  └── verify(auditKey) → bool
+
+AuditSinkInterface
+  └── AuditFileSink (append-only JSON Lines with LOCK_EX)
+```
+
+## Configuration
+
+Audit logging is configured under the `audit` key in `config/observability.php`:
+
+```php
+// config/observability.php
+return [
+    // ... logging config ...
+    'audit' => [
+        'enabled'  => true,
+        'log_path' => 'storage/audit/audit.jsonl',
+        'events'   => ['*'],  // Log all event types, or specify: ['authentication', 'authorization']
+    ],
+];
+```
+
+Environment variable overrides:
+
+| Variable         | Overrides        |
+| ---------------- | ---------------- |
+| `AUDIT_LOG_PATH` | `audit.log_path` |
+
+## Events and Outcomes
+
+### AuditEvent
+
+```php
+enum AuditEvent: string
+{
+    case Authentication     = 'authentication';
+    case Authorization      = 'authorization';
+    case DataAccess         = 'data_access';
+    case DataModification   = 'data_modification';
+    case ConfigurationChange = 'configuration_change';
+    case SecurityEvent      = 'security_event';
+    case SystemEvent        = 'system_event';
+}
+```
+
+### AuditOutcome
+
+```php
+enum AuditOutcome: string
+{
+    case Success = 'success';
+    case Failure = 'failure';
+    case Denied  = 'denied';
+    case Error   = 'error';
+}
+```
+
+## Usage
+
+### Basic Logging
+
+```php
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditOutcome;
+
+$auditLogger->log(
+    event: AuditEvent::Authentication,
+    outcome: AuditOutcome::Success,
+    actor: 'user:42',
+    action: 'login',
+    resource: 'session',
+    metadata: ['ip' => '192.168.1.1', 'method' => 'password'],
+);
+```
+
+### Common Patterns
+
+**Authentication events:**
+
+```php
+// Successful login
+$auditLogger->log(
+    event: AuditEvent::Authentication,
+    outcome: AuditOutcome::Success,
+    actor: "user:{$userId}",
+    action: 'login',
+    resource: 'session',
+);
+
+// Failed login attempt
+$auditLogger->log(
+    event: AuditEvent::Authentication,
+    outcome: AuditOutcome::Failure,
+    actor: "email:{$email}",
+    action: 'login',
+    resource: 'session',
+    metadata: ['reason' => 'invalid_credentials'],
+);
+```
+
+**Authorization events:**
+
+```php
+// Access denied
+$auditLogger->log(
+    event: AuditEvent::Authorization,
+    outcome: AuditOutcome::Denied,
+    actor: "user:{$userId}",
+    action: 'view',
+    resource: "document:{$docId}",
+    metadata: ['required_role' => 'admin'],
+);
+```
+
+**Data access events:**
+
+```php
+// Sensitive data accessed
+$auditLogger->log(
+    event: AuditEvent::DataAccess,
+    outcome: AuditOutcome::Success,
+    actor: "user:{$userId}",
+    action: 'export',
+    resource: 'patient_records',
+    metadata: ['record_count' => 150, 'format' => 'csv'],
+);
+```
+
+## HMAC Chain (Tamper Evidence)
+
+Each audit entry includes an HMAC computed over all its fields plus the previous entry's HMAC. This creates a chain where modifying or deleting any entry invalidates all subsequent entries.
+
+### How It Works
+
+1. **Seed**: The chain starts with a seed HMAC: `Hmac::computeHex('PULSAR_AUDIT_SEED', auditKey)`
+2. **Entry HMAC**: Each entry's HMAC covers: `id | event | outcome | actor | action | resource | timestamp | metadata_json | previousHmac`
+3. **Chain advancement**: After writing an entry, its HMAC becomes the `previousHmac` for the next entry
+
+### Key Derivation
+
+The audit key is derived from the master key using libsodium's KDF:
+
+```
+MasterKey (PULSAR_MASTER_KEY env)
+  └── deriveSubKey(subKeyId: 2, context: 'audit___')
+        └── auditKey (32 bytes)
+```
+
+### Verification
+
+Each entry can independently verify its own HMAC given the audit key and the previous entry's HMAC:
+
+```php
+$entry = AuditEntry::create(
+    event: AuditEvent::Authentication,
+    outcome: AuditOutcome::Success,
+    actor: 'user:42',
+    action: 'login',
+    resource: 'session',
+    metadata: [],
+    previousHmac: $previousHmac,
+    auditKey: $auditKey,
+);
+
+$valid = $entry->verify($auditKey);  // true
+```
+
+### Chain Verification
+
+To verify the entire audit log, replay entries in order:
+
+1. Compute the seed HMAC
+2. For each entry, verify its HMAC against the expected `previousHmac`
+3. If any entry fails, the chain is broken at that point — indicating tampering
+
+## AuditEntry
+
+Immutable value object representing a single audit log entry.
+
+### Fields
+
+| Field          | Type           | Description                              |
+| -------------- | -------------- | ---------------------------------------- |
+| `id`           | `string`       | UUIDv4 identifier                        |
+| `event`        | `AuditEvent`   | Category of the event                    |
+| `outcome`      | `AuditOutcome` | Result of the action                     |
+| `actor`        | `string`       | Who performed the action (e.g., `user:42`) |
+| `action`       | `string`       | What was done (e.g., `login`, `export`)  |
+| `resource`     | `string`       | What was acted upon (e.g., `session`)    |
+| `timestamp`    | `string`       | ISO 8601 with microseconds              |
+| `metadata`     | `array`        | Additional context (key-value pairs)     |
+| `hmac`         | `string`       | HMAC-BLAKE2b hex covering all fields     |
+| `previousHmac` | `string`       | Previous entry's HMAC (chain link)       |
+
+### Serialization
+
+```php
+$array = $entry->toArray();
+// [
+//     'id'            => 'a1b2c3d4-...',
+//     'event'         => 'authentication',
+//     'outcome'       => 'success',
+//     'actor'         => 'user:42',
+//     'action'        => 'login',
+//     'resource'      => 'session',
+//     'timestamp'     => '2026-02-03T12:00:00.123456+00:00',
+//     'metadata'      => ['ip' => '192.168.1.1'],
+//     'hmac'          => '5a3f...',
+//     'previous_hmac' => 'b7e2...',
+// ]
+```
+
+## AuditFileSink
+
+Append-only file sink writing JSON Lines format with exclusive locking.
+
+### Behavior
+
+- Creates the target directory with `0750` permissions if it does not exist
+- Each entry is written as a single JSON line followed by a newline
+- Uses `LOCK_EX` for atomic writes (safe for single-process deployments)
+- Throws `SecurityException::auditWriteFailed()` on write failure
+
+### File Format
+
+Each line is a self-contained JSON object:
+
+```jsonl
+{"id":"a1b2...","event":"authentication","outcome":"success","actor":"user:42","action":"login","resource":"session","timestamp":"2026-02-03T12:00:00.123456+00:00","metadata":{"ip":"192.168.1.1"},"hmac":"5a3f...","previous_hmac":"b7e2..."}
+{"id":"c3d4...","event":"data_access","outcome":"success","actor":"user:42","action":"view","resource":"report:7","timestamp":"2026-02-03T12:00:01.234567+00:00","metadata":{},"hmac":"9f1a...","previous_hmac":"5a3f..."}
+```
+
+## AuditLogger
+
+Orchestrates audit entry creation, HMAC chain management, and sink writing.
+
+### Constructor
+
+```php
+$auditLogger = new AuditLogger(
+    sink: $auditFileSink,
+    auditKey: $auditKey,    // 32-byte derived key
+);
+```
+
+### Lifecycle
+
+1. On construction, computes the seed HMAC: `Hmac::computeHex('PULSAR_AUDIT_SEED', auditKey)`
+2. On each `log()` call:
+   - Creates an `AuditEntry` with the current `previousHmac`
+   - Writes the entry to the sink
+   - Updates `previousHmac` to the new entry's HMAC
+3. The chain is maintained in memory for the lifetime of the `AuditLogger` instance
+
+## Kernel Registration
+
+When `PULSAR_MASTER_KEY` is set, the kernel automatically:
+
+1. Loads the master key via `MasterKey::fromEnvironment()`
+2. Derives the audit subkey: `masterKey->deriveSubKey(2, 'audit___')`
+3. Creates `AuditFileSink` with the configured log path
+4. Creates `AuditLogger` with the sink and derived key
+5. Registers `AuditLogger` in the container
+
+If `PULSAR_MASTER_KEY` is not set, `AuditLogger` is not registered. Application code should check container availability before using it.
+
+## Security Considerations
+
+- **Key protection**: The `PULSAR_MASTER_KEY` must be kept secret. If compromised, an attacker could forge valid audit entries.
+- **Append-only storage**: Use filesystem permissions and/or immutable storage to prevent direct file modification.
+- **Chain gaps**: If the application restarts, the HMAC chain restarts from the seed. For continuous chain verification across restarts, persist the last HMAC.
+- **Clock integrity**: Timestamps use the system clock. Use NTP to ensure accurate, monotonic timestamps.
+- **Distributed deployments**: `AuditFileSink` uses `LOCK_EX` for single-process safety. For multi-process or distributed deployments, implement a custom `AuditSinkInterface` backed by a database or message queue.

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -39,19 +39,19 @@ return [
 
 Environment variable overrides:
 
-| Variable              | Overrides                   |
-| --------------------- | --------------------------- |
-| `SESSION_COOKIE_NAME` | `session.cookie_name`       |
+| Variable              | Overrides             |
+| --------------------- | --------------------- |
+| `SESSION_COOKIE_NAME` | `session.cookie_name` |
 
 ### Config DTOs
 
-| Class                    | Responsibility                       |
-| ------------------------ | ------------------------------------ |
-| `SecurityConfig`         | Top-level; composes sub-configs      |
-| `SessionConfig`          | Session cookie and lifetime settings |
-| `CsrfConfig`             | CSRF toggle, token length, names     |
-| `SecurityHeadersConfig`  | Header key-value pairs               |
-| `RateLimitConfig`        | Rate limit window and max attempts   |
+| Class                   | Responsibility                       |
+| ----------------------- | ------------------------------------ |
+| `SecurityConfig`        | Top-level; composes sub-configs      |
+| `SessionConfig`         | Session cookie and lifetime settings |
+| `CsrfConfig`            | CSRF toggle, token length, names     |
+| `SecurityHeadersConfig` | Header key-value pairs               |
+| `RateLimitConfig`       | Rate limit window and max attempts   |
 
 All DTOs are `readonly` classes with `fromArray()` factory methods, following the same pattern as `AppConfig` and `ObservabilityConfig`.
 
@@ -131,12 +131,15 @@ $manager->rotate();                   // Invalidate old, generate new
 Automatically validates CSRF tokens on state-changing HTTP methods.
 
 **Safe methods** (pass through without validation):
+
 - `GET`, `HEAD`, `OPTIONS`
 
 **Validated methods** (require a valid CSRF token):
+
 - `POST`, `PUT`, `PATCH`, `DELETE`
 
 **Token extraction** (checked in order, first match wins):
+
 1. Request header (`X-CSRF-Token` by default)
 2. POST form field (`_csrf_token` by default)
 
@@ -164,8 +167,8 @@ Include the token as a hidden field:
 
 ```html
 <form method="POST" action="/submit">
-    <input type="hidden" name="_csrf_token" value="{{ csrfToken }}">
-    <!-- form fields -->
+  <input type="hidden" name="_csrf_token" value="{{ csrfToken }}" />
+  <!-- form fields -->
 </form>
 ```
 
@@ -175,12 +178,12 @@ Include the token in a request header:
 
 ```js
 fetch('/api/data', {
-    method: 'POST',
-    headers: {
-        'X-CSRF-Token': token,
-        'Content-Type': 'application/json',
-    },
-    body: JSON.stringify(data),
+  method: 'POST',
+  headers: {
+    'X-CSRF-Token': token,
+    'Content-Type': 'application/json',
+  },
+  body: JSON.stringify(data),
 });
 ```
 
@@ -196,11 +199,11 @@ $middleware = new SecurityHeadersMiddleware($headersConfig);
 
 Default headers from `config/security.php`:
 
-| Header                     | Value                                |
-| -------------------------- | ------------------------------------ |
-| `X-Content-Type-Options`   | `nosniff`                            |
-| `X-Frame-Options`          | `DENY`                               |
-| `Referrer-Policy`          | `strict-origin-when-cross-origin`    |
+| Header                   | Value                             |
+| ------------------------ | --------------------------------- |
+| `X-Content-Type-Options` | `nosniff`                         |
+| `X-Frame-Options`        | `DENY`                            |
+| `Referrer-Policy`        | `strict-origin-when-cross-origin` |
 
 Additional recommended headers can be added via configuration:
 
@@ -301,29 +304,29 @@ boot() →
 
 `createSecurityServices()` registers:
 
-| Service                       | Container ID                          |
-| ----------------------------- | ------------------------------------- |
-| `Session`                     | `SessionInterface`                    |
-| `CsrfTokenManager`           | `CsrfTokenManagerInterface`           |
-| `CsrfMiddleware`             | `CsrfMiddleware::class`              |
-| `SecurityHeadersMiddleware`   | `SecurityHeadersMiddleware::class`    |
-| `MasterKey`                   | `MasterKey::class` (if key present)   |
-| `Encryptor`                   | `Encryptor::class` (if key present)   |
-| `AuditLogger`                 | `AuditLogger::class` (if key present) |
+| Service                     | Container ID                          |
+| --------------------------- | ------------------------------------- |
+| `Session`                   | `SessionInterface`                    |
+| `CsrfTokenManager`          | `CsrfTokenManagerInterface`           |
+| `CsrfMiddleware`            | `CsrfMiddleware::class`               |
+| `SecurityHeadersMiddleware` | `SecurityHeadersMiddleware::class`    |
+| `MasterKey`                 | `MasterKey::class` (if key present)   |
+| `Encryptor`                 | `Encryptor::class` (if key present)   |
+| `AuditLogger`               | `AuditLogger::class` (if key present) |
 
 ## SecurityException
 
 All security errors throw `Pulsar\Security\Exception\SecurityException` with descriptive factory methods:
 
-| Factory Method              | When                                       |
-| --------------------------- | ------------------------------------------ |
-| `csrfTokenMissing()`        | State-changing request without CSRF token   |
-| `csrfTokenInvalid()`        | CSRF token fails validation                 |
-| `sessionNotStarted()`       | Session operation before `start()`          |
-| `sessionStartFailed()`      | PHP `session_start()` returns false         |
-| `masterKeyMissing()`        | `PULSAR_MASTER_KEY` env var not set         |
-| `masterKeyInvalid()`        | Master key not exactly 32 bytes             |
-| `encryptionFailed()`        | `sodium_crypto_secretbox` fails             |
-| `decryptionFailed()`        | Ciphertext tampered or wrong key            |
-| `auditIntegrityViolation()` | Audit entry HMAC verification fails         |
-| `auditWriteFailed()`        | Audit file sink cannot write                |
+| Factory Method              | When                                      |
+| --------------------------- | ----------------------------------------- |
+| `csrfTokenMissing()`        | State-changing request without CSRF token |
+| `csrfTokenInvalid()`        | CSRF token fails validation               |
+| `sessionNotStarted()`       | Session operation before `start()`        |
+| `sessionStartFailed()`      | PHP `session_start()` returns false       |
+| `masterKeyMissing()`        | `PULSAR_MASTER_KEY` env var not set       |
+| `masterKeyInvalid()`        | Master key not exactly 32 bytes           |
+| `encryptionFailed()`        | `sodium_crypto_secretbox` fails           |
+| `decryptionFailed()`        | Ciphertext tampered or wrong key          |
+| `auditIntegrityViolation()` | Audit entry HMAC verification fails       |
+| `auditWriteFailed()`        | Audit file sink cannot write              |

--- a/docs/SECURITY_BASELINE.md
+++ b/docs/SECURITY_BASELINE.md
@@ -1,0 +1,329 @@
+# Security Baseline
+
+Pulsar ships secure defaults for session management, CSRF protection, security headers, cryptographic primitives, and audit logging. All security features are configured via the `SecurityConfig` DTO loaded from `config/security.php`.
+
+## Configuration
+
+### SecurityConfig
+
+Top-level DTO composing all security sub-configs:
+
+```php
+// config/security.php
+return [
+    'session' => [
+        'cookie_name'   => 'PULSAR_SESSION',
+        'lifetime'      => 7200,
+        'cookie_httponly'=> true,
+        'cookie_secure'  => true,
+        'cookie_samesite'=> 'Lax',
+        'regenerate_on_privilege_change' => true,
+    ],
+    'csrf' => [
+        'enabled'         => true,
+        'token_length'    => 32,
+        'header_name'     => 'X-CSRF-Token',
+        'form_field_name' => '_csrf_token',
+    ],
+    'headers' => [
+        'X-Content-Type-Options' => 'nosniff',
+        'X-Frame-Options'        => 'DENY',
+        'Referrer-Policy'        => 'strict-origin-when-cross-origin',
+    ],
+    'rate_limit' => [
+        'max_attempts'   => 60,
+        'window_seconds' => 60,
+    ],
+];
+```
+
+Environment variable overrides:
+
+| Variable              | Overrides                   |
+| --------------------- | --------------------------- |
+| `SESSION_COOKIE_NAME` | `session.cookie_name`       |
+
+### Config DTOs
+
+| Class                    | Responsibility                       |
+| ------------------------ | ------------------------------------ |
+| `SecurityConfig`         | Top-level; composes sub-configs      |
+| `SessionConfig`          | Session cookie and lifetime settings |
+| `CsrfConfig`             | CSRF toggle, token length, names     |
+| `SecurityHeadersConfig`  | Header key-value pairs               |
+| `RateLimitConfig`        | Rate limit window and max attempts   |
+
+All DTOs are `readonly` classes with `fromArray()` factory methods, following the same pattern as `AppConfig` and `ObservabilityConfig`.
+
+## Session Management
+
+### SessionInterface
+
+```php
+interface SessionInterface
+{
+    public function start(): void;
+    public function isStarted(): bool;
+    public function get(string $key, mixed $default = null): mixed;
+    public function set(string $key, mixed $value): void;
+    public function has(string $key): bool;
+    public function remove(string $key): void;
+    public function id(): string;
+    public function regenerate(bool $deleteOldSession = true): void;
+    public function destroy(): void;
+    public function all(): array;
+}
+```
+
+### Session
+
+`Pulsar\Security\Session\Session` wraps PHP's native session functions with security settings from `SessionConfig`:
+
+- **HttpOnly cookies** — prevents JavaScript access to session cookies
+- **Secure cookies** — cookies only sent over HTTPS
+- **SameSite** — mitigates cross-site request forgery via cookie policy
+- **Strict mode** — rejects uninitialized session IDs
+- **Cookies only** — prevents session ID leakage via URL parameters
+
+```php
+$session = new Session($sessionConfig);
+$session->start();
+$session->set('user_id', 42);
+$userId = $session->get('user_id');  // 42
+$session->regenerate();              // New session ID, same data
+$session->destroy();                 // Clears all data
+```
+
+Call `regenerate()` after privilege escalation (login, role change) to prevent session fixation attacks.
+
+## CSRF Protection
+
+### Synchronizer Token Pattern
+
+Pulsar uses the synchronizer token pattern: a random token is generated and stored server-side in the session. State-changing requests must include the token for validation.
+
+### CsrfTokenManagerInterface
+
+```php
+interface CsrfTokenManagerInterface
+{
+    public function generate(): string;
+    public function getToken(): string;
+    public function validate(string $submittedToken): bool;
+    public function rotate(): string;
+}
+```
+
+### CsrfTokenManager
+
+Generates hex-encoded tokens via `random_bytes()`, stores them in the session, and validates using constant-time `hash_equals()` comparison.
+
+```php
+$manager = new CsrfTokenManager($session, $csrfConfig);
+
+$token = $manager->getToken();       // Get current or generate new
+$valid = $manager->validate($token);  // true
+$manager->rotate();                   // Invalidate old, generate new
+```
+
+### CsrfMiddleware
+
+Automatically validates CSRF tokens on state-changing HTTP methods.
+
+**Safe methods** (pass through without validation):
+- `GET`, `HEAD`, `OPTIONS`
+
+**Validated methods** (require a valid CSRF token):
+- `POST`, `PUT`, `PATCH`, `DELETE`
+
+**Token extraction** (checked in order, first match wins):
+1. Request header (`X-CSRF-Token` by default)
+2. POST form field (`_csrf_token` by default)
+
+**On failure**, the middleware returns a 403 JSON response:
+
+```json
+{
+  "error": "Forbidden",
+  "message": "CSRF token missing."
+}
+```
+
+```json
+{
+  "error": "Forbidden",
+  "message": "CSRF token invalid."
+}
+```
+
+**Disabling CSRF**: Set `csrf.enabled` to `false` in `config/security.php`. The middleware will pass all requests through without validation.
+
+### HTML Form Usage
+
+Include the token as a hidden field:
+
+```html
+<form method="POST" action="/submit">
+    <input type="hidden" name="_csrf_token" value="{{ csrfToken }}">
+    <!-- form fields -->
+</form>
+```
+
+### AJAX Usage
+
+Include the token in a request header:
+
+```js
+fetch('/api/data', {
+    method: 'POST',
+    headers: {
+        'X-CSRF-Token': token,
+        'Content-Type': 'application/json',
+    },
+    body: JSON.stringify(data),
+});
+```
+
+## Security Headers
+
+### SecurityHeadersMiddleware
+
+Applies configured HTTP security headers to every response. Add this middleware globally to ensure all responses include security headers, including error responses.
+
+```php
+$middleware = new SecurityHeadersMiddleware($headersConfig);
+```
+
+Default headers from `config/security.php`:
+
+| Header                     | Value                                |
+| -------------------------- | ------------------------------------ |
+| `X-Content-Type-Options`   | `nosniff`                            |
+| `X-Frame-Options`          | `DENY`                               |
+| `Referrer-Policy`          | `strict-origin-when-cross-origin`    |
+
+Additional recommended headers can be added via configuration:
+
+```php
+'headers' => [
+    'X-Content-Type-Options'            => 'nosniff',
+    'X-Frame-Options'                   => 'DENY',
+    'Referrer-Policy'                   => 'strict-origin-when-cross-origin',
+    'Strict-Transport-Security'         => 'max-age=31536000; includeSubDomains',
+    'Content-Security-Policy'           => "default-src 'self'",
+    'Permissions-Policy'                => 'camera=(), microphone=(), geolocation=()',
+],
+```
+
+### Pipeline Order
+
+Place `SecurityHeadersMiddleware` as the **outermost** middleware so headers are applied even when inner middleware short-circuits (e.g., CSRF returning 403):
+
+```
+Request → SecurityHeaders → CSRF → RateLimit → Handler
+                                                  ↓
+Response ← SecurityHeaders ← CSRF ← RateLimit ← Response
+```
+
+## Cryptographic Primitives
+
+All crypto operations use **libsodium** (bundled with PHP 7.2+). No third-party dependencies.
+
+### Hmac
+
+Static utility for BLAKE2b keyed hashing via `sodium_crypto_generichash`:
+
+```php
+use Pulsar\Security\Crypto\Hmac;
+
+$hex  = Hmac::computeHex('message', $key);   // 64-char hex string
+$raw  = Hmac::compute('message', $key);       // 32-byte binary
+
+$valid = Hmac::verifyHex($hex, 'message', $key);  // true
+$valid = Hmac::verify($raw, 'message', $key);      // true
+```
+
+Key must be at least `SODIUM_CRYPTO_GENERICHASH_KEYBYTES_MIN` (16 bytes).
+
+### MasterKey
+
+Loads a 32-byte master key from the `PULSAR_MASTER_KEY` environment variable (hex-encoded, 64 characters). Derives purpose-specific subkeys via `sodium_crypto_kdf_derive_from_key`:
+
+```php
+use Pulsar\Security\Crypto\MasterKey;
+
+$masterKey = MasterKey::fromEnvironment();
+$subKey    = $masterKey->deriveSubKey(subKeyId: 1, context: 'encrypt_');
+```
+
+- **subKeyId**: integer identifier for the derived key (different IDs produce different keys)
+- **context**: 8-byte context string (padded or truncated automatically)
+- `__debugInfo()` returns `[REDACTED]` to prevent accidental key leakage in logs/dumps
+
+### Encryptor
+
+Authenticated encryption via `sodium_crypto_secretbox` (XSalsa20 stream cipher + Poly1305 MAC):
+
+```php
+use Pulsar\Security\Crypto\Encryptor;
+
+$encryptor  = new Encryptor($masterKey);
+$ciphertext = $encryptor->encrypt('sensitive data');  // base64(nonce || ciphertext)
+$plaintext  = $encryptor->decrypt($ciphertext);       // 'sensitive data'
+```
+
+- Fresh 24-byte random nonce per encryption
+- Ciphertext format: `base64_encode(nonce || ciphertext+MAC)`
+- Tamper detection: any modification to the ciphertext causes decryption to fail with `SecurityException`
+- Uses derived subkey (id=1, context=`encrypt_`)
+
+### Key Management
+
+1. Generate a master key: `php -r "echo bin2hex(random_bytes(32));"`
+2. Set the environment variable: `PULSAR_MASTER_KEY=<64-char-hex>`
+3. The kernel automatically registers `MasterKey`, `Encryptor`, and `AuditLogger` when the key is present
+4. If `PULSAR_MASTER_KEY` is not set, crypto-dependent services are not registered; session, CSRF, and security headers still function
+
+## Kernel Integration
+
+The kernel boot pipeline registers security services automatically:
+
+```
+boot() →
+  1. ConfigManager::load() (app + observability + security)
+  2. registerConfigServices()
+  3. createLogger()
+  4. createExceptionHandler()
+  5. createSecurityServices()      ← security layer
+  6. Extension register phase
+  7. Extension boot phase
+```
+
+`createSecurityServices()` registers:
+
+| Service                       | Container ID                          |
+| ----------------------------- | ------------------------------------- |
+| `Session`                     | `SessionInterface`                    |
+| `CsrfTokenManager`           | `CsrfTokenManagerInterface`           |
+| `CsrfMiddleware`             | `CsrfMiddleware::class`              |
+| `SecurityHeadersMiddleware`   | `SecurityHeadersMiddleware::class`    |
+| `MasterKey`                   | `MasterKey::class` (if key present)   |
+| `Encryptor`                   | `Encryptor::class` (if key present)   |
+| `AuditLogger`                 | `AuditLogger::class` (if key present) |
+
+## SecurityException
+
+All security errors throw `Pulsar\Security\Exception\SecurityException` with descriptive factory methods:
+
+| Factory Method              | When                                       |
+| --------------------------- | ------------------------------------------ |
+| `csrfTokenMissing()`        | State-changing request without CSRF token   |
+| `csrfTokenInvalid()`        | CSRF token fails validation                 |
+| `sessionNotStarted()`       | Session operation before `start()`          |
+| `sessionStartFailed()`      | PHP `session_start()` returns false         |
+| `masterKeyMissing()`        | `PULSAR_MASTER_KEY` env var not set         |
+| `masterKeyInvalid()`        | Master key not exactly 32 bytes             |
+| `encryptionFailed()`        | `sodium_crypto_secretbox` fails             |
+| `decryptionFailed()`        | Ciphertext tampered or wrong key            |
+| `auditIntegrityViolation()` | Audit entry HMAC verification fails         |
+| `auditWriteFailed()`        | Audit file sink cannot write                |

--- a/src/Config/AuditConfig.php
+++ b/src/Config/AuditConfig.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Typed configuration DTO for audit logging settings.
+ *
+ * Maps from the `audit` key of `config/observability.php`.
+ */
+readonly class AuditConfig
+{
+    /**
+     * @param bool              $enabled    Whether audit logging is enabled
+     * @param string            $logPath    File path for audit log output
+     * @param list<string>      $events     Which event types to audit
+     */
+    public function __construct(
+        public bool $enabled = true,
+        public string $logPath = 'var/logs/audit.jsonl',
+        public array $events = [],
+    ) {}
+
+    /**
+     * Build from the raw audit config array.
+     *
+     * @param array<string, mixed> $data Raw `audit` sub-array from config/observability.php
+     */
+    public static function fromArray(array $data, Environment $environment): self
+    {
+        $enabled = (bool) ($data['enabled'] ?? true);
+
+        $logPath = $environment->get('AUDIT_LOG_PATH')
+            ?? (string) ($data['log_path'] ?? 'var/logs/audit.jsonl'); // @phpstan-ignore cast.string
+
+        /** @var list<string> $events */
+        $events = $data['events'] ?? [];
+
+        return new self(
+            enabled: $enabled,
+            logPath: $logPath,
+            events: $events,
+        );
+    }
+}

--- a/src/Config/ConfigManager.php
+++ b/src/Config/ConfigManager.php
@@ -50,6 +50,11 @@ final class ConfigManager
         $observabilityData = $this->loadConfigFile('observability');
         $observabilityConfig = ObservabilityConfig::fromArray($observabilityData, $this->environment);
         $this->repository->set($observabilityConfig);
+
+        // Load security config
+        $securityData = $this->loadConfigFile('security');
+        $securityConfig = SecurityConfig::fromArray($securityData, $this->environment);
+        $this->repository->set($securityConfig);
     }
 
     /**

--- a/src/Config/CsrfConfig.php
+++ b/src/Config/CsrfConfig.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Typed configuration DTO for CSRF protection settings.
+ *
+ * Maps from the `csrf` key of `config/security.php`.
+ */
+readonly class CsrfConfig
+{
+    public function __construct(
+        public bool $enabled,
+        public int $tokenLength,
+        public string $headerName,
+        public string $formFieldName,
+    ) {}
+
+    /**
+     * Build from the raw CSRF config array.
+     *
+     * @param array<string, mixed> $data Raw `csrf` sub-array from config/security.php
+     */
+    public static function fromArray(array $data): self
+    {
+        $enabled = (bool) ($data['enabled'] ?? true);
+        $tokenLength = (int) ($data['token_length'] ?? 32); // @phpstan-ignore cast.int
+        $headerName = (string) ($data['header_name'] ?? 'X-CSRF-Token'); // @phpstan-ignore cast.string
+        $formFieldName = (string) ($data['form_field_name'] ?? '_csrf_token'); // @phpstan-ignore cast.string
+
+        return new self(
+            enabled: $enabled,
+            tokenLength: $tokenLength,
+            headerName: $headerName,
+            formFieldName: $formFieldName,
+        );
+    }
+}

--- a/src/Config/ObservabilityConfig.php
+++ b/src/Config/ObservabilityConfig.php
@@ -21,6 +21,7 @@ readonly class ObservabilityConfig
         public MetricsConfig $metrics = new MetricsConfig(),
         public TracingConfig $tracing = new TracingConfig(),
         public ErrorTrackingConfig $errorTracking = new ErrorTrackingConfig(),
+        public AuditConfig $audit = new AuditConfig(),
     ) {}
 
     /**
@@ -69,6 +70,11 @@ readonly class ObservabilityConfig
         $errorTrackingData = $data['error_tracking'] ?? [];
         $errorTrackingConfig = ErrorTrackingConfig::fromArray($errorTrackingData);
 
+        // Build audit config
+        /** @var array<string, mixed> $auditData */
+        $auditData = $data['audit'] ?? [];
+        $auditConfig = AuditConfig::fromArray($auditData, $environment);
+
         return new self(
             defaultLoggingChannel: $defaultChannel,
             loggingLevel: $level,
@@ -76,6 +82,7 @@ readonly class ObservabilityConfig
             metrics: $metricsConfig,
             tracing: $tracingConfig,
             errorTracking: $errorTrackingConfig,
+            audit: $auditConfig,
         );
     }
 }

--- a/src/Config/RateLimitConfig.php
+++ b/src/Config/RateLimitConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Typed configuration DTO for rate limiting settings.
+ *
+ * Maps from the `rate_limiting` key of `config/security.php`.
+ */
+readonly class RateLimitConfig
+{
+    public function __construct(
+        public bool $enabled,
+        public int $defaultLimit,
+        public int $defaultWindow,
+    ) {}
+
+    /**
+     * Build from the raw rate limit config array.
+     *
+     * @param array<string, mixed> $data Raw `rate_limiting` sub-array from config/security.php
+     */
+    public static function fromArray(array $data): self
+    {
+        $enabled = (bool) ($data['enabled'] ?? true);
+        $defaultLimit = (int) ($data['default_limit'] ?? 60); // @phpstan-ignore cast.int
+        $defaultWindow = (int) ($data['default_window'] ?? 60); // @phpstan-ignore cast.int
+
+        return new self(
+            enabled: $enabled,
+            defaultLimit: $defaultLimit,
+            defaultWindow: $defaultWindow,
+        );
+    }
+}

--- a/src/Config/SecurityConfig.php
+++ b/src/Config/SecurityConfig.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Top-level typed configuration DTO for `config/security.php`.
+ *
+ * Composes sub-config DTOs for session, CSRF, security headers, and rate limiting.
+ */
+readonly class SecurityConfig
+{
+    public function __construct(
+        public SessionConfig $session,
+        public CsrfConfig $csrf,
+        public SecurityHeadersConfig $headers,
+        public RateLimitConfig $rateLimit,
+    ) {}
+
+    /**
+     * Build from the raw security config array and environment.
+     *
+     * @param array<string, mixed> $data Raw array from config/security.php
+     */
+    public static function fromArray(array $data, Environment $environment): self
+    {
+        /** @var array<string, mixed> $sessionData */
+        $sessionData = $data['session'] ?? [];
+
+        /** @var array<string, mixed> $csrfData */
+        $csrfData = $data['csrf'] ?? [];
+
+        /** @var array<string, mixed> $headersData */
+        $headersData = $data['headers'] ?? [];
+
+        /** @var array<string, mixed> $rateLimitData */
+        $rateLimitData = $data['rate_limiting'] ?? [];
+
+        return new self(
+            session: SessionConfig::fromArray($sessionData, $environment),
+            csrf: CsrfConfig::fromArray($csrfData),
+            headers: SecurityHeadersConfig::fromArray($headersData),
+            rateLimit: RateLimitConfig::fromArray($rateLimitData),
+        );
+    }
+}

--- a/src/Config/SecurityHeadersConfig.php
+++ b/src/Config/SecurityHeadersConfig.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Typed configuration DTO for security headers.
+ *
+ * Maps from the `headers` key of `config/security.php`.
+ */
+readonly class SecurityHeadersConfig
+{
+    /**
+     * @param array<string, string> $headers Header name => value pairs applied to every response
+     */
+    public function __construct(
+        public array $headers,
+    ) {}
+
+    /**
+     * Build from the raw security headers config array.
+     *
+     * @param array<string, mixed> $data Raw `headers` sub-array from config/security.php
+     */
+    public static function fromArray(array $data): self
+    {
+        /** @var array<string, string> $headers */
+        $headers = [];
+
+        foreach ($data as $name => $value) {
+            $headers[$name] = (string) $value; // @phpstan-ignore cast.string
+        }
+
+        return new self(headers: $headers);
+    }
+}

--- a/src/Config/SessionConfig.php
+++ b/src/Config/SessionConfig.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Config;
+
+/**
+ * Typed configuration DTO for session settings.
+ *
+ * Maps from the `session` key of `config/security.php`.
+ */
+readonly class SessionConfig
+{
+    public function __construct(
+        public string $cookieName,
+        public int $lifetime,
+        public bool $cookieHttpOnly,
+        public bool $cookieSecure,
+        public string $cookieSameSite,
+        public bool $regenerateOnPrivilegeChange,
+    ) {}
+
+    /**
+     * Build from the raw session config array.
+     *
+     * @param array<string, mixed> $data Raw `session` sub-array from config/security.php
+     */
+    public static function fromArray(array $data, Environment $environment): self
+    {
+        $cookieName = $environment->get('SESSION_COOKIE_NAME')
+            ?? (string) ($data['cookie_name'] ?? 'PULSAR_SESSION'); // @phpstan-ignore cast.string
+
+        $lifetime = (int) ($data['lifetime'] ?? 7200); // @phpstan-ignore cast.int
+
+        $cookieHttpOnly = (bool) ($data['cookie_httponly'] ?? true);
+        $cookieSecure = (bool) ($data['cookie_secure'] ?? true);
+
+        $cookieSameSite = (string) ($data['cookie_samesite'] ?? 'Strict'); // @phpstan-ignore cast.string
+
+        $regenerateOnPrivilegeChange = (bool) ($data['regenerate_on_privilege_change'] ?? true);
+
+        return new self(
+            cookieName: $cookieName,
+            lifetime: $lifetime,
+            cookieHttpOnly: $cookieHttpOnly,
+            cookieSecure: $cookieSecure,
+            cookieSameSite: $cookieSameSite,
+            regenerateOnPrivilegeChange: $regenerateOnPrivilegeChange,
+        );
+    }
+}

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -10,17 +10,21 @@ use function is_string;
 
 use Psr\Log\LoggerInterface;
 use Pulsar\Config\AppConfig;
+use Pulsar\Config\AuditConfig;
 use Pulsar\Config\ConfigManager;
 use Pulsar\Config\ConfigRepository;
+use Pulsar\Config\CsrfConfig;
 use Pulsar\Config\Environment;
 use Pulsar\Config\ObservabilityConfig;
+use Pulsar\Config\SecurityConfig;
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Config\SessionConfig;
 use Pulsar\Container\Container;
 use Pulsar\Container\ContainerInterface;
 use Pulsar\ErrorHandling\DevelopmentRenderer;
 use Pulsar\ErrorHandling\ExceptionHandler;
 use Pulsar\ErrorHandling\ProductionRenderer;
 use Pulsar\Extensibility\ExtensionBootstrap;
-use Pulsar\Http\Method;
 use Pulsar\Http\Middleware\MetricsMiddleware;
 use Pulsar\Http\Middleware\MiddlewareInterface;
 use Pulsar\Http\Middleware\MiddlewarePipeline;
@@ -38,6 +42,18 @@ use Pulsar\Observability\Metrics\PrometheusExporter;
 use Pulsar\Observability\Tracing\InMemorySpanCollector;
 use Pulsar\Routing\MatchedRoute;
 use Pulsar\Routing\Router;
+use Pulsar\Security\Audit\AuditFileSink;
+use Pulsar\Security\Audit\AuditLogger;
+use Pulsar\Security\Audit\AuditSinkInterface;
+use Pulsar\Security\Crypto\Encryptor;
+use Pulsar\Security\Crypto\MasterKey;
+use Pulsar\Security\Csrf\CsrfMiddleware;
+use Pulsar\Security\Csrf\CsrfTokenManager;
+use Pulsar\Security\Csrf\CsrfTokenManagerInterface;
+use Pulsar\Security\Exception\SecurityException;
+use Pulsar\Security\Middleware\SecurityHeadersMiddleware;
+use Pulsar\Security\Session\Session;
+use Pulsar\Security\Session\SessionInterface;
 use RuntimeException;
 
 use function sprintf;
@@ -51,7 +67,7 @@ use Throwable;
  * managing the lifecycle, and orchestrating the request/response cycle.
  *
  * Boot pipeline order:
- * Config -> Logger -> Tracer -> Metrics -> ErrorTracker -> ExceptionHandler -> DiagnosticsRoute -> Extensions
+ * Config -> Logger -> Tracer -> Metrics -> ErrorTracker -> ExceptionHandler -> SecurityServices -> DiagnosticsRoute -> Extensions
  */
 final class Kernel
 {
@@ -100,9 +116,10 @@ final class Kernel
      * 4. Metrics creation (MetricsMiddleware as inner global middleware)
      * 5. Error tracker creation
      * 6. Exception handler creation
-     * 7. Diagnostics route registration (debug mode only)
-     * 8. Extension register phase
-     * 9. Extension boot phase
+     * 7. Security services creation
+     * 8. Diagnostics route registration (debug mode only)
+     * 9. Extension register phase
+     * 10. Extension boot phase
      */
     public function boot(): void
     {
@@ -119,6 +136,7 @@ final class Kernel
             $this->createMetrics();
             $this->createErrorTracker();
             $this->createExceptionHandler();
+            $this->createSecurityServices();
             $this->registerDiagnosticsRoute();
         }
 
@@ -349,6 +367,14 @@ final class Kernel
         /** @var ObservabilityConfig $observabilityConfig */
         $observabilityConfig = $repository->get(ObservabilityConfig::class);
         $this->container->instance(ObservabilityConfig::class, $observabilityConfig);
+        $this->container->instance(AuditConfig::class, $observabilityConfig->audit);
+
+        /** @var SecurityConfig $securityConfig */
+        $securityConfig = $repository->get(SecurityConfig::class);
+        $this->container->instance(SecurityConfig::class, $securityConfig);
+        $this->container->instance(SessionConfig::class, $securityConfig->session);
+        $this->container->instance(CsrfConfig::class, $securityConfig->csrf);
+        $this->container->instance(SecurityHeadersConfig::class, $securityConfig->headers);
     }
 
     /**
@@ -488,6 +514,70 @@ final class Kernel
         /** @var SensitiveDataScrubber|null $scrubber */
         $this->exceptionHandler = new ExceptionHandler($renderer, $logger, $aggregator, $scrubber);
         $this->container->instance(ExceptionHandler::class, $this->exceptionHandler);
+    }
+
+    /**
+     * Create security services and register in the container.
+     *
+     * Registers: Session, CsrfTokenManager, CsrfMiddleware,
+     * SecurityHeadersMiddleware. If PULSAR_MASTER_KEY is set,
+     * also registers MasterKey, Encryptor, and AuditLogger.
+     */
+    private function createSecurityServices(): void
+    {
+        /** @var ConfigManager $configManager */
+        $configManager = $this->configManager;
+        $environment = $configManager->environment();
+
+        /** @var SecurityConfig $securityConfig */
+        $securityConfig = $configManager->repository()->get(SecurityConfig::class);
+
+        // Session
+        $session = new Session($securityConfig->session);
+        $this->container->instance(Session::class, $session);
+        $this->container->instance(SessionInterface::class, $session);
+
+        // CSRF
+        $csrfTokenManager = new CsrfTokenManager($session, $securityConfig->csrf);
+        $this->container->instance(CsrfTokenManager::class, $csrfTokenManager);
+        $this->container->instance(CsrfTokenManagerInterface::class, $csrfTokenManager);
+
+        $csrfMiddleware = new CsrfMiddleware($csrfTokenManager, $securityConfig->csrf);
+        $this->container->instance(CsrfMiddleware::class, $csrfMiddleware);
+
+        // Security Headers
+        $headersMiddleware = new SecurityHeadersMiddleware($securityConfig->headers);
+        $this->container->instance(SecurityHeadersMiddleware::class, $headersMiddleware);
+
+        // Crypto + Audit (only if master key is available)
+        $masterKeyHex = $environment->get('PULSAR_MASTER_KEY');
+
+        if ($masterKeyHex !== null && $masterKeyHex !== '') {
+            try {
+                $masterKey = MasterKey::fromHex($masterKeyHex);
+                $this->container->instance(MasterKey::class, $masterKey);
+
+                $encryptor = new Encryptor($masterKey);
+                $this->container->instance(Encryptor::class, $encryptor);
+
+                // Audit logger with HMAC chain
+                /** @var ObservabilityConfig $obsConfig */
+                $obsConfig = $configManager->repository()->get(ObservabilityConfig::class);
+
+                if ($obsConfig->audit->enabled) {
+                    $auditKey = $masterKey->deriveSubKey(2, 'audit___');
+                    $auditSink = new AuditFileSink($obsConfig->audit->logPath);
+                    $this->container->instance(AuditSinkInterface::class, $auditSink);
+                    $this->container->instance(AuditFileSink::class, $auditSink);
+
+                    $auditLogger = new AuditLogger($auditSink, $auditKey);
+                    $this->container->instance(AuditLogger::class, $auditLogger);
+                }
+            } catch (SecurityException) {
+                // Master key is invalid — skip crypto/audit registration.
+                // Session, CSRF, and headers still work without it.
+            }
+        }
     }
 
     /**

--- a/src/Core/Version.php
+++ b/src/Core/Version.php
@@ -10,7 +10,7 @@ namespace Pulsar\Core;
 final class Version
 {
     public const int MAJOR = 0;
-    public const int MINOR = 4;
+    public const int MINOR = 6;
     public const int PATCH = 0;
     public const string PRERELEASE = '';
 

--- a/src/Security/Audit/AuditEntry.php
+++ b/src/Security/Audit/AuditEntry.php
@@ -1,0 +1,157 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Audit;
+
+use DateTimeImmutable;
+
+use function hash_equals;
+use function json_encode;
+
+use Pulsar\Security\Crypto\Hmac;
+
+/**
+ * Immutable audit log entry with HMAC chain for tamper evidence.
+ *
+ * Each entry's HMAC covers all fields plus the previous entry's HMAC,
+ * creating a chain where modifying or deleting any entry invalidates all
+ * subsequent HMACs.
+ */
+readonly class AuditEntry
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $id,
+        public AuditEvent $event,
+        public AuditOutcome $outcome,
+        public string $actor,
+        public string $action,
+        public string $resource,
+        public DateTimeImmutable $timestamp,
+        public array $metadata,
+        public string $previousHmac,
+        public string $hmac,
+    ) {}
+
+    /**
+     * Create a new audit entry and compute its HMAC.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public static function create(
+        string $id,
+        AuditEvent $event,
+        AuditOutcome $outcome,
+        string $actor,
+        string $action,
+        string $resource,
+        DateTimeImmutable $timestamp,
+        array $metadata,
+        string $previousHmac,
+        string $auditKey,
+    ): self {
+        $metadataJson = json_encode($metadata, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $message = self::buildMessage(
+            $id,
+            $event->value,
+            $outcome->value,
+            $actor,
+            $action,
+            $resource,
+            $timestamp->format('Y-m-d\TH:i:s.uP'),
+            $metadataJson,
+            $previousHmac,
+        );
+
+        $hmac = Hmac::computeHex($message, $auditKey);
+
+        return new self(
+            id: $id,
+            event: $event,
+            outcome: $outcome,
+            actor: $actor,
+            action: $action,
+            resource: $resource,
+            timestamp: $timestamp,
+            metadata: $metadata,
+            previousHmac: $previousHmac,
+            hmac: $hmac,
+        );
+    }
+
+    /**
+     * Verify this entry's HMAC is valid for the given audit key.
+     */
+    public function verify(string $auditKey): bool
+    {
+        $metadataJson = json_encode($this->metadata, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $message = self::buildMessage(
+            $this->id,
+            $this->event->value,
+            $this->outcome->value,
+            $this->actor,
+            $this->action,
+            $this->resource,
+            $this->timestamp->format('Y-m-d\TH:i:s.uP'),
+            $metadataJson,
+            $this->previousHmac,
+        );
+
+        $expected = Hmac::computeHex($message, $auditKey);
+
+        return hash_equals($expected, $this->hmac);
+    }
+
+    /**
+     * Convert to array for serialization.
+     *
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'id' => $this->id,
+            'event' => $this->event->value,
+            'outcome' => $this->outcome->value,
+            'actor' => $this->actor,
+            'action' => $this->action,
+            'resource' => $this->resource,
+            'timestamp' => $this->timestamp->format('Y-m-d\TH:i:s.uP'),
+            'metadata' => $this->metadata,
+            'previous_hmac' => $this->previousHmac,
+            'hmac' => $this->hmac,
+        ];
+    }
+
+    /**
+     * Build the message string for HMAC computation.
+     */
+    private static function buildMessage(
+        string $id,
+        string $event,
+        string $outcome,
+        string $actor,
+        string $action,
+        string $resource,
+        string $timestamp,
+        string $metadataJson,
+        string $previousHmac,
+    ): string {
+        return implode('|', [
+            $id,
+            $event,
+            $outcome,
+            $actor,
+            $action,
+            $resource,
+            $timestamp,
+            $metadataJson,
+            $previousHmac,
+        ]);
+    }
+}

--- a/src/Security/Audit/AuditEvent.php
+++ b/src/Security/Audit/AuditEvent.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Audit;
+
+/**
+ * Types of auditable security events.
+ */
+enum AuditEvent: string
+{
+    case Authentication = 'authentication';
+    case Authorization = 'authorization';
+    case DataAccess = 'data_access';
+    case DataModification = 'data_modification';
+    case ConfigurationChange = 'configuration_change';
+    case SecurityEvent = 'security_event';
+    case SystemEvent = 'system_event';
+}

--- a/src/Security/Audit/AuditFileSink.php
+++ b/src/Security/Audit/AuditFileSink.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Audit;
+
+use function dirname;
+
+use const FILE_APPEND;
+
+use function file_put_contents;
+use function is_dir;
+use function json_encode;
+
+use const LOCK_EX;
+
+use function mkdir;
+
+use Pulsar\Security\Exception\SecurityException;
+
+use function sprintf;
+
+/**
+ * Append-only JSON Lines audit log file sink.
+ *
+ * Each entry is written as a single JSON line with `LOCK_EX` for
+ * concurrent write safety. The log directory is created with 0750
+ * permissions if it does not exist.
+ */
+final class AuditFileSink implements AuditSinkInterface
+{
+    /**
+     * Directory permissions for auto-created directories.
+     */
+    private const int DIR_PERMISSIONS = 0o750;
+
+    public function __construct(
+        private readonly string $logPath,
+    ) {}
+
+    public function write(AuditEntry $entry): void
+    {
+        $this->ensureDirectory();
+
+        $line = json_encode(
+            $entry->toArray(),
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ) . "\n";
+
+        $result = file_put_contents($this->logPath, $line, FILE_APPEND | LOCK_EX);
+
+        if ($result === false) {
+            throw SecurityException::auditWriteFailed(
+                sprintf('Could not write to audit log at "%s"', $this->logPath),
+            );
+        }
+    }
+
+    /**
+     * Ensure the log directory exists with appropriate permissions.
+     */
+    private function ensureDirectory(): void
+    {
+        $dir = dirname($this->logPath);
+
+        if (is_dir($dir)) {
+            return;
+        }
+
+        if (!mkdir($dir, self::DIR_PERMISSIONS, true) && !is_dir($dir)) {
+            throw SecurityException::auditWriteFailed(
+                sprintf('Could not create audit log directory "%s"', $dir),
+            );
+        }
+    }
+}

--- a/src/Security/Audit/AuditLogger.php
+++ b/src/Security/Audit/AuditLogger.php
@@ -1,0 +1,82 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Audit;
+
+use function bin2hex;
+
+use DateTimeImmutable;
+use Pulsar\Security\Crypto\Hmac;
+
+use function random_bytes;
+
+/**
+ * Orchestrates tamper-evident audit logging with HMAC chain.
+ *
+ * Tracks the previousHmac state across entries to maintain the chain.
+ * The seed HMAC is computed from a well-known string and the audit key,
+ * so verification tools can reconstruct the chain from the beginning.
+ */
+final class AuditLogger
+{
+    /**
+     * Seed message used to compute the initial chain HMAC.
+     */
+    private const string SEED_MESSAGE = 'PULSAR_AUDIT_SEED';
+
+    private string $previousHmac;
+
+    public function __construct(
+        private readonly AuditSinkInterface $sink,
+        private readonly string $auditKey,
+    ) {
+        $this->previousHmac = Hmac::computeHex(self::SEED_MESSAGE, $this->auditKey);
+    }
+
+    /**
+     * Log an audit event.
+     *
+     * Creates an AuditEntry with HMAC chain, writes it to the sink,
+     * and advances the chain state.
+     *
+     * @param array<string, mixed> $metadata
+     */
+    public function log(
+        AuditEvent $event,
+        AuditOutcome $outcome,
+        string $actor,
+        string $action,
+        string $resource = '',
+        array $metadata = [],
+    ): AuditEntry {
+        $id = bin2hex(random_bytes(16));
+        $timestamp = new DateTimeImmutable();
+
+        $entry = AuditEntry::create(
+            id: $id,
+            event: $event,
+            outcome: $outcome,
+            actor: $actor,
+            action: $action,
+            resource: $resource,
+            timestamp: $timestamp,
+            metadata: $metadata,
+            previousHmac: $this->previousHmac,
+            auditKey: $this->auditKey,
+        );
+
+        $this->sink->write($entry);
+        $this->previousHmac = $entry->hmac;
+
+        return $entry;
+    }
+
+    /**
+     * Get the current chain HMAC (the HMAC of the last written entry).
+     */
+    public function previousHmac(): string
+    {
+        return $this->previousHmac;
+    }
+}

--- a/src/Security/Audit/AuditOutcome.php
+++ b/src/Security/Audit/AuditOutcome.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Audit;
+
+/**
+ * Outcome of an auditable event.
+ */
+enum AuditOutcome: string
+{
+    case Success = 'success';
+    case Failure = 'failure';
+    case Denied = 'denied';
+    case Error = 'error';
+}

--- a/src/Security/Audit/AuditSinkInterface.php
+++ b/src/Security/Audit/AuditSinkInterface.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Audit;
+
+/**
+ * Contract for audit log persistence backends.
+ *
+ * Implementations must guarantee that entries are durably written
+ * before returning from write().
+ */
+interface AuditSinkInterface
+{
+    /**
+     * Write an audit entry to the backing store.
+     *
+     * @throws \Pulsar\Security\Exception\SecurityException If the write fails
+     */
+    public function write(AuditEntry $entry): void;
+}

--- a/src/Security/Crypto/Encryptor.php
+++ b/src/Security/Crypto/Encryptor.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Crypto;
+
+use Pulsar\Security\Exception\SecurityException;
+
+use function sodium_crypto_secretbox;
+use function sodium_crypto_secretbox_open;
+use function strlen;
+
+/**
+ * Authenticated encryption using libsodium's secretbox (XSalsa20-Poly1305).
+ *
+ * Uses a derived subkey from MasterKey (subKeyId=1, context='encrypt_').
+ * Ciphertext format: nonce (24 bytes) || ciphertext+mac.
+ */
+final class Encryptor
+{
+    /**
+     * Sub-key ID for encryption.
+     */
+    private const int SUB_KEY_ID = 1;
+
+    /**
+     * KDF context for encryption key derivation.
+     */
+    private const string KDF_CONTEXT = 'encrypt_';
+
+    /**
+     * Nonce length in bytes.
+     */
+    private const int NONCE_LENGTH = SODIUM_CRYPTO_SECRETBOX_NONCEBYTES;
+
+    private readonly string $key;
+
+    public function __construct(MasterKey $masterKey)
+    {
+        $this->key = $masterKey->deriveSubKey(self::SUB_KEY_ID, self::KDF_CONTEXT);
+    }
+
+    /**
+     * Encrypt plaintext and return base64-encoded ciphertext.
+     *
+     * Output format: base64(nonce || ciphertext_with_mac)
+     *
+     * @throws SecurityException If encryption fails
+     */
+    public function encrypt(string $plaintext): string
+    {
+        $nonce = random_bytes(self::NONCE_LENGTH);
+        $ciphertext = sodium_crypto_secretbox($plaintext, $nonce, $this->key);
+
+        return base64_encode($nonce . $ciphertext);
+    }
+
+    /**
+     * Decrypt a base64-encoded ciphertext produced by encrypt().
+     *
+     * @throws SecurityException If decryption fails (wrong key, tampered data, etc.)
+     */
+    public function decrypt(string $encoded): string
+    {
+        $decoded = base64_decode($encoded, true);
+
+        if ($decoded === false) {
+            throw SecurityException::decryptionFailed();
+        }
+
+        if (strlen($decoded) < self::NONCE_LENGTH + SODIUM_CRYPTO_SECRETBOX_MACBYTES) {
+            throw SecurityException::decryptionFailed();
+        }
+
+        $nonce = substr($decoded, 0, self::NONCE_LENGTH);
+        $ciphertext = substr($decoded, self::NONCE_LENGTH);
+
+        $plaintext = sodium_crypto_secretbox_open($ciphertext, $nonce, $this->key);
+
+        if ($plaintext === false) {
+            throw SecurityException::decryptionFailed();
+        }
+
+        return $plaintext;
+    }
+
+    /**
+     * Prevent key from leaking in debug output.
+     *
+     * @return array<string, string>
+     */
+    public function __debugInfo(): array
+    {
+        return ['key' => '[REDACTED]'];
+    }
+}

--- a/src/Security/Crypto/Hmac.php
+++ b/src/Security/Crypto/Hmac.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Crypto;
+
+use function hash_equals;
+
+use InvalidArgumentException;
+
+use function sodium_crypto_generichash;
+use function sprintf;
+use function strlen;
+
+/**
+ * HMAC wrapper using libsodium's BLAKE2b (sodium_crypto_generichash).
+ *
+ * Provides keyed hashing for integrity verification and tamper detection.
+ */
+final class Hmac
+{
+    /**
+     * Minimum key length in bytes for keyed hashing.
+     */
+    private const int MIN_KEY_LENGTH = SODIUM_CRYPTO_GENERICHASH_KEYBYTES_MIN;
+
+    /**
+     * Output length in bytes (32 bytes = 256 bits).
+     */
+    private const int HASH_LENGTH = SODIUM_CRYPTO_GENERICHASH_BYTES;
+
+    private function __construct() {}
+
+    /**
+     * Compute a keyed BLAKE2b hash and return as hex string.
+     */
+    public static function computeHex(string $message, string $key): string
+    {
+        self::validateKey($key);
+
+        $raw = sodium_crypto_generichash($message, $key, self::HASH_LENGTH);
+
+        return sodium_bin2hex($raw);
+    }
+
+    /**
+     * Compute a keyed BLAKE2b hash and return raw bytes.
+     */
+    public static function compute(string $message, string $key): string
+    {
+        self::validateKey($key);
+
+        return sodium_crypto_generichash($message, $key, self::HASH_LENGTH);
+    }
+
+    /**
+     * Verify a hex-encoded HMAC against a message and key.
+     *
+     * Uses constant-time comparison to prevent timing attacks.
+     */
+    public static function verifyHex(string $message, string $expectedHex, string $key): bool
+    {
+        $computedHex = self::computeHex($message, $key);
+
+        return hash_equals($expectedHex, $computedHex);
+    }
+
+    /**
+     * Verify raw HMAC bytes against a message and key.
+     *
+     * Uses constant-time comparison to prevent timing attacks.
+     */
+    public static function verify(string $message, string $expected, string $key): bool
+    {
+        $computed = self::compute($message, $key);
+
+        return hash_equals($expected, $computed);
+    }
+
+    /**
+     * Validate that the key meets minimum length requirements.
+     */
+    private static function validateKey(string $key): void
+    {
+        if (strlen($key) < self::MIN_KEY_LENGTH) {
+            throw new InvalidArgumentException(
+                sprintf(
+                    'HMAC key must be at least %d bytes, got %d',
+                    self::MIN_KEY_LENGTH,
+                    strlen($key),
+                ),
+            );
+        }
+    }
+}

--- a/src/Security/Crypto/MasterKey.php
+++ b/src/Security/Crypto/MasterKey.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Crypto;
+
+use Pulsar\Security\Exception\SecurityException;
+
+use function sodium_bin2hex;
+use function sodium_crypto_kdf_derive_from_key;
+use function sodium_hex2bin;
+use function sprintf;
+use function strlen;
+
+/**
+ * Master key management backed by libsodium KDF.
+ *
+ * Loads the application master key from the `PULSAR_MASTER_KEY` environment variable
+ * (hex-encoded 32 bytes) and derives purpose-specific subkeys using
+ * `sodium_crypto_kdf_derive_from_key`.
+ *
+ * Sub-key IDs:
+ * - 1 = encryption (used by Encryptor)
+ * - 2 = audit HMAC chain
+ */
+final class MasterKey
+{
+    /**
+     * Expected key length in bytes.
+     */
+    private const int KEY_LENGTH = SODIUM_CRYPTO_KDF_KEYBYTES;
+
+    /**
+     * Context must be exactly 8 bytes for sodium KDF.
+     */
+    private const int CONTEXT_LENGTH = SODIUM_CRYPTO_KDF_CONTEXTBYTES;
+
+    private readonly string $rawKey;
+
+    private function __construct(string $rawKey)
+    {
+        $this->rawKey = $rawKey;
+    }
+
+    /**
+     * Load master key from a hex-encoded string.
+     *
+     * @throws SecurityException If the key is invalid
+     */
+    public static function fromHex(string $hex): self
+    {
+        $raw = sodium_hex2bin($hex);
+
+        if (strlen($raw) !== self::KEY_LENGTH) {
+            throw SecurityException::masterKeyInvalid(
+                sprintf('expected %d bytes, got %d', self::KEY_LENGTH, strlen($raw)),
+            );
+        }
+
+        return new self($raw);
+    }
+
+    /**
+     * Load master key from the PULSAR_MASTER_KEY environment variable.
+     *
+     * @throws SecurityException If the variable is missing or invalid
+     */
+    public static function fromEnvironment(?string $envValue = null): self
+    {
+        $hex = $envValue ?? getenv('PULSAR_MASTER_KEY');
+
+        if ($hex === false || $hex === '') {
+            throw SecurityException::masterKeyMissing();
+        }
+
+        return self::fromHex($hex);
+    }
+
+    /**
+     * Derive a purpose-specific subkey.
+     *
+     * @param int    $subKeyId Non-negative integer identifying the subkey purpose
+     * @param string $context  Exactly 8-byte ASCII context string (padded/truncated automatically)
+     * @param int    $length   Desired subkey length in bytes (16–64)
+     *
+     * @return string Raw subkey bytes
+     */
+    public function deriveSubKey(int $subKeyId, string $context, int $length = SODIUM_CRYPTO_SECRETBOX_KEYBYTES): string
+    {
+        $context = self::normalizeContext($context);
+
+        return sodium_crypto_kdf_derive_from_key($length, $subKeyId, $context, $this->rawKey);
+    }
+
+    /**
+     * Derive a subkey and return it as hex.
+     */
+    public function deriveSubKeyHex(int $subKeyId, string $context, int $length = SODIUM_CRYPTO_SECRETBOX_KEYBYTES): string
+    {
+        return sodium_bin2hex($this->deriveSubKey($subKeyId, $context, $length));
+    }
+
+    /**
+     * Prevent master key from leaking in debug output.
+     *
+     * @return array<string, string>
+     */
+    public function __debugInfo(): array
+    {
+        return ['rawKey' => '[REDACTED]'];
+    }
+
+    /**
+     * Normalize context to exactly CONTEXT_LENGTH bytes.
+     */
+    private static function normalizeContext(string $context): string
+    {
+        if (strlen($context) >= self::CONTEXT_LENGTH) {
+            return substr($context, 0, self::CONTEXT_LENGTH);
+        }
+
+        return str_pad($context, self::CONTEXT_LENGTH, '_');
+    }
+}

--- a/src/Security/Csrf/CsrfMiddleware.php
+++ b/src/Security/Csrf/CsrfMiddleware.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Csrf;
+
+use function is_string;
+
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Http\Middleware\MiddlewareInterface;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+
+/**
+ * CSRF protection middleware.
+ *
+ * Validates CSRF tokens on state-changing HTTP methods (POST, PUT, PATCH, DELETE).
+ * Safe methods (GET, HEAD, OPTIONS) pass through without validation.
+ *
+ * Token is extracted from either:
+ * - The configured header (default: `X-CSRF-Token`)
+ * - The configured POST field (default: `_csrf_token`)
+ *
+ * Returns a 403 Forbidden JSON response when validation fails.
+ */
+final readonly class CsrfMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private CsrfTokenManagerInterface $tokenManager,
+        private CsrfConfig $config,
+    ) {}
+
+    public function process(Request $request, callable $next): Response
+    {
+        if (!$this->config->enabled) {
+            return $next($request);
+        }
+
+        // Safe methods do not require CSRF validation
+        if ($request->method->isSafe()) {
+            return $next($request);
+        }
+
+        $token = $this->extractToken($request);
+
+        if ($token === null) {
+            return self::forbiddenResponse('CSRF token is missing');
+        }
+
+        if (!$this->tokenManager->validate($token)) {
+            return self::forbiddenResponse('CSRF token is invalid');
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Extract the CSRF token from the request (header or POST field).
+     */
+    private function extractToken(Request $request): ?string
+    {
+        // Try header first
+        $headerToken = $request->header($this->config->headerName);
+
+        if ($headerToken !== null && $headerToken !== '') {
+            return $headerToken;
+        }
+
+        // Fall back to POST field
+        $fieldToken = $request->post($this->config->formFieldName);
+
+        if (is_string($fieldToken) && $fieldToken !== '') {
+            return $fieldToken;
+        }
+
+        return null;
+    }
+
+    /**
+     * Create a 403 Forbidden JSON response.
+     */
+    private static function forbiddenResponse(string $message): Response
+    {
+        return Response::json(
+            ['error' => 'Forbidden', 'message' => $message],
+            ResponseStatus::Forbidden,
+        );
+    }
+}

--- a/src/Security/Csrf/CsrfTokenManager.php
+++ b/src/Security/Csrf/CsrfTokenManager.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Csrf;
+
+use function bin2hex;
+use function hash_equals;
+use function is_string;
+
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Security\Session\SessionInterface;
+
+use function random_bytes;
+
+/**
+ * CSRF token manager using the synchronizer token pattern.
+ *
+ * Tokens are stored server-side in the session. On state-changing requests,
+ * the submitted token is compared against the stored token using constant-time
+ * comparison.
+ */
+final class CsrfTokenManager implements CsrfTokenManagerInterface
+{
+    /**
+     * Session key for storing the CSRF token.
+     */
+    private const string SESSION_KEY = '_csrf_token';
+
+    public function __construct(
+        private readonly SessionInterface $session,
+        private readonly CsrfConfig $config,
+    ) {}
+
+    /**
+     * Generate a new CSRF token and store it in the session.
+     *
+     * @return string The generated token (hex-encoded)
+     */
+    public function generate(): string
+    {
+        $token = bin2hex(random_bytes(max(1, $this->config->tokenLength)));
+        $this->session->set(self::SESSION_KEY, $token);
+
+        return $token;
+    }
+
+    /**
+     * Get the current CSRF token, generating one if none exists.
+     */
+    public function getToken(): string
+    {
+        $token = $this->session->get(self::SESSION_KEY);
+
+        if ($token === null || !is_string($token)) {
+            return $this->generate();
+        }
+
+        return $token;
+    }
+
+    /**
+     * Validate a submitted token against the stored session token.
+     *
+     * Uses constant-time comparison to prevent timing attacks.
+     */
+    public function validate(string $submittedToken): bool
+    {
+        $storedToken = $this->session->get(self::SESSION_KEY);
+
+        if ($storedToken === null || !is_string($storedToken)) {
+            return false;
+        }
+
+        return hash_equals($storedToken, $submittedToken);
+    }
+
+    /**
+     * Rotate the CSRF token (generate a new one, invalidating the old).
+     *
+     * Call after successful form submission to prevent replay.
+     */
+    public function rotate(): string
+    {
+        return $this->generate();
+    }
+}

--- a/src/Security/Csrf/CsrfTokenManagerInterface.php
+++ b/src/Security/Csrf/CsrfTokenManagerInterface.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Csrf;
+
+/**
+ * Contract for CSRF token management.
+ *
+ * Abstracts token operations for testability while allowing
+ * the concrete implementation to remain final.
+ */
+interface CsrfTokenManagerInterface
+{
+    /**
+     * Generate a new CSRF token and store it.
+     */
+    public function generate(): string;
+
+    /**
+     * Get the current CSRF token, generating one if none exists.
+     */
+    public function getToken(): string;
+
+    /**
+     * Validate a submitted token against the stored token.
+     */
+    public function validate(string $submittedToken): bool;
+
+    /**
+     * Rotate the CSRF token (generate a new one, invalidating the old).
+     */
+    public function rotate(): string;
+}

--- a/src/Security/Exception/SecurityException.php
+++ b/src/Security/Exception/SecurityException.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Exception;
+
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Base exception for all security-related errors.
+ *
+ * Provides static factory methods for specific security error scenarios.
+ */
+final class SecurityException extends RuntimeException
+{
+    /**
+     * CSRF token validation failed.
+     */
+    public static function csrfTokenMissing(): self
+    {
+        return new self('CSRF token is missing from the request');
+    }
+
+    /**
+     * CSRF token does not match expected value.
+     */
+    public static function csrfTokenInvalid(): self
+    {
+        return new self('CSRF token is invalid');
+    }
+
+    /**
+     * Session has not been started.
+     */
+    public static function sessionNotStarted(): self
+    {
+        return new self('Session has not been started');
+    }
+
+    /**
+     * Session could not be started.
+     */
+    public static function sessionStartFailed(): self
+    {
+        return new self('Failed to start session');
+    }
+
+    /**
+     * Master key is missing from environment.
+     */
+    public static function masterKeyMissing(): self
+    {
+        return new self('PULSAR_MASTER_KEY environment variable is not set');
+    }
+
+    /**
+     * Master key has invalid format.
+     */
+    public static function masterKeyInvalid(string $reason): self
+    {
+        return new self(sprintf('Invalid master key: %s', $reason));
+    }
+
+    /**
+     * Encryption failed.
+     */
+    public static function encryptionFailed(string $reason): self
+    {
+        return new self(sprintf('Encryption failed: %s', $reason));
+    }
+
+    /**
+     * Decryption failed (wrong key, tampered ciphertext, etc.).
+     */
+    public static function decryptionFailed(): self
+    {
+        return new self('Decryption failed: ciphertext is invalid or has been tampered with');
+    }
+
+    /**
+     * Audit log integrity verification failed.
+     */
+    public static function auditIntegrityViolation(string $entryId): self
+    {
+        return new self(sprintf('Audit log integrity violation for entry "%s"', $entryId));
+    }
+
+    /**
+     * Audit sink write failure.
+     */
+    public static function auditWriteFailed(string $reason): self
+    {
+        return new self(sprintf('Failed to write audit entry: %s', $reason));
+    }
+}

--- a/src/Security/Middleware/SecurityHeadersMiddleware.php
+++ b/src/Security/Middleware/SecurityHeadersMiddleware.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Middleware;
+
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Http\Middleware\MiddlewareInterface;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+
+/**
+ * Middleware that applies configured security headers to every response.
+ *
+ * Adds headers like X-Content-Type-Options, X-Frame-Options, Referrer-Policy,
+ * etc. as configured in SecurityHeadersConfig.
+ */
+final readonly class SecurityHeadersMiddleware implements MiddlewareInterface
+{
+    public function __construct(
+        private SecurityHeadersConfig $config,
+    ) {}
+
+    public function process(Request $request, callable $next): Response
+    {
+        /** @var Response $response */
+        $response = $next($request);
+
+        foreach ($this->config->headers as $name => $value) {
+            $response = $response->withHeader($name, $value);
+        }
+
+        return $response;
+    }
+}

--- a/src/Security/Session/Session.php
+++ b/src/Security/Session/Session.php
@@ -1,0 +1,171 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Session;
+
+use function array_key_exists;
+
+use Pulsar\Config\SessionConfig;
+use Pulsar\Security\Exception\SecurityException;
+
+use function session_destroy;
+use function session_id;
+use function session_name;
+use function session_regenerate_id;
+use function session_start;
+use function session_status;
+
+/**
+ * Secure session wrapper around PHP's native session functions.
+ *
+ * Applies security settings from SessionConfig (HttpOnly, Secure, SameSite)
+ * and provides a testable abstraction over `$_SESSION`.
+ */
+final class Session implements SessionInterface
+{
+    private bool $started = false;
+
+    public function __construct(
+        private readonly SessionConfig $config,
+    ) {}
+
+    /**
+     * Start the session with security settings applied.
+     *
+     * @throws SecurityException If the session cannot be started
+     */
+    public function start(): void
+    {
+        if ($this->started || session_status() === PHP_SESSION_ACTIVE) {
+            $this->started = true;
+            return;
+        }
+
+        session_name($this->config->cookieName);
+
+        $started = session_start([
+            'cookie_httponly' => $this->config->cookieHttpOnly,
+            'cookie_secure' => $this->config->cookieSecure,
+            'cookie_samesite' => $this->config->cookieSameSite,
+            'cookie_lifetime' => $this->config->lifetime,
+            'use_strict_mode' => true,
+            'use_only_cookies' => true,
+        ]);
+
+        if (!$started) {
+            throw SecurityException::sessionStartFailed();
+        }
+
+        $this->started = true;
+    }
+
+    /**
+     * Check if the session is active.
+     */
+    public function isStarted(): bool
+    {
+        return $this->started || session_status() === PHP_SESSION_ACTIVE;
+    }
+
+    /**
+     * Get a value from the session.
+     */
+    public function get(string $key, mixed $default = null): mixed
+    {
+        $this->ensureStarted();
+
+        return $_SESSION[$key] ?? $default;
+    }
+
+    /**
+     * Set a value in the session.
+     */
+    public function set(string $key, mixed $value): void
+    {
+        $this->ensureStarted();
+
+        $_SESSION[$key] = $value;
+    }
+
+    /**
+     * Check if a key exists in the session.
+     */
+    public function has(string $key): bool
+    {
+        $this->ensureStarted();
+
+        /** @psalm-suppress InvalidScalarArgument -- $_SESSION is always available after session_start() */
+        return array_key_exists($key, $_SESSION);
+    }
+
+    /**
+     * Remove a key from the session.
+     */
+    public function remove(string $key): void
+    {
+        $this->ensureStarted();
+
+        unset($_SESSION[$key]);
+    }
+
+    /**
+     * Get the current session ID.
+     */
+    public function id(): string
+    {
+        return session_id() ?: '';
+    }
+
+    /**
+     * Regenerate the session ID (preserving session data).
+     *
+     * Use after privilege escalation (login, role change) to prevent session fixation.
+     */
+    public function regenerate(bool $deleteOldSession = true): void
+    {
+        $this->ensureStarted();
+
+        session_regenerate_id($deleteOldSession);
+    }
+
+    /**
+     * Destroy the session completely.
+     */
+    public function destroy(): void
+    {
+        if (session_status() === PHP_SESSION_ACTIVE) {
+            $_SESSION = [];
+            session_destroy();
+        }
+
+        $this->started = false;
+    }
+
+    /**
+     * Get all session data.
+     *
+     * @return array<string, mixed>
+     *
+     * @psalm-suppress InvalidReturnType, InvalidReturnStatement -- $_SESSION keys are strings after session_start()
+     */
+    public function all(): array
+    {
+        $this->ensureStarted();
+
+        /** @var array<string, mixed> $_SESSION */
+        return $_SESSION;
+    }
+
+    /**
+     * Ensure the session is started before reading/writing.
+     *
+     * @throws SecurityException If the session has not been started
+     */
+    private function ensureStarted(): void
+    {
+        if (!$this->isStarted()) {
+            throw SecurityException::sessionNotStarted();
+        }
+    }
+}

--- a/src/Security/Session/SessionInterface.php
+++ b/src/Security/Session/SessionInterface.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Security\Session;
+
+/**
+ * Contract for session management.
+ *
+ * Abstracts session operations for testability while allowing
+ * the concrete implementation to remain final.
+ */
+interface SessionInterface
+{
+    /**
+     * Start the session.
+     */
+    public function start(): void;
+
+    /**
+     * Check if the session is active.
+     */
+    public function isStarted(): bool;
+
+    /**
+     * Get a value from the session.
+     */
+    public function get(string $key, mixed $default = null): mixed;
+
+    /**
+     * Set a value in the session.
+     */
+    public function set(string $key, mixed $value): void;
+
+    /**
+     * Check if a key exists in the session.
+     */
+    public function has(string $key): bool;
+
+    /**
+     * Remove a key from the session.
+     */
+    public function remove(string $key): void;
+
+    /**
+     * Get the current session ID.
+     */
+    public function id(): string;
+
+    /**
+     * Regenerate the session ID.
+     */
+    public function regenerate(bool $deleteOldSession = true): void;
+
+    /**
+     * Destroy the session completely.
+     */
+    public function destroy(): void;
+
+    /**
+     * Get all session data.
+     *
+     * @return array<string, mixed>
+     */
+    public function all(): array;
+}

--- a/tests/Integration/ErrorHandling/KernelErrorHandlingTest.php
+++ b/tests/Integration/ErrorHandling/KernelErrorHandlingTest.php
@@ -93,6 +93,18 @@ final class KernelErrorHandlingTest extends TestCase
                     "stderr" => ["driver" => "stream", "stream" => "php://stderr"],
                 ],
             ],
+            "audit" => [
+                "enabled" => false,
+                "log_path" => "var/logs/audit.jsonl",
+                "events" => [],
+            ],
+        ];');
+
+        file_put_contents($this->tempDir . '/security.php', '<?php return [
+            "session" => [],
+            "csrf" => ["enabled" => false],
+            "headers" => [],
+            "rate_limiting" => ["enabled" => false],
         ];');
     }
 

--- a/tests/Integration/Http/ValidationMiddlewareTest.php
+++ b/tests/Integration/Http/ValidationMiddlewareTest.php
@@ -96,6 +96,18 @@ final class ValidationMiddlewareTest extends TestCase
                     "stderr" => ["driver" => "stream", "stream" => "php://stderr"],
                 ],
             ],
+            "audit" => [
+                "enabled" => false,
+                "log_path" => "var/logs/audit.jsonl",
+                "events" => [],
+            ],
+        ];');
+
+        file_put_contents($this->tempDir . '/security.php', '<?php return [
+            "session" => [],
+            "csrf" => ["enabled" => false],
+            "headers" => [],
+            "rate_limiting" => ["enabled" => false],
         ];');
     }
 

--- a/tests/Integration/Security/SecurityMiddlewareIntegrationTest.php
+++ b/tests/Integration/Security/SecurityMiddlewareIntegrationTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Integration\Security;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Security\Csrf\CsrfMiddleware;
+use Pulsar\Security\Csrf\CsrfTokenManagerInterface;
+use Pulsar\Security\Middleware\SecurityHeadersMiddleware;
+
+/**
+ * Integration tests for the full security middleware stack.
+ */
+#[CoversClass(SecurityHeadersMiddleware::class)]
+#[CoversClass(CsrfMiddleware::class)]
+final class SecurityMiddlewareIntegrationTest extends TestCase
+{
+    private CsrfConfig $csrfConfig;
+    private SecurityHeadersConfig $headersConfig;
+
+    protected function setUp(): void
+    {
+        $this->csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $this->headersConfig = new SecurityHeadersConfig(headers: [
+            'X-Content-Type-Options' => 'nosniff',
+            'X-Frame-Options' => 'DENY',
+            'Referrer-Policy' => 'strict-origin-when-cross-origin',
+        ]);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed>  $post
+     */
+    private function createRequest(
+        Method $method = Method::GET,
+        string $path = '/',
+        array $headers = [],
+        array $post = [],
+    ): Request {
+        return new Request(
+            method: $method,
+            uri: $path,
+            path: $path,
+            queryString: '',
+            headers: new HeaderBag($headers),
+            body: '',
+            post: $post,
+        );
+    }
+
+    #[Test]
+    public function securityHeadersAppliedToEveryResponse(): void
+    {
+        $middleware = new SecurityHeadersMiddleware($this->headersConfig);
+
+        $handler = fn(Request $r): Response => Response::json(['status' => 'ok']);
+
+        $response = $middleware->process($this->createRequest(), $handler);
+
+        self::assertSame('nosniff', $response->headers->first('X-Content-Type-Options'));
+        self::assertSame('DENY', $response->headers->first('X-Frame-Options'));
+        self::assertSame('strict-origin-when-cross-origin', $response->headers->first('Referrer-Policy'));
+        self::assertSame(ResponseStatus::OK, $response->status);
+    }
+
+    #[Test]
+    public function csrfMiddlewareAllowsGetThroughThenBlocksPost(): void
+    {
+        $tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $tokenManager->method('validate')->willReturn(false);
+
+        $middleware = new CsrfMiddleware($tokenManager, $this->csrfConfig);
+        $handler = fn(Request $r): Response => Response::text('OK');
+
+        // GET passes through
+        $getResponse = $middleware->process(
+            $this->createRequest(Method::GET),
+            $handler,
+        );
+        self::assertSame(ResponseStatus::OK, $getResponse->status);
+
+        // POST without token returns 403
+        $postResponse = $middleware->process(
+            $this->createRequest(Method::POST, '/submit'),
+            $handler,
+        );
+        self::assertSame(ResponseStatus::Forbidden, $postResponse->status);
+    }
+
+    #[Test]
+    public function csrfMiddlewareAcceptsValidTokenInHeader(): void
+    {
+        $token = bin2hex(random_bytes(32));
+
+        $tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $tokenManager->method('validate')
+            ->with($token)
+            ->willReturn(true);
+
+        $middleware = new CsrfMiddleware($tokenManager, $this->csrfConfig);
+        $handler = fn(Request $r): Response => Response::text('Created');
+
+        $response = $middleware->process(
+            $this->createRequest(
+                Method::POST,
+                '/submit',
+                headers: ['X-CSRF-Token' => $token],
+            ),
+            $handler,
+        );
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        self::assertSame('Created', $response->body);
+    }
+
+    #[Test]
+    public function csrfMiddlewareAcceptsValidTokenInPostField(): void
+    {
+        $token = bin2hex(random_bytes(32));
+
+        $tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $tokenManager->method('validate')
+            ->with($token)
+            ->willReturn(true);
+
+        $middleware = new CsrfMiddleware($tokenManager, $this->csrfConfig);
+        $handler = fn(Request $r): Response => Response::text('Created');
+
+        $response = $middleware->process(
+            $this->createRequest(
+                Method::POST,
+                '/submit',
+                post: ['_csrf_token' => $token],
+            ),
+            $handler,
+        );
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+    }
+
+    #[Test]
+    public function combinedMiddlewareStackAppliesAllHeaders(): void
+    {
+        $token = bin2hex(random_bytes(32));
+
+        $tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $tokenManager->method('validate')->with($token)->willReturn(true);
+
+        $csrfMiddleware = new CsrfMiddleware($tokenManager, $this->csrfConfig);
+        $headersMiddleware = new SecurityHeadersMiddleware($this->headersConfig);
+
+        $handler = fn(Request $r): Response => Response::json(['data' => 'value']);
+
+        // Build pipeline: security headers wraps CSRF which wraps handler
+        $pipeline = fn(Request $r): Response => $headersMiddleware->process(
+            $r,
+            fn(Request $inner): Response => $csrfMiddleware->process($inner, $handler),
+        );
+
+        $request = $this->createRequest(
+            Method::POST,
+            '/api/data',
+            headers: ['X-CSRF-Token' => $token],
+        );
+
+        $response = $pipeline($request);
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        self::assertSame('nosniff', $response->headers->first('X-Content-Type-Options'));
+        self::assertSame('DENY', $response->headers->first('X-Frame-Options'));
+    }
+
+    #[Test]
+    public function forbiddenResponseFromCsrfStillGetsSecurityHeaders(): void
+    {
+        $tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+        $tokenManager->method('validate')->willReturn(false);
+
+        $csrfMiddleware = new CsrfMiddleware($tokenManager, $this->csrfConfig);
+        $headersMiddleware = new SecurityHeadersMiddleware($this->headersConfig);
+
+        $handler = fn(Request $r): Response => Response::text('OK');
+
+        $pipeline = fn(Request $r): Response => $headersMiddleware->process(
+            $r,
+            fn(Request $inner): Response => $csrfMiddleware->process($inner, $handler),
+        );
+
+        $request = $this->createRequest(Method::POST, '/submit');
+        $response = $pipeline($request);
+
+        // CSRF blocks with 403
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+
+        // But security headers are still applied
+        self::assertSame('nosniff', $response->headers->first('X-Content-Type-Options'));
+        self::assertSame('DENY', $response->headers->first('X-Frame-Options'));
+    }
+}

--- a/tests/Unit/Config/ConfigManagerTest.php
+++ b/tests/Unit/Config/ConfigManagerTest.php
@@ -83,6 +83,37 @@ final class ConfigManagerTest extends TestCase
                     "stderr" => ["driver" => "stream", "stream" => "php://stderr"],
                 ],
             ],
+            "audit" => [
+                "enabled" => true,
+                "log_path" => "var/logs/audit.jsonl",
+                "events" => ["authentication"],
+            ],
+        ];');
+
+        file_put_contents($this->tempDir . '/security.php', '<?php return [
+            "session" => [
+                "cookie_name" => "TEST_SESSION",
+                "lifetime" => 3600,
+                "cookie_httponly" => true,
+                "cookie_secure" => true,
+                "cookie_samesite" => "Strict",
+                "regenerate_on_privilege_change" => true,
+            ],
+            "csrf" => [
+                "enabled" => true,
+                "token_length" => 32,
+                "header_name" => "X-CSRF-Token",
+                "form_field_name" => "_csrf_token",
+            ],
+            "headers" => [
+                "X-Content-Type-Options" => "nosniff",
+                "X-Frame-Options" => "DENY",
+            ],
+            "rate_limiting" => [
+                "enabled" => true,
+                "default_limit" => 60,
+                "default_window" => 60,
+            ],
         ];');
     }
 
@@ -153,6 +184,7 @@ final class ConfigManagerTest extends TestCase
     {
         file_put_contents($this->tempDir . '/app.php', '<?php return "not an array";');
         file_put_contents($this->tempDir . '/observability.php', '<?php return [];');
+        file_put_contents($this->tempDir . '/security.php', '<?php return [];');
 
         $manager = new ConfigManager(configPath: $this->tempDir);
 

--- a/tests/Unit/Config/SecurityConfigTest.php
+++ b/tests/Unit/Config/SecurityConfigTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Config\Environment;
+use Pulsar\Config\RateLimitConfig;
+use Pulsar\Config\SecurityConfig;
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Config\SessionConfig;
+
+#[CoversClass(SecurityConfig::class)]
+#[CoversClass(SessionConfig::class)]
+#[CoversClass(CsrfConfig::class)]
+#[CoversClass(SecurityHeadersConfig::class)]
+#[CoversClass(RateLimitConfig::class)]
+final class SecurityConfigTest extends TestCase
+{
+    private Environment $environment;
+
+    protected function setUp(): void
+    {
+        putenv('SESSION_COOKIE_NAME');
+        $this->environment = Environment::load();
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('SESSION_COOKIE_NAME');
+    }
+
+    #[Test]
+    public function fromArrayBuildsAllSubConfigs(): void
+    {
+        $data = [
+            'session' => [
+                'cookie_name' => 'MY_SESSION',
+                'lifetime' => 3600,
+                'cookie_httponly' => true,
+                'cookie_secure' => false,
+                'cookie_samesite' => 'Lax',
+                'regenerate_on_privilege_change' => false,
+            ],
+            'csrf' => [
+                'enabled' => false,
+                'token_length' => 64,
+                'header_name' => 'X-Custom-CSRF',
+                'form_field_name' => '_token',
+            ],
+            'headers' => [
+                'X-Content-Type-Options' => 'nosniff',
+                'X-Frame-Options' => 'SAMEORIGIN',
+            ],
+            'rate_limiting' => [
+                'enabled' => false,
+                'default_limit' => 100,
+                'default_window' => 120,
+            ],
+        ];
+
+        $config = SecurityConfig::fromArray($data, $this->environment);
+
+        // Session
+        self::assertSame('MY_SESSION', $config->session->cookieName);
+        self::assertSame(3600, $config->session->lifetime);
+        self::assertTrue($config->session->cookieHttpOnly);
+        self::assertFalse($config->session->cookieSecure);
+        self::assertSame('Lax', $config->session->cookieSameSite);
+        self::assertFalse($config->session->regenerateOnPrivilegeChange);
+
+        // CSRF
+        self::assertFalse($config->csrf->enabled);
+        self::assertSame(64, $config->csrf->tokenLength);
+        self::assertSame('X-Custom-CSRF', $config->csrf->headerName);
+        self::assertSame('_token', $config->csrf->formFieldName);
+
+        // Headers
+        self::assertSame('nosniff', $config->headers->headers['X-Content-Type-Options']);
+        self::assertSame('SAMEORIGIN', $config->headers->headers['X-Frame-Options']);
+
+        // Rate limiting
+        self::assertFalse($config->rateLimit->enabled);
+        self::assertSame(100, $config->rateLimit->defaultLimit);
+        self::assertSame(120, $config->rateLimit->defaultWindow);
+    }
+
+    #[Test]
+    public function defaultsAppliedWhenKeysAreMissing(): void
+    {
+        $config = SecurityConfig::fromArray([], $this->environment);
+
+        self::assertSame('PULSAR_SESSION', $config->session->cookieName);
+        self::assertSame(7200, $config->session->lifetime);
+        self::assertTrue($config->session->cookieHttpOnly);
+        self::assertTrue($config->session->cookieSecure);
+        self::assertSame('Strict', $config->session->cookieSameSite);
+        self::assertTrue($config->session->regenerateOnPrivilegeChange);
+
+        self::assertTrue($config->csrf->enabled);
+        self::assertSame(32, $config->csrf->tokenLength);
+        self::assertSame('X-CSRF-Token', $config->csrf->headerName);
+        self::assertSame('_csrf_token', $config->csrf->formFieldName);
+
+        self::assertSame([], $config->headers->headers);
+
+        self::assertTrue($config->rateLimit->enabled);
+        self::assertSame(60, $config->rateLimit->defaultLimit);
+        self::assertSame(60, $config->rateLimit->defaultWindow);
+    }
+
+    #[Test]
+    public function envOverridesSessionCookieName(): void
+    {
+        putenv('SESSION_COOKIE_NAME=ENV_SESSION');
+
+        $environment = Environment::load();
+        $config = SecurityConfig::fromArray([
+            'session' => ['cookie_name' => 'FILE_SESSION'],
+        ], $environment);
+
+        self::assertSame('ENV_SESSION', $config->session->cookieName);
+    }
+
+    #[Test]
+    public function securityHeadersConfigFromArray(): void
+    {
+        $config = SecurityHeadersConfig::fromArray([
+            'Strict-Transport-Security' => 'max-age=31536000; includeSubDomains',
+            'Content-Security-Policy' => "default-src 'self'",
+        ]);
+
+        self::assertCount(2, $config->headers);
+        self::assertSame('max-age=31536000; includeSubDomains', $config->headers['Strict-Transport-Security']);
+    }
+}

--- a/tests/Unit/Core/VersionTest.php
+++ b/tests/Unit/Core/VersionTest.php
@@ -56,11 +56,11 @@ final class VersionTest extends TestCase
     }
 
     #[Test]
-    public function currentVersionIs040(): void
+    public function currentVersionIs060(): void
     {
         self::assertSame(0, Version::MAJOR);
-        self::assertSame(4, Version::MINOR);
+        self::assertSame(6, Version::MINOR);
         self::assertSame(0, Version::PATCH);
-        self::assertSame('0.4.0', Version::short());
+        self::assertSame('0.6.0', Version::short());
     }
 }

--- a/tests/Unit/Observability/Log/LoggerTest.php
+++ b/tests/Unit/Observability/Log/LoggerTest.php
@@ -137,6 +137,11 @@ final class LoggerTest extends TestCase
                     stream: 'php://stderr',
                 ),
             ],
+            audit: new \Pulsar\Config\AuditConfig(
+                enabled: false,
+                logPath: 'var/logs/audit.jsonl',
+                events: [],
+            ),
         );
 
         $logger = Logger::fromConfig($config);

--- a/tests/Unit/Security/Audit/AuditEntryTest.php
+++ b/tests/Unit/Security/Audit/AuditEntryTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Audit;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Security\Audit\AuditEntry;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditOutcome;
+
+#[CoversClass(AuditEntry::class)]
+final class AuditEntryTest extends TestCase
+{
+    private string $auditKey;
+
+    protected function setUp(): void
+    {
+        $this->auditKey = random_bytes(32);
+    }
+
+    #[Test]
+    public function createProducesValidEntry(): void
+    {
+        $timestamp = new DateTimeImmutable('2025-01-15T10:30:00.000000+00:00');
+
+        $entry = AuditEntry::create(
+            id: 'entry-001',
+            event: AuditEvent::Authentication,
+            outcome: AuditOutcome::Success,
+            actor: 'user@example.com',
+            action: 'login',
+            resource: '/auth/login',
+            timestamp: $timestamp,
+            metadata: ['ip' => '192.168.1.1'],
+            previousHmac: 'seed_hmac_value',
+            auditKey: $this->auditKey,
+        );
+
+        self::assertSame('entry-001', $entry->id);
+        self::assertSame(AuditEvent::Authentication, $entry->event);
+        self::assertSame(AuditOutcome::Success, $entry->outcome);
+        self::assertSame('user@example.com', $entry->actor);
+        self::assertSame('login', $entry->action);
+        self::assertSame('/auth/login', $entry->resource);
+        self::assertSame($timestamp, $entry->timestamp);
+        self::assertSame(['ip' => '192.168.1.1'], $entry->metadata);
+        self::assertSame('seed_hmac_value', $entry->previousHmac);
+        self::assertNotEmpty($entry->hmac);
+    }
+
+    #[Test]
+    public function verifyReturnsTrueForUntamperedEntry(): void
+    {
+        $entry = AuditEntry::create(
+            id: 'entry-002',
+            event: AuditEvent::Authorization,
+            outcome: AuditOutcome::Denied,
+            actor: 'admin',
+            action: 'access_restricted',
+            resource: '/admin/settings',
+            timestamp: new DateTimeImmutable(),
+            metadata: [],
+            previousHmac: 'prev',
+            auditKey: $this->auditKey,
+        );
+
+        self::assertTrue($entry->verify($this->auditKey));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForWrongKey(): void
+    {
+        $entry = AuditEntry::create(
+            id: 'entry-003',
+            event: AuditEvent::DataAccess,
+            outcome: AuditOutcome::Success,
+            actor: 'service',
+            action: 'read',
+            resource: '/api/users',
+            timestamp: new DateTimeImmutable(),
+            metadata: [],
+            previousHmac: 'prev',
+            auditKey: $this->auditKey,
+        );
+
+        $wrongKey = random_bytes(32);
+
+        self::assertFalse($entry->verify($wrongKey));
+    }
+
+    #[Test]
+    public function toArrayContainsAllFields(): void
+    {
+        $timestamp = new DateTimeImmutable('2025-06-01T12:00:00.000000+00:00');
+
+        $entry = AuditEntry::create(
+            id: 'entry-004',
+            event: AuditEvent::ConfigurationChange,
+            outcome: AuditOutcome::Success,
+            actor: 'admin',
+            action: 'update_setting',
+            resource: 'app.debug',
+            timestamp: $timestamp,
+            metadata: ['old' => 'false', 'new' => 'true'],
+            previousHmac: 'chain_previous',
+            auditKey: $this->auditKey,
+        );
+
+        $array = $entry->toArray();
+
+        self::assertSame('entry-004', $array['id']);
+        self::assertSame('configuration_change', $array['event']);
+        self::assertSame('success', $array['outcome']);
+        self::assertSame('admin', $array['actor']);
+        self::assertSame('update_setting', $array['action']);
+        self::assertSame('app.debug', $array['resource']);
+        self::assertSame('2025-06-01T12:00:00.000000+00:00', $array['timestamp']);
+        self::assertSame(['old' => 'false', 'new' => 'true'], $array['metadata']);
+        self::assertSame('chain_previous', $array['previous_hmac']);
+        self::assertNotEmpty($array['hmac']);
+    }
+
+    #[Test]
+    public function hmacChainEnforcesOrder(): void
+    {
+        $entry1 = AuditEntry::create(
+            id: 'e1',
+            event: AuditEvent::Authentication,
+            outcome: AuditOutcome::Success,
+            actor: 'user1',
+            action: 'login',
+            resource: '',
+            timestamp: new DateTimeImmutable(),
+            metadata: [],
+            previousHmac: 'seed',
+            auditKey: $this->auditKey,
+        );
+
+        $entry2 = AuditEntry::create(
+            id: 'e2',
+            event: AuditEvent::DataAccess,
+            outcome: AuditOutcome::Success,
+            actor: 'user1',
+            action: 'read',
+            resource: '/data',
+            timestamp: new DateTimeImmutable(),
+            metadata: [],
+            previousHmac: $entry1->hmac,
+            auditKey: $this->auditKey,
+        );
+
+        // Both entries verify individually
+        self::assertTrue($entry1->verify($this->auditKey));
+        self::assertTrue($entry2->verify($this->auditKey));
+
+        // entry2's previousHmac must match entry1's hmac
+        self::assertSame($entry1->hmac, $entry2->previousHmac);
+    }
+
+    #[Test]
+    public function differentMetadataProducesDifferentHmac(): void
+    {
+        $base = [
+            'id' => 'same-id',
+            'event' => AuditEvent::Authentication,
+            'outcome' => AuditOutcome::Success,
+            'actor' => 'user',
+            'action' => 'login',
+            'resource' => '',
+            'timestamp' => new DateTimeImmutable('2025-01-01T00:00:00.000000+00:00'),
+            'previousHmac' => 'seed',
+            'auditKey' => $this->auditKey,
+        ];
+
+        $entry1 = AuditEntry::create(...[...$base, 'metadata' => ['key' => 'value1']]);
+        $entry2 = AuditEntry::create(...[...$base, 'metadata' => ['key' => 'value2']]);
+
+        self::assertNotSame($entry1->hmac, $entry2->hmac);
+    }
+}

--- a/tests/Unit/Security/Audit/AuditFileSinkTest.php
+++ b/tests/Unit/Security/Audit/AuditFileSinkTest.php
@@ -1,0 +1,149 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Audit;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Security\Audit\AuditEntry;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditFileSink;
+use Pulsar\Security\Audit\AuditOutcome;
+
+#[CoversClass(AuditFileSink::class)]
+final class AuditFileSinkTest extends TestCase
+{
+    private string $tempDir;
+    private string $auditKey;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/pulsar_audit_test_' . uniqid();
+        mkdir($this->tempDir, 0o775, true);
+        $this->auditKey = random_bytes(32);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->cleanDir($this->tempDir);
+    }
+
+    private function cleanDir(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+        $items = scandir($dir);
+        if ($items !== false) {
+            foreach ($items as $item) {
+                if ($item === '.' || $item === '..') {
+                    continue;
+                }
+                $path = $dir . DIRECTORY_SEPARATOR . $item;
+                if (is_dir($path)) {
+                    $this->cleanDir($path);
+                } else {
+                    unlink($path);
+                }
+            }
+        }
+        rmdir($dir);
+    }
+
+    private function createEntry(string $id = 'test-entry'): AuditEntry
+    {
+        return AuditEntry::create(
+            id: $id,
+            event: AuditEvent::Authentication,
+            outcome: AuditOutcome::Success,
+            actor: 'user@test.com',
+            action: 'login',
+            resource: '/auth',
+            timestamp: new DateTimeImmutable('2025-01-15T10:00:00.000000+00:00'),
+            metadata: ['ip' => '127.0.0.1'],
+            previousHmac: 'seed',
+            auditKey: $this->auditKey,
+        );
+    }
+
+    #[Test]
+    public function writeCreatesFileAndAppendsJsonLine(): void
+    {
+        $logPath = $this->tempDir . '/audit.jsonl';
+        $sink = new AuditFileSink($logPath);
+
+        $entry = $this->createEntry();
+        $sink->write($entry);
+
+        self::assertFileExists($logPath);
+
+        $contents = file_get_contents($logPath);
+        self::assertIsString($contents);
+
+        $lines = array_filter(explode("\n", $contents));
+        self::assertCount(1, $lines);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($lines[0], true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('test-entry', $decoded['id']);
+        self::assertSame('authentication', $decoded['event']);
+    }
+
+    #[Test]
+    public function writeAppendsMultipleEntries(): void
+    {
+        $logPath = $this->tempDir . '/audit.jsonl';
+        $sink = new AuditFileSink($logPath);
+
+        $sink->write($this->createEntry('entry-1'));
+        $sink->write($this->createEntry('entry-2'));
+        $sink->write($this->createEntry('entry-3'));
+
+        $contents = file_get_contents($logPath);
+        self::assertIsString($contents);
+
+        $lines = array_filter(explode("\n", $contents));
+        self::assertCount(3, $lines);
+    }
+
+    #[Test]
+    public function writeCreatesDirectoryIfMissing(): void
+    {
+        $logPath = $this->tempDir . '/nested/dir/audit.jsonl';
+        $sink = new AuditFileSink($logPath);
+
+        $sink->write($this->createEntry());
+
+        self::assertFileExists($logPath);
+        self::assertDirectoryExists($this->tempDir . '/nested/dir');
+    }
+
+    #[Test]
+    public function writtenEntriesAreValidJson(): void
+    {
+        $logPath = $this->tempDir . '/audit.jsonl';
+        $sink = new AuditFileSink($logPath);
+
+        $entry = $this->createEntry();
+        $sink->write($entry);
+
+        $line = trim((string) file_get_contents($logPath));
+
+        /** @var array<string, mixed> $data */
+        $data = json_decode($line, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('id', $data);
+        self::assertArrayHasKey('event', $data);
+        self::assertArrayHasKey('outcome', $data);
+        self::assertArrayHasKey('actor', $data);
+        self::assertArrayHasKey('action', $data);
+        self::assertArrayHasKey('resource', $data);
+        self::assertArrayHasKey('timestamp', $data);
+        self::assertArrayHasKey('metadata', $data);
+        self::assertArrayHasKey('previous_hmac', $data);
+        self::assertArrayHasKey('hmac', $data);
+    }
+}

--- a/tests/Unit/Security/Audit/AuditLoggerTest.php
+++ b/tests/Unit/Security/Audit/AuditLoggerTest.php
@@ -1,0 +1,162 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Audit;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Security\Audit\AuditEntry;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditLogger;
+use Pulsar\Security\Audit\AuditOutcome;
+use Pulsar\Security\Audit\AuditSinkInterface;
+use Pulsar\Security\Crypto\Hmac;
+
+#[CoversClass(AuditLogger::class)]
+final class AuditLoggerTest extends TestCase
+{
+    private string $auditKey;
+
+    protected function setUp(): void
+    {
+        $this->auditKey = random_bytes(32);
+    }
+
+    #[Test]
+    public function initialPreviousHmacIsSeedHmac(): void
+    {
+        $sink = $this->createMock(AuditSinkInterface::class);
+        $logger = new AuditLogger($sink, $this->auditKey);
+
+        $expected = Hmac::computeHex('PULSAR_AUDIT_SEED', $this->auditKey);
+
+        self::assertSame($expected, $logger->previousHmac());
+    }
+
+    #[Test]
+    public function logWritesEntryToSink(): void
+    {
+        $sink = $this->createMock(AuditSinkInterface::class);
+        $sink->expects($this->once())
+            ->method('write')
+            ->with($this->isInstanceOf(AuditEntry::class));
+
+        $logger = new AuditLogger($sink, $this->auditKey);
+
+        $entry = $logger->log(
+            event: AuditEvent::Authentication,
+            outcome: AuditOutcome::Success,
+            actor: 'user@example.com',
+            action: 'login',
+        );
+
+        self::assertInstanceOf(AuditEntry::class, $entry);
+    }
+
+    #[Test]
+    public function logAdvancesChainState(): void
+    {
+        $sink = $this->createMock(AuditSinkInterface::class);
+        $logger = new AuditLogger($sink, $this->auditKey);
+
+        $seedHmac = $logger->previousHmac();
+
+        $entry1 = $logger->log(
+            event: AuditEvent::Authentication,
+            outcome: AuditOutcome::Success,
+            actor: 'user1',
+            action: 'login',
+        );
+
+        // previousHmac should now be entry1's hmac
+        self::assertSame($entry1->hmac, $logger->previousHmac());
+        self::assertNotSame($seedHmac, $logger->previousHmac());
+
+        $entry2 = $logger->log(
+            event: AuditEvent::DataAccess,
+            outcome: AuditOutcome::Success,
+            actor: 'user1',
+            action: 'read',
+            resource: '/api/data',
+        );
+
+        // entry2's previousHmac is entry1's hmac
+        self::assertSame($entry1->hmac, $entry2->previousHmac);
+        self::assertSame($entry2->hmac, $logger->previousHmac());
+    }
+
+    #[Test]
+    public function loggedEntriesVerifyCorrectly(): void
+    {
+        $sink = $this->createMock(AuditSinkInterface::class);
+        $logger = new AuditLogger($sink, $this->auditKey);
+
+        $entry = $logger->log(
+            event: AuditEvent::Authorization,
+            outcome: AuditOutcome::Denied,
+            actor: 'attacker',
+            action: 'access_admin',
+            resource: '/admin',
+            metadata: ['ip' => '10.0.0.1'],
+        );
+
+        self::assertTrue($entry->verify($this->auditKey));
+    }
+
+    #[Test]
+    public function logPopulatesAllFields(): void
+    {
+        $sink = $this->createMock(AuditSinkInterface::class);
+        $logger = new AuditLogger($sink, $this->auditKey);
+
+        $entry = $logger->log(
+            event: AuditEvent::ConfigurationChange,
+            outcome: AuditOutcome::Success,
+            actor: 'admin',
+            action: 'update_config',
+            resource: 'security.csrf.enabled',
+            metadata: ['old' => 'true', 'new' => 'false'],
+        );
+
+        self::assertNotEmpty($entry->id);
+        self::assertSame(AuditEvent::ConfigurationChange, $entry->event);
+        self::assertSame(AuditOutcome::Success, $entry->outcome);
+        self::assertSame('admin', $entry->actor);
+        self::assertSame('update_config', $entry->action);
+        self::assertSame('security.csrf.enabled', $entry->resource);
+        self::assertSame(['old' => 'true', 'new' => 'false'], $entry->metadata);
+    }
+
+    #[Test]
+    public function multipleEntriesFormValidChain(): void
+    {
+        $entries = [];
+        $sink = $this->createMock(AuditSinkInterface::class);
+        $logger = new AuditLogger($sink, $this->auditKey);
+
+        $seedHmac = $logger->previousHmac();
+
+        for ($i = 0; $i < 5; $i++) {
+            $entries[] = $logger->log(
+                event: AuditEvent::DataAccess,
+                outcome: AuditOutcome::Success,
+                actor: 'user',
+                action: 'read_' . $i,
+            );
+        }
+
+        // Verify chain integrity
+        self::assertSame($seedHmac, $entries[0]->previousHmac);
+
+        for ($i = 1; $i < 5; $i++) {
+            self::assertSame($entries[$i - 1]->hmac, $entries[$i]->previousHmac);
+        }
+
+        // All entries verify
+        foreach ($entries as $entry) {
+            self::assertTrue($entry->verify($this->auditKey));
+        }
+    }
+}

--- a/tests/Unit/Security/Crypto/EncryptorTest.php
+++ b/tests/Unit/Security/Crypto/EncryptorTest.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Crypto;
+
+use function chr;
+use function ord;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Security\Crypto\Encryptor;
+use Pulsar\Security\Crypto\MasterKey;
+use Pulsar\Security\Exception\SecurityException;
+
+use function strlen;
+
+#[CoversClass(Encryptor::class)]
+final class EncryptorTest extends TestCase
+{
+    private Encryptor $encryptor;
+
+    protected function setUp(): void
+    {
+        $hex = sodium_bin2hex(random_bytes(32));
+        $masterKey = MasterKey::fromHex($hex);
+        $this->encryptor = new Encryptor($masterKey);
+    }
+
+    #[Test]
+    public function encryptAndDecryptRoundTrip(): void
+    {
+        $plaintext = 'The quick brown fox jumps over the lazy dog';
+
+        $ciphertext = $this->encryptor->encrypt($plaintext);
+        $decrypted = $this->encryptor->decrypt($ciphertext);
+
+        self::assertSame($plaintext, $decrypted);
+    }
+
+    #[Test]
+    public function encryptProducesDifferentCiphertextEachTime(): void
+    {
+        $plaintext = 'same message';
+
+        $ct1 = $this->encryptor->encrypt($plaintext);
+        $ct2 = $this->encryptor->encrypt($plaintext);
+
+        self::assertNotSame($ct1, $ct2);
+    }
+
+    #[Test]
+    public function decryptFailsForTamperedCiphertext(): void
+    {
+        $ciphertext = $this->encryptor->encrypt('sensitive');
+
+        // Tamper with the ciphertext
+        $decoded = base64_decode($ciphertext, true);
+        self::assertIsString($decoded);
+
+        $tampered = $decoded;
+        $tampered[strlen($tampered) - 1] = chr(ord($tampered[strlen($tampered) - 1]) ^ 0xFF);
+
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('tampered');
+
+        $this->encryptor->decrypt(base64_encode($tampered));
+    }
+
+    #[Test]
+    public function decryptFailsForInvalidBase64(): void
+    {
+        $this->expectException(SecurityException::class);
+
+        $this->encryptor->decrypt('not-valid-base64!!!');
+    }
+
+    #[Test]
+    public function decryptFailsForTruncatedCiphertext(): void
+    {
+        $this->expectException(SecurityException::class);
+
+        $this->encryptor->decrypt(base64_encode('short'));
+    }
+
+    #[Test]
+    public function differentMasterKeyCannotDecrypt(): void
+    {
+        $ciphertext = $this->encryptor->encrypt('secret');
+
+        $otherHex = sodium_bin2hex(random_bytes(32));
+        $otherKey = MasterKey::fromHex($otherHex);
+        $otherEncryptor = new Encryptor($otherKey);
+
+        $this->expectException(SecurityException::class);
+
+        $otherEncryptor->decrypt($ciphertext);
+    }
+
+    #[Test]
+    public function encryptHandlesEmptyString(): void
+    {
+        $ciphertext = $this->encryptor->encrypt('');
+        $decrypted = $this->encryptor->decrypt($ciphertext);
+
+        self::assertSame('', $decrypted);
+    }
+
+    #[Test]
+    public function encryptHandlesLargePayload(): void
+    {
+        $plaintext = str_repeat('A', 100_000);
+
+        $ciphertext = $this->encryptor->encrypt($plaintext);
+        $decrypted = $this->encryptor->decrypt($ciphertext);
+
+        self::assertSame($plaintext, $decrypted);
+    }
+
+    #[Test]
+    public function debugInfoRedactsKey(): void
+    {
+        $debug = $this->encryptor->__debugInfo();
+
+        self::assertSame('[REDACTED]', $debug['key']);
+    }
+}

--- a/tests/Unit/Security/Crypto/HmacTest.php
+++ b/tests/Unit/Security/Crypto/HmacTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Crypto;
+
+use InvalidArgumentException;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Security\Crypto\Hmac;
+
+use function strlen;
+
+#[CoversClass(Hmac::class)]
+final class HmacTest extends TestCase
+{
+    private string $key;
+
+    protected function setUp(): void
+    {
+        // 32-byte key (meets minimum BLAKE2b requirement)
+        $this->key = random_bytes(32);
+    }
+
+    #[Test]
+    public function computeHexReturnsDeterministicHash(): void
+    {
+        $hash1 = Hmac::computeHex('hello', $this->key);
+        $hash2 = Hmac::computeHex('hello', $this->key);
+
+        self::assertSame($hash1, $hash2);
+        self::assertSame(64, strlen($hash1)); // 32 bytes = 64 hex chars
+    }
+
+    #[Test]
+    public function differentMessagesDifferentHashes(): void
+    {
+        $hash1 = Hmac::computeHex('hello', $this->key);
+        $hash2 = Hmac::computeHex('world', $this->key);
+
+        self::assertNotSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function differentKeysDifferentHashes(): void
+    {
+        $key2 = random_bytes(32);
+
+        $hash1 = Hmac::computeHex('hello', $this->key);
+        $hash2 = Hmac::computeHex('hello', $key2);
+
+        self::assertNotSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function verifyHexReturnsTrueForValidHmac(): void
+    {
+        $hash = Hmac::computeHex('test message', $this->key);
+
+        self::assertTrue(Hmac::verifyHex('test message', $hash, $this->key));
+    }
+
+    #[Test]
+    public function verifyHexReturnsFalseForInvalidHmac(): void
+    {
+        self::assertFalse(Hmac::verifyHex('test message', str_repeat('a', 64), $this->key));
+    }
+
+    #[Test]
+    public function verifyHexReturnsFalseForTamperedMessage(): void
+    {
+        $hash = Hmac::computeHex('original', $this->key);
+
+        self::assertFalse(Hmac::verifyHex('tampered', $hash, $this->key));
+    }
+
+    #[Test]
+    public function computeReturnsRawBytes(): void
+    {
+        $raw = Hmac::compute('hello', $this->key);
+
+        self::assertSame(32, strlen($raw)); // BLAKE2b-256 = 32 bytes
+    }
+
+    #[Test]
+    public function verifyReturnsTrueForValidRawHmac(): void
+    {
+        $raw = Hmac::compute('test', $this->key);
+
+        self::assertTrue(Hmac::verify('test', $raw, $this->key));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForInvalidRawHmac(): void
+    {
+        self::assertFalse(Hmac::verify('test', random_bytes(32), $this->key));
+    }
+
+    #[Test]
+    public function throwsForKeyTooShort(): void
+    {
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('HMAC key must be at least');
+
+        Hmac::computeHex('message', 'short');
+    }
+}

--- a/tests/Unit/Security/Crypto/MasterKeyTest.php
+++ b/tests/Unit/Security/Crypto/MasterKeyTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Crypto;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Security\Crypto\MasterKey;
+use Pulsar\Security\Exception\SecurityException;
+
+use function strlen;
+
+#[CoversClass(MasterKey::class)]
+final class MasterKeyTest extends TestCase
+{
+    private string $validHex;
+
+    protected function setUp(): void
+    {
+        // 32-byte key hex-encoded
+        $this->validHex = sodium_bin2hex(random_bytes(32));
+    }
+
+    #[Test]
+    public function fromHexCreatesInstance(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        self::assertInstanceOf(MasterKey::class, $masterKey);
+    }
+
+    #[Test]
+    public function fromHexThrowsForInvalidLength(): void
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('expected');
+
+        MasterKey::fromHex(sodium_bin2hex(random_bytes(16))); // 16 bytes, need 32
+    }
+
+    #[Test]
+    public function deriveSubKeyReturnsDeterministicOutput(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        $subKey1 = $masterKey->deriveSubKey(1, 'encrypt_');
+        $subKey2 = $masterKey->deriveSubKey(1, 'encrypt_');
+
+        self::assertSame($subKey1, $subKey2);
+    }
+
+    #[Test]
+    public function differentSubKeyIdsDifferentKeys(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        $subKey1 = $masterKey->deriveSubKey(1, 'encrypt_');
+        $subKey2 = $masterKey->deriveSubKey(2, 'encrypt_');
+
+        self::assertNotSame($subKey1, $subKey2);
+    }
+
+    #[Test]
+    public function differentContextsDifferentKeys(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        $subKey1 = $masterKey->deriveSubKey(1, 'encrypt_');
+        $subKey2 = $masterKey->deriveSubKey(1, 'audit___');
+
+        self::assertNotSame($subKey1, $subKey2);
+    }
+
+    #[Test]
+    public function deriveSubKeyHexReturnsHexString(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        $hex = $masterKey->deriveSubKeyHex(1, 'encrypt_');
+
+        // 32-byte key = 64 hex chars
+        self::assertSame(64, strlen($hex));
+        self::assertMatchesRegularExpression('/^[0-9a-f]+$/', $hex);
+    }
+
+    #[Test]
+    public function contextNormalizationPadShort(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        // Short context should be padded — no error
+        $subKey = $masterKey->deriveSubKey(1, 'ab');
+
+        self::assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, strlen($subKey));
+    }
+
+    #[Test]
+    public function contextNormalizationTruncateLong(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        // Long context should be truncated — no error
+        $subKey = $masterKey->deriveSubKey(1, 'this_is_a_very_long_context');
+
+        self::assertSame(SODIUM_CRYPTO_SECRETBOX_KEYBYTES, strlen($subKey));
+    }
+
+    #[Test]
+    public function debugInfoRedactsKey(): void
+    {
+        $masterKey = MasterKey::fromHex($this->validHex);
+
+        $debug = $masterKey->__debugInfo();
+
+        self::assertSame('[REDACTED]', $debug['rawKey']);
+    }
+
+    #[Test]
+    public function fromEnvironmentThrowsWhenMissing(): void
+    {
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('PULSAR_MASTER_KEY');
+
+        MasterKey::fromEnvironment('');
+    }
+
+    #[Test]
+    public function fromEnvironmentWithExplicitValue(): void
+    {
+        $masterKey = MasterKey::fromEnvironment($this->validHex);
+
+        self::assertInstanceOf(MasterKey::class, $masterKey);
+    }
+}

--- a/tests/Unit/Security/Csrf/CsrfMiddlewareTest.php
+++ b/tests/Unit/Security/Csrf/CsrfMiddlewareTest.php
@@ -1,0 +1,216 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Csrf;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\MockObject;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Security\Csrf\CsrfMiddleware;
+use Pulsar\Security\Csrf\CsrfTokenManagerInterface;
+
+#[CoversClass(CsrfMiddleware::class)]
+final class CsrfMiddlewareTest extends TestCase
+{
+    private string $validToken;
+    private CsrfConfig $config;
+
+    /** @var CsrfTokenManagerInterface&MockObject */
+    private CsrfTokenManagerInterface $tokenManager;
+
+    protected function setUp(): void
+    {
+        $this->validToken = bin2hex(random_bytes(32));
+
+        $this->config = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $this->tokenManager = $this->createMock(CsrfTokenManagerInterface::class);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     * @param array<string, mixed>  $post
+     */
+    private function createRequest(
+        Method $method = Method::GET,
+        string $path = '/',
+        array $headers = [],
+        array $post = [],
+    ): Request {
+        return new Request(
+            method: $method,
+            uri: $path,
+            path: $path,
+            queryString: '',
+            headers: new HeaderBag($headers),
+            body: '',
+            post: $post,
+        );
+    }
+
+    private function successHandler(): callable
+    {
+        return fn(Request $r): Response => Response::text('OK');
+    }
+
+    #[Test]
+    public function safeMethodsPassThrough(): void
+    {
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        foreach ([Method::GET, Method::HEAD, Method::OPTIONS] as $method) {
+            $request = $this->createRequest($method);
+            $response = $middleware->process($request, $this->successHandler());
+
+            self::assertSame(ResponseStatus::OK, $response->status, "Failed for method: {$method->value}");
+        }
+    }
+
+    #[Test]
+    public function postWithValidHeaderTokenPasses(): void
+    {
+        $this->tokenManager->method('validate')
+            ->with($this->validToken)
+            ->willReturn(true);
+
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        $request = $this->createRequest(
+            Method::POST,
+            '/submit',
+            headers: ['X-CSRF-Token' => $this->validToken],
+        );
+
+        $response = $middleware->process($request, $this->successHandler());
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+    }
+
+    #[Test]
+    public function postWithValidFormFieldTokenPasses(): void
+    {
+        $this->tokenManager->method('validate')
+            ->with($this->validToken)
+            ->willReturn(true);
+
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        $request = $this->createRequest(
+            Method::POST,
+            '/submit',
+            post: ['_csrf_token' => $this->validToken],
+        );
+
+        $response = $middleware->process($request, $this->successHandler());
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+    }
+
+    #[Test]
+    public function postWithoutTokenReturns403(): void
+    {
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        $request = $this->createRequest(Method::POST, '/submit');
+        $response = $middleware->process($request, $this->successHandler());
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+
+        /** @var array{error: string, message: string} $body */
+        $body = json_decode($response->body, true, 512, JSON_THROW_ON_ERROR);
+        self::assertSame('Forbidden', $body['error']);
+        self::assertStringContainsString('missing', $body['message']);
+    }
+
+    #[Test]
+    public function postWithInvalidTokenReturns403(): void
+    {
+        $this->tokenManager->method('validate')
+            ->willReturn(false);
+
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        $request = $this->createRequest(
+            Method::POST,
+            '/submit',
+            headers: ['X-CSRF-Token' => 'wrong_token'],
+        );
+
+        $response = $middleware->process($request, $this->successHandler());
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+
+        /** @var array{error: string, message: string} $body */
+        $body = json_decode($response->body, true, 512, JSON_THROW_ON_ERROR);
+        self::assertStringContainsString('invalid', $body['message']);
+    }
+
+    #[Test]
+    public function putAndPatchAndDeleteRequireCsrf(): void
+    {
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        foreach ([Method::PUT, Method::PATCH, Method::DELETE] as $method) {
+            $request = $this->createRequest($method, '/resource');
+            $response = $middleware->process($request, $this->successHandler());
+
+            self::assertSame(
+                ResponseStatus::Forbidden,
+                $response->status,
+                "Expected 403 for method: {$method->value}",
+            );
+        }
+    }
+
+    #[Test]
+    public function disabledCsrfSkipsValidation(): void
+    {
+        $config = new CsrfConfig(
+            enabled: false,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $middleware = new CsrfMiddleware($this->tokenManager, $config);
+
+        $request = $this->createRequest(Method::POST, '/submit');
+        $response = $middleware->process($request, $this->successHandler());
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+    }
+
+    #[Test]
+    public function headerTokenTakesPrecedenceOverFormField(): void
+    {
+        $this->tokenManager->method('validate')
+            ->with($this->validToken)
+            ->willReturn(true);
+
+        $middleware = new CsrfMiddleware($this->tokenManager, $this->config);
+
+        $request = $this->createRequest(
+            Method::POST,
+            '/submit',
+            headers: ['X-CSRF-Token' => $this->validToken],
+            post: ['_csrf_token' => 'different_token'],
+        );
+
+        $response = $middleware->process($request, $this->successHandler());
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+    }
+}

--- a/tests/Unit/Security/Csrf/CsrfTokenManagerTest.php
+++ b/tests/Unit/Security/Csrf/CsrfTokenManagerTest.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Csrf;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Security\Csrf\CsrfTokenManager;
+use Pulsar\Security\Session\SessionInterface;
+
+use function strlen;
+
+#[CoversClass(CsrfTokenManager::class)]
+final class CsrfTokenManagerTest extends TestCase
+{
+    protected function setUp(): void {}
+
+
+    #[Test]
+    public function generateProducesTokenOfCorrectLength(): void
+    {
+        // We need to mock session since we can't start a real session in PHPUnit
+        $session = $this->createSessionMock();
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+        $token = $manager->generate();
+
+        // 32 random bytes = 64 hex chars
+        self::assertSame(64, strlen($token));
+        self::assertMatchesRegularExpression('/^[0-9a-f]+$/', $token);
+    }
+
+    #[Test]
+    public function getTokenGeneratesIfNoneExists(): void
+    {
+        $session = $this->createSessionMock(null);
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+        $token = $manager->getToken();
+
+        self::assertSame(64, strlen($token));
+    }
+
+    #[Test]
+    public function getTokenReturnsExistingToken(): void
+    {
+        $existingToken = bin2hex(random_bytes(32));
+        $session = $this->createSessionMock($existingToken);
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+
+        self::assertSame($existingToken, $manager->getToken());
+    }
+
+    #[Test]
+    public function validateReturnsTrueForMatchingToken(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        $session = $this->createSessionMock($token);
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+
+        self::assertTrue($manager->validate($token));
+    }
+
+    #[Test]
+    public function validateReturnsFalseForMismatchedToken(): void
+    {
+        $token = bin2hex(random_bytes(32));
+        $session = $this->createSessionMock($token);
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+
+        self::assertFalse($manager->validate('wrong_token'));
+    }
+
+    #[Test]
+    public function validateReturnsFalseWhenNoTokenInSession(): void
+    {
+        $session = $this->createSessionMock(null);
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+
+        self::assertFalse($manager->validate('any_token'));
+    }
+
+    #[Test]
+    public function rotateGeneratesNewToken(): void
+    {
+        $oldToken = bin2hex(random_bytes(32));
+        $session = $this->createSessionMock($oldToken);
+        $csrfConfig = new CsrfConfig(
+            enabled: true,
+            tokenLength: 32,
+            headerName: 'X-CSRF-Token',
+            formFieldName: '_csrf_token',
+        );
+
+        $manager = new CsrfTokenManager($session, $csrfConfig);
+        $newToken = $manager->rotate();
+
+        self::assertSame(64, strlen($newToken));
+        // The new token should differ from the old (statistically guaranteed)
+        self::assertNotSame($oldToken, $newToken);
+    }
+
+    /**
+     * Create a mock SessionInterface that returns the given token for the CSRF session key.
+     */
+    private function createSessionMock(?string $storedToken = 'default'): SessionInterface
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->method('isStarted')->willReturn(true);
+
+        if ($storedToken === null) {
+            $session->method('get')
+                ->with('_csrf_token')
+                ->willReturn(null);
+        } else {
+            $session->method('get')
+                ->with('_csrf_token')
+                ->willReturn($storedToken === 'default' ? null : $storedToken);
+        }
+
+        return $session;
+    }
+}

--- a/tests/Unit/Security/Middleware/SecurityHeadersMiddlewareTest.php
+++ b/tests/Unit/Security/Middleware/SecurityHeadersMiddlewareTest.php
@@ -1,0 +1,101 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Security\Middleware\SecurityHeadersMiddleware;
+
+#[CoversClass(SecurityHeadersMiddleware::class)]
+final class SecurityHeadersMiddlewareTest extends TestCase
+{
+    private function createRequest(): Request
+    {
+        return new Request(
+            method: Method::GET,
+            uri: '/',
+            path: '/',
+            queryString: '',
+            headers: new HeaderBag(),
+            body: '',
+        );
+    }
+
+    #[Test]
+    public function addsConfiguredHeaders(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'X-Content-Type-Options' => 'nosniff',
+            'X-Frame-Options' => 'DENY',
+            'Referrer-Policy' => 'strict-origin-when-cross-origin',
+        ]);
+
+        $middleware = new SecurityHeadersMiddleware($config);
+
+        $handler = fn(Request $r): Response => Response::text('OK');
+        $response = $middleware->process($this->createRequest(), $handler);
+
+        self::assertSame('nosniff', $response->headers->first('X-Content-Type-Options'));
+        self::assertSame('DENY', $response->headers->first('X-Frame-Options'));
+        self::assertSame('strict-origin-when-cross-origin', $response->headers->first('Referrer-Policy'));
+    }
+
+    #[Test]
+    public function emptyConfigAddsNoHeaders(): void
+    {
+        $config = new SecurityHeadersConfig(headers: []);
+        $middleware = new SecurityHeadersMiddleware($config);
+
+        $handler = fn(Request $r): Response => Response::text('OK');
+        $response = $middleware->process($this->createRequest(), $handler);
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        // Only the Content-Type from Response::text()
+        self::assertSame('text/plain; charset=utf-8', $response->headers->first('Content-Type'));
+    }
+
+    #[Test]
+    public function preservesExistingResponseHeaders(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'X-Frame-Options' => 'DENY',
+        ]);
+
+        $middleware = new SecurityHeadersMiddleware($config);
+
+        $handler = fn(Request $r): Response => Response::json(['status' => 'ok']);
+        $response = $middleware->process($this->createRequest(), $handler);
+
+        // Original Content-Type preserved
+        self::assertStringContainsString('application/json', $response->headers->first('Content-Type') ?? '');
+        // Security header added
+        self::assertSame('DENY', $response->headers->first('X-Frame-Options'));
+    }
+
+    #[Test]
+    public function overridesHeaderIfAlreadySet(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'X-Frame-Options' => 'DENY',
+        ]);
+
+        $middleware = new SecurityHeadersMiddleware($config);
+
+        $handler = fn(Request $r): Response => Response::text('OK')
+            ->withHeader('X-Frame-Options', 'SAMEORIGIN');
+
+        $response = $middleware->process($this->createRequest(), $handler);
+
+        // Config value should override
+        self::assertSame('DENY', $response->headers->first('X-Frame-Options'));
+    }
+}

--- a/tests/Unit/Security/Session/SessionTest.php
+++ b/tests/Unit/Security/Session/SessionTest.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Security\Session;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\SessionConfig;
+use Pulsar\Security\Exception\SecurityException;
+use Pulsar\Security\Session\Session;
+
+/**
+ * Session tests are limited in PHPUnit because native session functions
+ * require headers not to have been sent. We test the logic paths that
+ * do not depend on actual session_start().
+ */
+#[CoversClass(Session::class)]
+final class SessionTest extends TestCase
+{
+    private SessionConfig $config;
+
+    protected function setUp(): void
+    {
+        $this->config = new SessionConfig(
+            cookieName: 'TEST_SESSION',
+            lifetime: 3600,
+            cookieHttpOnly: true,
+            cookieSecure: false,
+            cookieSameSite: 'Lax',
+            regenerateOnPrivilegeChange: true,
+        );
+    }
+
+    #[Test]
+    public function isNotStartedByDefault(): void
+    {
+        $session = new Session($this->config);
+
+        // In CLI, session_status() returns PHP_SESSION_NONE
+        self::assertFalse($session->isStarted());
+    }
+
+    #[Test]
+    public function getThrowsIfNotStarted(): void
+    {
+        $session = new Session($this->config);
+
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('not been started');
+
+        $session->get('key');
+    }
+
+    #[Test]
+    public function setThrowsIfNotStarted(): void
+    {
+        $session = new Session($this->config);
+
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('not been started');
+
+        $session->set('key', 'value');
+    }
+
+    #[Test]
+    public function hasThrowsIfNotStarted(): void
+    {
+        $session = new Session($this->config);
+
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('not been started');
+
+        $session->has('key');
+    }
+
+    #[Test]
+    public function removeThrowsIfNotStarted(): void
+    {
+        $session = new Session($this->config);
+
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('not been started');
+
+        $session->remove('key');
+    }
+
+    #[Test]
+    public function allThrowsIfNotStarted(): void
+    {
+        $session = new Session($this->config);
+
+        $this->expectException(SecurityException::class);
+        $this->expectExceptionMessage('not been started');
+
+        $session->all();
+    }
+
+    #[Test]
+    public function idReturnsEmptyStringWhenNoSession(): void
+    {
+        $session = new Session($this->config);
+
+        self::assertSame('', $session->id());
+    }
+
+    #[Test]
+    public function destroyWithoutActiveSessionDoesNotThrow(): void
+    {
+        $session = new Session($this->config);
+
+        // Should not throw even when no session is active
+        $session->destroy();
+
+        self::assertFalse($session->isStarted());
+    }
+}


### PR DESCRIPTION
## Summary

- Implement session hardening with secure cookie defaults (HttpOnly, Secure, SameSite, strict mode) via `Session` wrapping PHP native sessions
- Add CSRF protection using synchronizer token pattern with constant-time `hash_equals()` validation, configurable header/form field extraction
- Add `SecurityHeadersMiddleware` applying configurable HTTP security headers (X-Content-Type-Options, X-Frame-Options, Referrer-Policy, etc.) to every response
- Implement crypto primitives using pure libsodium: `Hmac` (BLAKE2b), `MasterKey` (KDF subkey derivation), `Encryptor` (XSalsa20-Poly1305 authenticated encryption)
- Build tamper-evident audit logging with HMAC-chained entries and append-only JSON Lines file sink
- Add `SecurityConfig` DTO composing `SessionConfig`, `CsrfConfig`, `SecurityHeadersConfig`, `RateLimitConfig`; loaded via `ConfigManager`
- Add `SecurityException` with factory methods for all security error cases
- Integrate security services into Kernel boot pipeline via `createSecurityServices()`
- Bump version from 0.5.0 to 0.6.0

## New Files (35)

**Config DTOs**: `AuditConfig`, `CsrfConfig`, `RateLimitConfig`, `SecurityConfig`, `SecurityHeadersConfig`, `SessionConfig`
**Security Exception**: `SecurityException` with 10 factory methods
**Crypto**: `Hmac`, `MasterKey`, `Encryptor`
**Session**: `SessionInterface`, `Session`
**CSRF**: `CsrfTokenManagerInterface`, `CsrfTokenManager`, `CsrfMiddleware`
**Security Headers**: `SecurityHeadersMiddleware`
**Audit**: `AuditEvent`, `AuditOutcome`, `AuditEntry`, `AuditSinkInterface`, `AuditFileSink`, `AuditLogger`
**Tests**: 12 test files (93 new tests)
**Docs**: `SECURITY_BASELINE.md`, `AUDIT_LOGGING.md`

## QA Results

- **Tests**: 655 pass, 1273 assertions (93 new security tests + existing tests)
- **PHPStan**: 0 errors at max level
- **Psalm**: 0 errors at error level 1
- **CS Check**: 0 violations (PER-CS2.0)

## Test plan

- [x] `composer test` — all 655 tests pass
- [x] `composer phpstan -- --memory-limit=512M` — 0 errors
- [x] `composer psalm` — 0 errors
- [x] `composer cs:check` — 0 violations
- [x] `vendor/bin/phpunit -c tools/php/phpunit.xml --filter Security` — all security tests pass
- [x] Verify CSRF middleware blocks POST/PUT/PATCH/DELETE without valid token (403)
- [x] Verify CSRF middleware passes safe methods (GET/HEAD/OPTIONS)
- [x] Verify security headers applied to all responses including error responses
- [x] Verify Encryptor round-trip and tamper detection
- [ ] Verify audit HMAC chain integrity (modifying any entry breaks chain)

## Linked Issues
Resolves #125
Resolves #133
Resolves #142
Resolves #154
Resolves #164
