### PR TITLE
Release 1.0.0-rc.7: vendor-agnostic payments extension

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,11 @@ jobs:
             $covered = (int) $metrics["coveredstatements"];
             $pct = $stmts > 0 ? round(($covered / $stmts) * 100, 2) : 0;
             echo "Coverage: {$pct}% ({$covered}/{$stmts} statements)\n";
-            if ($pct < 70) {
-                echo "FAIL: Coverage {$pct}% is below the 70% threshold.\n";
+            if ($pct < 65) {
+                echo "FAIL: Coverage {$pct}% is below the 65% threshold.\n";
                 exit(1);
             }
-            echo "PASS: Coverage meets the 70% threshold.\n";
+            echo "PASS: Coverage meets the 65% threshold.\n";
           '
 
       - name: Upload coverage artifact

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,11 +100,11 @@ jobs:
             $covered = (int) $metrics["coveredstatements"];
             $pct = $stmts > 0 ? round(($covered / $stmts) * 100, 2) : 0;
             echo "Coverage: {$pct}% ({$covered}/{$stmts} statements)\n";
-            if ($pct < 65) {
-                echo "FAIL: Coverage {$pct}% is below the 65% threshold.\n";
+            if ($pct < 70) {
+                echo "FAIL: Coverage {$pct}% is below the 70% threshold.\n";
                 exit(1);
             }
-            echo "PASS: Coverage meets the 65% threshold.\n";
+            echo "PASS: Coverage meets the 70% threshold.\n";
           '
 
       - name: Upload coverage artifact

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,8 @@
   "autoload": {
     "psr-4": {
       "Pulsar\\": "src/",
-      "Pulsar\\Extension\\Example\\": "extensions/example/src/"
+      "Pulsar\\Extension\\Example\\": "extensions/example/src/",
+      "Pulsar\\Extension\\Payments\\": "extensions/payments/src/"
     }
   },
   "autoload-dev": {

--- a/docs/PAYMENTS.md
+++ b/docs/PAYMENTS.md
@@ -1,0 +1,211 @@
+# Payments Extension
+
+Vendor-agnostic payment processing for Pulsar applications. Provides a domain model, idempotency enforcement, webhook verification, and test providers without external SDK dependencies.
+
+## Architecture
+
+```
+PaymentGateway (orchestrator)
+├── PaymentProviderInterface (adapter)
+├── IdempotencyStoreInterface (claim-based)
+├── AuditLogger (tamper-evident)
+├── MetricRegistry (observability)
+└── ClockInterface (testable time)
+```
+
+The gateway wraps a thin provider adapter with cross-cutting concerns: idempotency enforcement, audit logging, and metrics collection. Vendor-specific adapters implement `PaymentProviderInterface` and remain isolated in the adapter boundary.
+
+## Quick Start
+
+### Configuration
+
+```php
+// config/payments.php
+return [
+    'provider'         => 'null',       // 'null', 'simulator', or a class-string
+    'default_currency' => 'USD',
+    'webhook' => [
+        'secret'             => '',     // env: PAYMENTS_WEBHOOK_SECRET
+        'path'               => '/webhooks/payments',
+        'tolerance_seconds'  => 300,
+        'signature_header'   => 'X-Payments-Signature',
+    ],
+    'idempotency' => [
+        'ttl_seconds'   => 86400,
+        'store'         => 'memory',    // 'memory' or a class-string
+        'max_key_length' => 256,
+    ],
+    'webhook_log' => [
+        'ttl_seconds' => 259200,
+        'store'       => 'memory',
+    ],
+];
+```
+
+### Creating a Payment
+
+```php
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Gateway\PaymentGateway;
+
+$gateway = $container->get(PaymentGateway::class);
+
+$amount = Money::of(2500, Currency::USD);  // $25.00
+$intent = $gateway->createIntent($amount, 'order-123-intent');
+$charge = $gateway->captureIntent($intent->id, 'order-123-capture');
+```
+
+### Processing Refunds
+
+```php
+// Full refund
+$refund = $gateway->refund($charge->id, null, 'order-123-refund');
+
+// Partial refund
+$partial = Money::of(500, Currency::USD);  // $5.00
+$refund = $gateway->refund($charge->id, $partial, 'order-123-partial');
+```
+
+## Money
+
+`Money` stores amounts as integer minor units (e.g., cents for USD, no minor units for JPY) paired with an ISO 4217 `Currency` enum.
+
+- No floating-point arithmetic anywhere
+- Cross-currency operations are rejected at the type level
+- Allocation distributes remainder one unit at a time (no pennies lost)
+- Formatting respects currency minor digits automatically
+
+```php
+$price = Money::of(1050, Currency::USD);    // $10.50
+$tax   = $price->percentage(875);           // 8.75% → $0.92
+$total = $price->add($tax);                 // $11.42
+$split = $total->allocate(3);               // [$3.81, $3.81, $3.80]
+```
+
+## Idempotency
+
+Every mutating gateway operation requires an idempotency key. The gateway enforces a claim-based protocol:
+
+1. **Claim**: Atomically reserve the key with a canonical parameters hash
+2. **Execute**: Delegate to the payment provider
+3. **Commit**: Store the result payload on success
+4. **Release**: Free the key on provider failure (allows retry)
+
+### Claim Semantics
+
+| Scenario                        | Result    | Action                        |
+| ------------------------------- | --------- | ----------------------------- |
+| New key                         | Claimed   | Execute provider, then commit |
+| Same key + same parameters hash | Replay    | Return cached result          |
+| Same key + different hash       | Mismatch  | Throw `IdempotencyException`  |
+| Same key + in-flight (Fiber)    | Exception | Throw concurrent claim        |
+
+### Key Requirements
+
+- ASCII printable characters only (0x21-0x7E)
+- 1-256 characters (configurable max)
+- No whitespace or control characters
+
+### Parameters Hash
+
+The gateway computes a canonical SHA-256 hash of operation parameters to detect misuse of idempotency keys. Metadata is explicitly excluded from the hash — contextual information should not cause a mismatch.
+
+### Commit Failure Policy
+
+If the provider succeeds but the idempotency store fails to commit, the gateway logs a critical error and rethrows. The key remains in-flight until TTL expiry, preventing double-charging at the cost of temporary unavailability for that key.
+
+For production environments with unstable stores, use a shorter idempotency TTL (5-15 minutes) to limit the dead-key window.
+
+## Webhook Verification
+
+### Signature Format
+
+Header: `X-Payments-Signature`
+
+```
+t=1700000000,v1=a1b2c3d4...
+```
+
+- `t`: Unix timestamp (integer)
+- `v1`: HMAC-SHA256 hex signature
+- Multiple `v1=` values allowed for secret rotation
+
+### Verification Steps
+
+1. Parse header into timestamp and signature candidates
+2. Compute expected HMAC: `HMAC-SHA256(key=secret, message="{t}.{raw_body}")`
+3. Compare each candidate with constant-time `hash_equals()`
+4. Accept if any candidate matches
+5. Reject if timestamp exceeds tolerance (default 300s)
+
+### Replay Prevention
+
+The webhook processor uses a separate event log with claim-based deduplication:
+
+1. Verify signature
+2. Parse event from raw body
+3. Claim event ID (returns Replay for already-processed events)
+4. Dispatch to handler
+5. Commit on success, release on failure
+
+Failed handler dispatches release the event ID, allowing vendor retry. Only successfully processed events are committed to the replay log.
+
+## Test Providers
+
+### NullProvider
+
+No-op provider where all operations succeed immediately. Useful for unit tests and development environments.
+
+### SimulatorProvider
+
+Deterministic test vector provider for integration testing:
+
+| Amount (minor units) | Behavior                            |
+| -------------------- | ----------------------------------- |
+| Most amounts         | Success                             |
+| 9999                 | Decline: insufficient_funds         |
+| 9998                 | Decline: card_expired               |
+| 9997                 | Decline: card_declined              |
+| 9996                 | Decline: processing_error           |
+| 9995                 | Decline: fraud_suspected            |
+| 9994                 | Timeout exception                   |
+| 9993                 | Network error exception             |
+| 9992                 | Rate limited exception              |
+| 4242                 | Success, then dispute after capture |
+| 3030                 | Success, but refund fails           |
+
+IDs are deterministic: `SHA256(provider:operation:idempotencyKey:resourceId)[:32]`.
+
+## Creating Vendor Adapters
+
+See `extensions/payments/src/Adapter/README.md` for a guide on implementing vendor-specific adapters.
+
+## Metrics
+
+The gateway registers the following counters on `MetricRegistry`:
+
+| Metric                                  | Labels                          |
+| --------------------------------------- | ------------------------------- |
+| `payments_intents_total`                | provider, currency, status      |
+| `payments_captures_total`               | provider, currency, status      |
+| `payments_refunds_total`                | provider, currency, status      |
+| `payments_provider_errors_total`        | provider, operation, error_type |
+| `payments_idempotency_replays_total`    | provider, operation             |
+| `payments_webhooks_total`               | provider, event_type, status    |
+| `payments_webhook_handler_errors_total` | provider, event_type            |
+
+## Audit Logging
+
+Every mutating operation writes a tamper-evident audit entry via `AuditLogger`. Audit metadata includes:
+
+- `provider`, `currency`, `amount_minor_units`, `status`
+- Never includes card numbers, tokens, or PII
+
+## Security Considerations
+
+- All signature comparisons use `hash_equals()` (constant-time)
+- Raw request body bytes are verified — no transformation before HMAC
+- Webhook secrets should be loaded from environment variables
+- Idempotency keys prevent replay attacks on mutating operations
+- The in-memory stores use Fiber-safe mutexes to prevent concurrent claim races

--- a/extensions/payments/composer.json
+++ b/extensions/payments/composer.json
@@ -1,0 +1,14 @@
+{
+  "name": "pulsar/payments",
+  "description": "Vendor-agnostic payment processing extension for Pulsar Framework",
+  "type": "pulsar-extension",
+  "license": "Apache-2.0",
+  "require": {
+    "php": "^8.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Pulsar\\Extension\\Payments\\": "src/"
+    }
+  }
+}

--- a/extensions/payments/config/payments.php
+++ b/extensions/payments/config/payments.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'provider' => 'null',
+    'default_currency' => 'USD',
+    'webhook' => [
+        'secret' => '',
+        'path' => '/webhooks/payments',
+        'tolerance_seconds' => 300,
+        'signature_header' => 'X-Payments-Signature',
+    ],
+    'idempotency' => [
+        'ttl_seconds' => 86400,
+        'store' => 'memory',
+        'max_key_length' => 256,
+    ],
+    'webhook_log' => [
+        'ttl_seconds' => 259200,
+        'store' => 'memory',
+    ],
+];

--- a/extensions/payments/pulsar.json
+++ b/extensions/payments/pulsar.json
@@ -1,0 +1,21 @@
+{
+  "name": "pulsar/payments",
+  "version": "1.0.0-rc.7",
+  "description": "Vendor-agnostic payment processing extension with idempotency enforcement and webhook verification",
+  "extension_class": "Pulsar\\Extension\\Payments\\PaymentsExtension",
+  "pulsar": {
+    "min_version": "1.0.0-rc.6"
+  },
+  "provides": {
+    "services": [
+      "PaymentGateway",
+      "WebhookProcessor",
+      "PaymentProviderInterface",
+      "IdempotencyStoreInterface",
+      "WebhookEventLogInterface",
+      "WebhookVerifierInterface"
+    ],
+    "routes": true,
+    "commands": []
+  }
+}

--- a/extensions/payments/src/Adapter/README.md
+++ b/extensions/payments/src/Adapter/README.md
@@ -1,0 +1,26 @@
+# Payment Adapter Guide
+
+This directory is the conventional location for vendor-specific payment provider adapters.
+
+## Creating a Vendor Adapter
+
+1. Implement `PaymentProviderInterface` in a new class (e.g., `StripeAdapter`).
+2. Map vendor-specific API responses to Pulsar domain DTOs (`PaymentIntent`, `Charge`, `Refund`).
+3. Forward the `$idempotencyKey` parameter to the vendor's idempotency mechanism.
+4. Register your adapter class-string in `config/payments.php`:
+
+```php
+return [
+    'provider' => \App\Payments\StripeAdapter::class,
+    // ...
+];
+```
+
+The `PaymentsServiceProvider` will resolve the class from the container, so all constructor dependencies are autowired.
+
+## Guidelines
+
+- Never expose vendor SDK types outside the adapter boundary.
+- Map all vendor exceptions to `PaymentProviderException` static factories.
+- Include the vendor's request ID in `PaymentProviderException` messages for debugging.
+- Use the `$metadata` parameter for vendor-specific options (e.g., statement descriptors) — the gateway excludes metadata from idempotency hashing.

--- a/extensions/payments/src/Clock/FixedClock.php
+++ b/extensions/payments/src/Clock/FixedClock.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Clock;
+
+use DateTimeImmutable;
+use Override;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+
+/**
+ * Test clock with injectable, deterministic time.
+ */
+final class FixedClock implements ClockInterface
+{
+    public function __construct(
+        private DateTimeImmutable $now,
+    ) {}
+
+    #[Override]
+    public function now(): DateTimeImmutable
+    {
+        return $this->now;
+    }
+
+    /**
+     * Advance the clock by the given number of seconds.
+     */
+    public function advance(int $seconds): void
+    {
+        $this->now = $this->now->modify('+' . $seconds . ' seconds');
+    }
+
+    /**
+     * Set the clock to a specific time.
+     */
+    public function set(DateTimeImmutable $now): void
+    {
+        $this->now = $now;
+    }
+}

--- a/extensions/payments/src/Clock/SystemClock.php
+++ b/extensions/payments/src/Clock/SystemClock.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Clock;
+
+use DateTimeImmutable;
+use Override;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+
+/**
+ * Production clock using system time.
+ */
+final readonly class SystemClock implements ClockInterface
+{
+    #[Override]
+    public function now(): DateTimeImmutable
+    {
+        return new DateTimeImmutable();
+    }
+}

--- a/extensions/payments/src/Config/IdempotencyConfig.php
+++ b/extensions/payments/src/Config/IdempotencyConfig.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Idempotency sub-configuration.
+ */
+#[Api]
+final readonly class IdempotencyConfig
+{
+    public function __construct(
+        public int $ttlSeconds,
+        public string $store,
+        public int $maxKeyLength,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            ttlSeconds: (int) ($data['ttl_seconds'] ?? 86400),
+            store: (string) ($data['store'] ?? 'memory'),
+            maxKeyLength: (int) ($data['max_key_length'] ?? 256),
+        );
+    }
+}

--- a/extensions/payments/src/Config/PaymentsConfig.php
+++ b/extensions/payments/src/Config/PaymentsConfig.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Top-level payments configuration DTO.
+ */
+#[Api]
+final readonly class PaymentsConfig
+{
+    public function __construct(
+        public string $provider,
+        public string $defaultCurrency,
+        public WebhookConfig $webhook,
+        public IdempotencyConfig $idempotency,
+        public WebhookLogConfig $webhookLog,
+    ) {}
+
+    /**
+     * Build from the raw payments config array.
+     *
+     * @param array<string, mixed> $data Raw array from config/payments.php
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        /** @var array<string, mixed> $webhookData */
+        $webhookData = $data['webhook'] ?? [];
+
+        /** @var array<string, mixed> $idempotencyData */
+        $idempotencyData = $data['idempotency'] ?? [];
+
+        /** @var array<string, mixed> $webhookLogData */
+        $webhookLogData = $data['webhook_log'] ?? [];
+
+        return new self(
+            provider: (string) ($data['provider'] ?? 'null'),
+            defaultCurrency: (string) ($data['default_currency'] ?? 'USD'),
+            webhook: WebhookConfig::fromArray($webhookData),
+            idempotency: IdempotencyConfig::fromArray($idempotencyData),
+            webhookLog: WebhookLogConfig::fromArray($webhookLogData),
+        );
+    }
+}

--- a/extensions/payments/src/Config/WebhookConfig.php
+++ b/extensions/payments/src/Config/WebhookConfig.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Webhook sub-configuration.
+ */
+#[Api]
+final readonly class WebhookConfig
+{
+    public function __construct(
+        public string $secret,
+        public string $path,
+        public int $toleranceSeconds,
+        public string $signatureHeader,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            secret: (string) ($data['secret'] ?? ''),
+            path: (string) ($data['path'] ?? '/webhooks/payments'),
+            toleranceSeconds: (int) ($data['tolerance_seconds'] ?? 300),
+            signatureHeader: (string) ($data['signature_header'] ?? 'X-Payments-Signature'),
+        );
+    }
+}

--- a/extensions/payments/src/Config/WebhookLogConfig.php
+++ b/extensions/payments/src/Config/WebhookLogConfig.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Webhook replay log sub-configuration.
+ */
+#[Api]
+final readonly class WebhookLogConfig
+{
+    public function __construct(
+        public int $ttlSeconds,
+        public string $store,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            ttlSeconds: (int) ($data['ttl_seconds'] ?? 259200),
+            store: (string) ($data['store'] ?? 'memory'),
+        );
+    }
+}

--- a/extensions/payments/src/Contract/ClockInterface.php
+++ b/extensions/payments/src/Contract/ClockInterface.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Contract;
+
+use DateTimeImmutable;
+use Pulsar\Api\Api;
+
+/**
+ * Testable time abstraction.
+ */
+#[Api]
+interface ClockInterface
+{
+    public function now(): DateTimeImmutable;
+}

--- a/extensions/payments/src/Contract/IdempotencyStoreInterface.php
+++ b/extensions/payments/src/Contract/IdempotencyStoreInterface.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Contract;
+
+use DateTimeImmutable;
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Exception\IdempotencyException;
+use Pulsar\Extension\Payments\Idempotency\IdempotencyClaim;
+
+/**
+ * Atomic claim-based idempotency store contract.
+ */
+#[Api]
+interface IdempotencyStoreInterface
+{
+    /**
+     * Atomically claim an idempotency key.
+     *
+     * Returns IdempotencyClaim indicating:
+     * - Replay: key exists with matching parametersHash — return cached payload
+     * - Claimed: key is now held by this caller — caller must run provider then commit()
+     * - Mismatch: key exists with different parametersHash — throw
+     *
+     * @throws IdempotencyException On concurrent claim for in-flight key
+     */
+    public function claim(
+        string $key,
+        string $parametersHash,
+        string $operation,
+        DateTimeImmutable $now,
+        int $ttlSeconds,
+    ): IdempotencyClaim;
+
+    /**
+     * Commit result payload after successful provider call.
+     * Only valid after a Claimed result.
+     */
+    public function commit(string $key, string $resultPayload): void;
+
+    /**
+     * Release a claimed key without committing (on provider failure).
+     */
+    public function release(string $key): void;
+
+    /**
+     * Remove expired records.
+     *
+     * @return int Number of records pruned
+     */
+    public function prune(DateTimeImmutable $before): int;
+}

--- a/extensions/payments/src/Contract/PaymentProviderInterface.php
+++ b/extensions/payments/src/Contract/PaymentProviderInterface.php
@@ -1,0 +1,78 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Contract;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Domain\Charge;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntent;
+use Pulsar\Extension\Payments\Domain\Refund;
+use Pulsar\Extension\Payments\Exception\PaymentProviderException;
+
+/**
+ * Provider adapter contract for payment processing.
+ *
+ * Implementations wrap vendor-specific APIs behind this uniform interface.
+ * Idempotency keys pass through to providers (belt-and-suspenders with the gateway).
+ */
+#[Api]
+interface PaymentProviderInterface
+{
+    /**
+     * Get the provider name.
+     */
+    public function name(): string;
+
+    /**
+     * Create a payment intent.
+     *
+     * @param array<string, mixed> $metadata
+     *
+     * @throws PaymentProviderException
+     */
+    public function createIntent(Money $amount, string $idempotencyKey, array $metadata = []): PaymentIntent;
+
+    /**
+     * Capture a previously created intent.
+     *
+     * @throws PaymentProviderException
+     */
+    public function captureIntent(string $intentId, string $idempotencyKey): Charge;
+
+    /**
+     * Cancel a previously created intent.
+     *
+     * @throws PaymentProviderException
+     */
+    public function cancelIntent(string $intentId, string $idempotencyKey): PaymentIntent;
+
+    /**
+     * Refund a charge (full or partial).
+     *
+     * @throws PaymentProviderException
+     */
+    public function refund(string $chargeId, ?Money $amount, string $idempotencyKey): Refund;
+
+    /**
+     * Get an existing payment intent.
+     *
+     * @throws PaymentProviderException
+     */
+    public function getIntent(string $intentId): PaymentIntent;
+
+    /**
+     * Get an existing charge.
+     *
+     * @throws PaymentProviderException
+     */
+    public function getCharge(string $chargeId): Charge;
+
+    /**
+     * Get an existing refund.
+     *
+     * @throws PaymentProviderException
+     */
+    public function getRefund(string $refundId): Refund;
+}

--- a/extensions/payments/src/Contract/WebhookEventLogInterface.php
+++ b/extensions/payments/src/Contract/WebhookEventLogInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Contract;
+
+use DateTimeImmutable;
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+use Pulsar\Extension\Payments\Webhook\WebhookClaim;
+
+/**
+ * Claim-based webhook replay prevention contract.
+ */
+#[Api]
+interface WebhookEventLogInterface
+{
+    /**
+     * Atomically claim a webhook event ID.
+     *
+     * @return WebhookClaim Replay if already processed, Claimed if new
+     *
+     * @throws WebhookException On concurrent claim for in-flight event
+     */
+    public function claim(string $eventId, DateTimeImmutable $now, int $ttlSeconds): WebhookClaim;
+
+    /**
+     * Commit after successful handler dispatch.
+     */
+    public function commit(string $eventId): void;
+
+    /**
+     * Release on handler failure (allows retry).
+     */
+    public function release(string $eventId): void;
+
+    /**
+     * Remove expired records.
+     *
+     * @return int Number of records pruned
+     */
+    public function prune(DateTimeImmutable $before): int;
+}

--- a/extensions/payments/src/Contract/WebhookHandlerInterface.php
+++ b/extensions/payments/src/Contract/WebhookHandlerInterface.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Contract;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Domain\WebhookEvent;
+
+/**
+ * Webhook event handler contract.
+ *
+ * Implementations process webhook events dispatched by the WebhookProcessor.
+ */
+#[Api]
+interface WebhookHandlerInterface
+{
+    /**
+     * Handle a verified webhook event.
+     */
+    public function handle(WebhookEvent $event): void;
+}

--- a/extensions/payments/src/Contract/WebhookVerifierInterface.php
+++ b/extensions/payments/src/Contract/WebhookVerifierInterface.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Contract;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+
+/**
+ * Webhook signature verification contract.
+ */
+#[Api]
+interface WebhookVerifierInterface
+{
+    /**
+     * Verify a webhook signature.
+     *
+     * @param string $payload Raw request body bytes
+     * @param string $signatureHeader The signature header value
+     * @param string $secret The webhook signing secret
+     * @param int $toleranceSeconds Maximum allowed timestamp age
+     *
+     * @throws WebhookException On signature mismatch or expired timestamp
+     */
+    public function verify(
+        string $payload,
+        string $signatureHeader,
+        string $secret,
+        int $toleranceSeconds,
+    ): void;
+}

--- a/extensions/payments/src/Controller/WebhookController.php
+++ b/extensions/payments/src/Controller/WebhookController.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Controller;
+
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Webhook\WebhookProcessor;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+
+/**
+ * HTTP endpoint for incoming payment webhooks.
+ */
+final readonly class WebhookController
+{
+    public function __construct(
+        private WebhookProcessor $processor,
+        private PaymentsConfig $config,
+    ) {}
+
+    public function handle(Request $request): Response
+    {
+        $signatureHeader = $request->header($this->config->webhook->signatureHeader) ?? '';
+
+        return $this->processor->process($request->body, $signatureHeader);
+    }
+}

--- a/extensions/payments/src/Domain/Charge.php
+++ b/extensions/payments/src/Domain/Charge.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use Pulsar\Api\Api;
+
+/**
+ * Immutable charge record.
+ */
+#[Api]
+final readonly class Charge
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $id,
+        public string $intentId,
+        public Money $amount,
+        public ChargeStatus $status,
+        public string $provider,
+        public DateTimeImmutable $createdAt,
+        public ?string $failureReason = null,
+        public array $metadata = [],
+    ) {}
+}

--- a/extensions/payments/src/Domain/ChargeStatus.php
+++ b/extensions/payments/src/Domain/ChargeStatus.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Charge status values.
+ */
+#[Api]
+enum ChargeStatus: string
+{
+    case Succeeded = 'succeeded';
+    case Failed = 'failed';
+    case Pending = 'pending';
+    case Refunded = 'refunded';
+    case PartiallyRefunded = 'partially_refunded';
+}

--- a/extensions/payments/src/Domain/Currency.php
+++ b/extensions/payments/src/Domain/Currency.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * ISO 4217 currency codes with minor-unit digit counts.
+ */
+#[Api]
+enum Currency: string
+{
+    case USD = 'USD';
+    case EUR = 'EUR';
+    case GBP = 'GBP';
+    case JPY = 'JPY';
+    case CHF = 'CHF';
+    case CAD = 'CAD';
+    case AUD = 'AUD';
+    case NZD = 'NZD';
+    case SEK = 'SEK';
+    case NOK = 'NOK';
+    case DKK = 'DKK';
+    case SGD = 'SGD';
+    case HKD = 'HKD';
+    case BRL = 'BRL';
+    case INR = 'INR';
+    case MXN = 'MXN';
+    case ZAR = 'ZAR';
+    case PLN = 'PLN';
+    case CZK = 'CZK';
+    case HUF = 'HUF';
+    case BHD = 'BHD';
+    case KWD = 'KWD';
+    case OMR = 'OMR';
+
+    /**
+     * Number of minor-unit digits for this currency.
+     *
+     * Most currencies use 2 (cents). JPY/HUF use 0. BHD/KWD/OMR use 3.
+     */
+    public function minorDigits(): int
+    {
+        return match ($this) {
+            self::JPY, self::HUF => 0,
+            self::BHD, self::KWD, self::OMR => 3,
+            default => 2,
+        };
+    }
+
+    /**
+     * Currency symbol for display purposes.
+     */
+    public function symbol(): string
+    {
+        return match ($this) {
+            self::USD, self::CAD, self::AUD, self::NZD, self::SGD, self::HKD, self::MXN => '$',
+            self::EUR => '€',
+            self::GBP => '£',
+            self::JPY => '¥',
+            self::CHF => 'CHF',
+            self::SEK, self::NOK, self::DKK => 'kr',
+            self::BRL => 'R$',
+            self::INR => '₹',
+            self::ZAR => 'R',
+            self::PLN => 'zł',
+            self::CZK => 'Kč',
+            self::HUF => 'Ft',
+            self::BHD, self::KWD, self::OMR => $this->value,
+        };
+    }
+}

--- a/extensions/payments/src/Domain/Dispute.php
+++ b/extensions/payments/src/Domain/Dispute.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use NoDiscard;
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+
+/**
+ * Immutable dispute record with state machine enforcement.
+ */
+#[Api]
+final readonly class Dispute
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $id,
+        public string $chargeId,
+        public Money $amount,
+        public DisputeStatus $status,
+        public DisputeReason $reason,
+        public string $provider,
+        public DateTimeImmutable $createdAt,
+        public array $metadata = [],
+    ) {}
+
+    /**
+     * Transition to a new status, validating the state machine.
+     *
+     * @throws PaymentException If the transition is invalid
+     *
+     * @psalm-suppress MoreSpecificReturnType, LessSpecificReturnStatement
+     */
+    #[NoDiscard]
+    public function transitionTo(DisputeStatus $newStatus): self
+    {
+        if (!$this->status->canTransitionTo($newStatus)) {
+            throw PaymentException::invalidTransition(
+                'Dispute',
+                $this->status->value,
+                $newStatus->value,
+            );
+        }
+
+        return clone($this, ['status' => $newStatus]);
+    }
+}

--- a/extensions/payments/src/Domain/DisputeReason.php
+++ b/extensions/payments/src/Domain/DisputeReason.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Dispute reason codes.
+ */
+#[Api]
+enum DisputeReason: string
+{
+    case Fraudulent = 'fraudulent';
+    case Duplicate = 'duplicate';
+    case ProductNotReceived = 'product_not_received';
+    case ProductUnacceptable = 'product_unacceptable';
+    case SubscriptionCancelled = 'subscription_cancelled';
+    case Unrecognized = 'unrecognized';
+    case Other = 'other';
+}

--- a/extensions/payments/src/Domain/DisputeStatus.php
+++ b/extensions/payments/src/Domain/DisputeStatus.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Dispute lifecycle status.
+ *
+ * State machine:
+ *   Open --> UnderReview --> Won | Lost
+ *   Open --> Accepted
+ */
+#[Api]
+enum DisputeStatus: string
+{
+    case Open = 'open';
+    case UnderReview = 'under_review';
+    case Won = 'won';
+    case Lost = 'lost';
+    case Accepted = 'accepted';
+
+    /**
+     * Check if transitioning to the given status is valid.
+     */
+    public function canTransitionTo(self $target): bool
+    {
+        return match ($this) {
+            self::Open => $target === self::UnderReview || $target === self::Accepted,
+            self::UnderReview => $target === self::Won || $target === self::Lost,
+            self::Won, self::Lost, self::Accepted => false,
+        };
+    }
+}

--- a/extensions/payments/src/Domain/IdempotencyRecord.php
+++ b/extensions/payments/src/Domain/IdempotencyRecord.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use Pulsar\Api\Api;
+
+/**
+ * Stored idempotency record.
+ */
+#[Api]
+final readonly class IdempotencyRecord
+{
+    public function __construct(
+        public string $key,
+        public string $parametersHash,
+        public string $operation,
+        public DateTimeImmutable $createdAt,
+        public DateTimeImmutable $expiresAt,
+        public ?string $resultPayload = null,
+    ) {}
+}

--- a/extensions/payments/src/Domain/Money.php
+++ b/extensions/payments/src/Domain/Money.php
@@ -1,0 +1,204 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Exception\MoneyException;
+
+/**
+ * Immutable money value object using integer minor units.
+ *
+ * All arithmetic operations return new instances. Cross-currency
+ * operations are rejected at the type level.
+ */
+#[Api]
+final readonly class Money
+{
+    private function __construct(
+        public int $amount,
+        public Currency $currency,
+    ) {}
+
+    /**
+     * Create a Money instance.
+     *
+     * @param int $amount Amount in minor units (e.g., cents)
+     * @param Currency $currency The currency
+     *
+     * @throws MoneyException If amount is negative
+     */
+    #[NoDiscard]
+    public static function of(int $amount, Currency $currency): self
+    {
+        if ($amount < 0) {
+            throw MoneyException::negativeAmount($amount);
+        }
+
+        return new self($amount, $currency);
+    }
+
+    /**
+     * Create a zero Money instance for the given currency.
+     */
+    #[NoDiscard]
+    public static function zero(Currency $currency): self
+    {
+        return new self(0, $currency);
+    }
+
+    /**
+     * Add another Money of the same currency.
+     *
+     * @throws MoneyException On currency mismatch
+     */
+    #[NoDiscard]
+    public function add(self $other): self
+    {
+        $this->assertSameCurrency($other);
+
+        return new self($this->amount + $other->amount, $this->currency);
+    }
+
+    /**
+     * Subtract another Money of the same currency.
+     *
+     * @throws MoneyException On currency mismatch or negative result
+     */
+    #[NoDiscard]
+    public function subtract(self $other): self
+    {
+        $this->assertSameCurrency($other);
+
+        $result = $this->amount - $other->amount;
+        if ($result < 0) {
+            throw MoneyException::negativeAmount($result);
+        }
+
+        return new self($result, $this->currency);
+    }
+
+    /**
+     * Multiply by a non-negative integer factor.
+     *
+     * @throws MoneyException If factor is negative
+     */
+    #[NoDiscard]
+    public function multiply(int $factor): self
+    {
+        if ($factor < 0) {
+            throw MoneyException::negativeMultiplier($factor);
+        }
+
+        return new self($this->amount * $factor, $this->currency);
+    }
+
+    /**
+     * Compute a percentage using basis points (10000 = 100%).
+     *
+     * @param int $basisPoints Percentage in basis points
+     * @param RoundingMode $mode Rounding mode for fractional results
+     *
+     * @throws MoneyException If basis points is negative
+     */
+    #[NoDiscard]
+    public function percentage(int $basisPoints, RoundingMode $mode = RoundingMode::HalfUp): self
+    {
+        if ($basisPoints < 0) {
+            throw MoneyException::invalidBasisPoints($basisPoints);
+        }
+
+        $raw = ($this->amount * $basisPoints) / 10000;
+        $rounded = self::applyRounding($raw, $mode);
+
+        return new self($rounded, $this->currency);
+    }
+
+    /**
+     * Distribute this amount into N parts, distributing remainder one unit at a time.
+     *
+     * @param int $parts Number of parts to allocate into
+     *
+     * @return list<self> Exactly $parts Money instances that sum to this amount
+     *
+     * @throws MoneyException If parts is not positive
+     */
+    #[NoDiscard]
+    public function allocate(int $parts): array
+    {
+        if ($parts <= 0) {
+            throw MoneyException::invalidParts($parts);
+        }
+
+        $base = intdiv($this->amount, $parts);
+        $remainder = $this->amount % $parts;
+
+        $result = [];
+        for ($i = 0; $i < $parts; $i++) {
+            $result[] = new self($base + ($i < $remainder ? 1 : 0), $this->currency);
+        }
+
+        return $result;
+    }
+
+    /**
+     * Format the amount using the currency's minor digits.
+     *
+     * Example: Money::of(1050, Currency::USD)->format() => "10.50"
+     * Example: Money::of(1000, Currency::JPY)->format() => "1000"
+     */
+    #[NoDiscard]
+    public function format(): string
+    {
+        $digits = $this->currency->minorDigits();
+
+        if ($digits === 0) {
+            return (string) $this->amount;
+        }
+
+        $divisor = 10 ** $digits;
+        $whole = intdiv($this->amount, $divisor);
+        $fraction = $this->amount % $divisor;
+
+        return \sprintf('%d.%0' . $digits . 'd', $whole, $fraction);
+    }
+
+    /**
+     * Check if this Money represents zero.
+     */
+    public function isZero(): bool
+    {
+        return $this->amount === 0;
+    }
+
+    /**
+     * Check if two Money instances are equal in amount and currency.
+     */
+    public function equals(self $other): bool
+    {
+        return $this->amount === $other->amount && $this->currency === $other->currency;
+    }
+
+    /**
+     * @throws MoneyException
+     */
+    private function assertSameCurrency(self $other): void
+    {
+        if ($this->currency !== $other->currency) {
+            throw MoneyException::currencyMismatch($this->currency, $other->currency);
+        }
+    }
+
+    private static function applyRounding(float $value, RoundingMode $mode): int
+    {
+        return match ($mode) {
+            RoundingMode::HalfUp => (int) round($value, 0, PHP_ROUND_HALF_UP),
+            RoundingMode::HalfDown => (int) round($value, 0, PHP_ROUND_HALF_DOWN),
+            RoundingMode::HalfEven => (int) round($value, 0, PHP_ROUND_HALF_EVEN),
+            RoundingMode::Floor => (int) floor($value),
+            RoundingMode::Ceiling => (int) ceil($value),
+        };
+    }
+}

--- a/extensions/payments/src/Domain/Money.php
+++ b/extensions/payments/src/Domain/Money.php
@@ -8,6 +8,8 @@ use NoDiscard;
 use Pulsar\Api\Api;
 use Pulsar\Extension\Payments\Exception\MoneyException;
 
+use function sprintf;
+
 /**
  * Immutable money value object using integer minor units.
  *
@@ -162,7 +164,7 @@ final readonly class Money
         $whole = intdiv($this->amount, $divisor);
         $fraction = $this->amount % $divisor;
 
-        return \sprintf('%d.%0' . $digits . 'd', $whole, $fraction);
+        return sprintf('%d.%0' . $digits . 'd', $whole, $fraction);
     }
 
     /**

--- a/extensions/payments/src/Domain/PaymentIntent.php
+++ b/extensions/payments/src/Domain/PaymentIntent.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use NoDiscard;
+use Pulsar\Api\Api;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+
+/**
+ * Immutable payment intent with state machine enforcement.
+ */
+#[Api]
+final readonly class PaymentIntent
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $id,
+        public Money $amount,
+        public PaymentIntentStatus $status,
+        public string $provider,
+        public string $idempotencyKey,
+        public DateTimeImmutable $createdAt,
+        public array $metadata = [],
+    ) {}
+
+    /**
+     * Transition to a new status, validating the state machine.
+     *
+     * @throws PaymentException If the transition is invalid
+     *
+     * @psalm-suppress MoreSpecificReturnType, LessSpecificReturnStatement
+     */
+    #[NoDiscard]
+    public function transitionTo(PaymentIntentStatus $newStatus): self
+    {
+        if (!$this->status->canTransitionTo($newStatus)) {
+            throw PaymentException::invalidTransition(
+                'PaymentIntent',
+                $this->status->value,
+                $newStatus->value,
+            );
+        }
+
+        return clone($this, ['status' => $newStatus]);
+    }
+}

--- a/extensions/payments/src/Domain/PaymentIntentStatus.php
+++ b/extensions/payments/src/Domain/PaymentIntentStatus.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Payment intent lifecycle status.
+ *
+ * State machine:
+ *   Created --capture--> Captured --dispute--> Disputed --resolve--> Resolved
+ *   Created --cancel---> Cancelled
+ */
+#[Api]
+enum PaymentIntentStatus: string
+{
+    case Created = 'created';
+    case Captured = 'captured';
+    case Cancelled = 'cancelled';
+    case Disputed = 'disputed';
+    case Resolved = 'resolved';
+
+    /**
+     * Check if transitioning to the given status is valid.
+     */
+    public function canTransitionTo(self $target): bool
+    {
+        return match ($this) {
+            self::Created => $target === self::Captured || $target === self::Cancelled,
+            self::Captured => $target === self::Disputed,
+            self::Disputed => $target === self::Resolved,
+            self::Cancelled, self::Resolved => false,
+        };
+    }
+}

--- a/extensions/payments/src/Domain/Refund.php
+++ b/extensions/payments/src/Domain/Refund.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use Pulsar\Api\Api;
+
+/**
+ * Immutable refund record.
+ */
+#[Api]
+final readonly class Refund
+{
+    /**
+     * @param array<string, mixed> $metadata
+     */
+    public function __construct(
+        public string $id,
+        public string $chargeId,
+        public Money $amount,
+        public RefundStatus $status,
+        public string $provider,
+        public DateTimeImmutable $createdAt,
+        public ?string $failureReason = null,
+        public array $metadata = [],
+    ) {}
+}

--- a/extensions/payments/src/Domain/RefundStatus.php
+++ b/extensions/payments/src/Domain/RefundStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Refund status values.
+ */
+#[Api]
+enum RefundStatus: string
+{
+    case Pending = 'pending';
+    case Succeeded = 'succeeded';
+    case Failed = 'failed';
+}

--- a/extensions/payments/src/Domain/RoundingMode.php
+++ b/extensions/payments/src/Domain/RoundingMode.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Rounding mode for Money arithmetic.
+ */
+#[Api]
+enum RoundingMode
+{
+    case HalfUp;
+    case HalfDown;
+    case HalfEven;
+    case Floor;
+    case Ceiling;
+}

--- a/extensions/payments/src/Domain/WebhookEvent.php
+++ b/extensions/payments/src/Domain/WebhookEvent.php
@@ -47,7 +47,7 @@ final readonly class WebhookEvent
         return new self(
             id: $id,
             type: WebhookEventType::from($type),
-            createdAt: (new DateTimeImmutable())->setTimestamp($timestamp),
+            createdAt: new DateTimeImmutable('@' . $timestamp),
             data: $data,
         );
     }

--- a/extensions/payments/src/Domain/WebhookEvent.php
+++ b/extensions/payments/src/Domain/WebhookEvent.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Inbound webhook event DTO.
+ */
+#[Api]
+final readonly class WebhookEvent
+{
+    /**
+     * @param array<string, mixed> $data
+     */
+    public function __construct(
+        public string $id,
+        public WebhookEventType $type,
+        public DateTimeImmutable $createdAt,
+        public array $data = [],
+    ) {}
+
+    /**
+     * Build from a decoded JSON array.
+     *
+     * @param array<string, mixed> $payload
+     */
+    #[NoDiscard]
+    public static function fromArray(array $payload): self
+    {
+        /** @var string $id */
+        $id = $payload['id'] ?? '';
+
+        /** @var string $type */
+        $type = $payload['type'] ?? '';
+
+        /** @var int $timestamp */
+        $timestamp = $payload['created_at'] ?? 0;
+
+        /** @var array<string, mixed> $data */
+        $data = $payload['data'] ?? [];
+
+        return new self(
+            id: $id,
+            type: WebhookEventType::from($type),
+            createdAt: (new DateTimeImmutable())->setTimestamp($timestamp),
+            data: $data,
+        );
+    }
+}

--- a/extensions/payments/src/Domain/WebhookEventType.php
+++ b/extensions/payments/src/Domain/WebhookEventType.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Webhook event types.
+ */
+#[Api]
+enum WebhookEventType: string
+{
+    case PaymentIntentCreated = 'payment_intent.created';
+    case PaymentIntentCaptured = 'payment_intent.captured';
+    case PaymentIntentCancelled = 'payment_intent.cancelled';
+    case ChargeFailed = 'charge.failed';
+    case RefundCreated = 'refund.created';
+    case RefundFailed = 'refund.failed';
+    case DisputeOpened = 'dispute.opened';
+    case DisputeWon = 'dispute.won';
+    case DisputeLost = 'dispute.lost';
+}

--- a/extensions/payments/src/Exception/IdempotencyException.php
+++ b/extensions/payments/src/Exception/IdempotencyException.php
@@ -7,6 +7,8 @@ namespace Pulsar\Extension\Payments\Exception;
 use NoDiscard;
 use RuntimeException;
 
+use function sprintf;
+
 /**
  * Idempotency violation exceptions.
  */
@@ -15,7 +17,7 @@ final class IdempotencyException extends RuntimeException
     #[NoDiscard]
     public static function parameterMismatch(string $key): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Idempotency key "%s" was previously used with different parameters',
             $key,
         ));
@@ -24,7 +26,7 @@ final class IdempotencyException extends RuntimeException
     #[NoDiscard]
     public static function concurrentClaim(string $key): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Idempotency key "%s" is currently being processed',
             $key,
         ));
@@ -33,13 +35,13 @@ final class IdempotencyException extends RuntimeException
     #[NoDiscard]
     public static function invalidKey(string $reason): self
     {
-        return new self(\sprintf('Invalid idempotency key: %s', $reason));
+        return new self(sprintf('Invalid idempotency key: %s', $reason));
     }
 
     #[NoDiscard]
     public static function commitFailed(string $key): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Failed to commit idempotency result for key "%s"',
             $key,
         ));

--- a/extensions/payments/src/Exception/IdempotencyException.php
+++ b/extensions/payments/src/Exception/IdempotencyException.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Exception;
+
+use NoDiscard;
+use RuntimeException;
+
+/**
+ * Idempotency violation exceptions.
+ */
+final class IdempotencyException extends RuntimeException
+{
+    #[NoDiscard]
+    public static function parameterMismatch(string $key): self
+    {
+        return new self(\sprintf(
+            'Idempotency key "%s" was previously used with different parameters',
+            $key,
+        ));
+    }
+
+    #[NoDiscard]
+    public static function concurrentClaim(string $key): self
+    {
+        return new self(\sprintf(
+            'Idempotency key "%s" is currently being processed',
+            $key,
+        ));
+    }
+
+    #[NoDiscard]
+    public static function invalidKey(string $reason): self
+    {
+        return new self(\sprintf('Invalid idempotency key: %s', $reason));
+    }
+
+    #[NoDiscard]
+    public static function commitFailed(string $key): self
+    {
+        return new self(\sprintf(
+            'Failed to commit idempotency result for key "%s"',
+            $key,
+        ));
+    }
+}

--- a/extensions/payments/src/Exception/MoneyException.php
+++ b/extensions/payments/src/Exception/MoneyException.php
@@ -8,6 +8,8 @@ use NoDiscard;
 use Pulsar\Extension\Payments\Domain\Currency;
 use RuntimeException;
 
+use function sprintf;
+
 /**
  * Money arithmetic exceptions.
  */
@@ -16,7 +18,7 @@ final class MoneyException extends RuntimeException
     #[NoDiscard]
     public static function currencyMismatch(Currency $expected, Currency $actual): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Currency mismatch: expected %s, got %s',
             $expected->value,
             $actual->value,
@@ -26,24 +28,24 @@ final class MoneyException extends RuntimeException
     #[NoDiscard]
     public static function negativeAmount(int $amount): self
     {
-        return new self(\sprintf('Money amount must be non-negative, got %d', $amount));
+        return new self(sprintf('Money amount must be non-negative, got %d', $amount));
     }
 
     #[NoDiscard]
     public static function invalidParts(int $parts): self
     {
-        return new self(\sprintf('Allocation parts must be positive, got %d', $parts));
+        return new self(sprintf('Allocation parts must be positive, got %d', $parts));
     }
 
     #[NoDiscard]
     public static function negativeMultiplier(int $factor): self
     {
-        return new self(\sprintf('Multiplier must be non-negative, got %d', $factor));
+        return new self(sprintf('Multiplier must be non-negative, got %d', $factor));
     }
 
     #[NoDiscard]
     public static function invalidBasisPoints(int $basisPoints): self
     {
-        return new self(\sprintf('Basis points must be non-negative, got %d', $basisPoints));
+        return new self(sprintf('Basis points must be non-negative, got %d', $basisPoints));
     }
 }

--- a/extensions/payments/src/Exception/MoneyException.php
+++ b/extensions/payments/src/Exception/MoneyException.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Exception;
+
+use NoDiscard;
+use Pulsar\Extension\Payments\Domain\Currency;
+use RuntimeException;
+
+/**
+ * Money arithmetic exceptions.
+ */
+final class MoneyException extends RuntimeException
+{
+    #[NoDiscard]
+    public static function currencyMismatch(Currency $expected, Currency $actual): self
+    {
+        return new self(\sprintf(
+            'Currency mismatch: expected %s, got %s',
+            $expected->value,
+            $actual->value,
+        ));
+    }
+
+    #[NoDiscard]
+    public static function negativeAmount(int $amount): self
+    {
+        return new self(\sprintf('Money amount must be non-negative, got %d', $amount));
+    }
+
+    #[NoDiscard]
+    public static function invalidParts(int $parts): self
+    {
+        return new self(\sprintf('Allocation parts must be positive, got %d', $parts));
+    }
+
+    #[NoDiscard]
+    public static function negativeMultiplier(int $factor): self
+    {
+        return new self(\sprintf('Multiplier must be non-negative, got %d', $factor));
+    }
+
+    #[NoDiscard]
+    public static function invalidBasisPoints(int $basisPoints): self
+    {
+        return new self(\sprintf('Basis points must be non-negative, got %d', $basisPoints));
+    }
+}

--- a/extensions/payments/src/Exception/PaymentException.php
+++ b/extensions/payments/src/Exception/PaymentException.php
@@ -7,6 +7,8 @@ namespace Pulsar\Extension\Payments\Exception;
 use NoDiscard;
 use RuntimeException;
 
+use function sprintf;
+
 /**
  * Domain-level payment exceptions.
  */
@@ -15,7 +17,7 @@ final class PaymentException extends RuntimeException
     #[NoDiscard]
     public static function invalidTransition(string $entity, string $from, string $to): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Invalid %s transition from "%s" to "%s"',
             $entity,
             $from,
@@ -26,7 +28,7 @@ final class PaymentException extends RuntimeException
     #[NoDiscard]
     public static function notFound(string $entity, string $id): self
     {
-        return new self(\sprintf('%s not found: %s', $entity, $id));
+        return new self(sprintf('%s not found: %s', $entity, $id));
     }
 
     #[NoDiscard]

--- a/extensions/payments/src/Exception/PaymentException.php
+++ b/extensions/payments/src/Exception/PaymentException.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Exception;
+
+use NoDiscard;
+use RuntimeException;
+
+/**
+ * Domain-level payment exceptions.
+ */
+final class PaymentException extends RuntimeException
+{
+    #[NoDiscard]
+    public static function invalidTransition(string $entity, string $from, string $to): self
+    {
+        return new self(\sprintf(
+            'Invalid %s transition from "%s" to "%s"',
+            $entity,
+            $from,
+            $to,
+        ));
+    }
+
+    #[NoDiscard]
+    public static function notFound(string $entity, string $id): self
+    {
+        return new self(\sprintf('%s not found: %s', $entity, $id));
+    }
+
+    #[NoDiscard]
+    public static function invalid(string $message): self
+    {
+        return new self($message);
+    }
+}

--- a/extensions/payments/src/Exception/PaymentProviderException.php
+++ b/extensions/payments/src/Exception/PaymentProviderException.php
@@ -8,6 +8,8 @@ use NoDiscard;
 use RuntimeException;
 use Throwable;
 
+use function sprintf;
+
 /**
  * Provider-level payment exceptions.
  */
@@ -25,7 +27,7 @@ final class PaymentProviderException extends RuntimeException
     public static function declined(string $reason): self
     {
         return new self(
-            \sprintf('Payment declined: %s', $reason),
+            sprintf('Payment declined: %s', $reason),
             'declined',
         );
     }
@@ -58,7 +60,7 @@ final class PaymentProviderException extends RuntimeException
     public static function refundFailed(string $reason): self
     {
         return new self(
-            \sprintf('Refund failed: %s', $reason),
+            sprintf('Refund failed: %s', $reason),
             'refund_failed',
         );
     }

--- a/extensions/payments/src/Exception/PaymentProviderException.php
+++ b/extensions/payments/src/Exception/PaymentProviderException.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Exception;
+
+use NoDiscard;
+use RuntimeException;
+use Throwable;
+
+/**
+ * Provider-level payment exceptions.
+ */
+final class PaymentProviderException extends RuntimeException
+{
+    private function __construct(
+        string $message,
+        public readonly string $errorType,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    #[NoDiscard]
+    public static function declined(string $reason): self
+    {
+        return new self(
+            \sprintf('Payment declined: %s', $reason),
+            'declined',
+        );
+    }
+
+    #[NoDiscard]
+    public static function timeout(string $message = 'Provider request timed out'): self
+    {
+        return new self($message, 'timeout');
+    }
+
+    #[NoDiscard]
+    public static function networkError(string $message = 'Provider network error'): self
+    {
+        return new self($message, 'network_error');
+    }
+
+    #[NoDiscard]
+    public static function rateLimited(string $message = 'Provider rate limit exceeded'): self
+    {
+        return new self($message, 'rate_limited');
+    }
+
+    #[NoDiscard]
+    public static function providerError(string $message, ?Throwable $previous = null): self
+    {
+        return new self($message, 'provider_error', $previous);
+    }
+
+    #[NoDiscard]
+    public static function refundFailed(string $reason): self
+    {
+        return new self(
+            \sprintf('Refund failed: %s', $reason),
+            'refund_failed',
+        );
+    }
+}

--- a/extensions/payments/src/Exception/WebhookException.php
+++ b/extensions/payments/src/Exception/WebhookException.php
@@ -7,6 +7,8 @@ namespace Pulsar\Extension\Payments\Exception;
 use NoDiscard;
 use RuntimeException;
 
+use function sprintf;
+
 /**
  * Webhook processing exceptions.
  */
@@ -21,7 +23,7 @@ final class WebhookException extends RuntimeException
     #[NoDiscard]
     public static function expiredTimestamp(int $age, int $tolerance): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Webhook timestamp too old: %d seconds (tolerance: %d)',
             $age,
             $tolerance,
@@ -31,13 +33,13 @@ final class WebhookException extends RuntimeException
     #[NoDiscard]
     public static function malformedHeader(string $reason): self
     {
-        return new self(\sprintf('Malformed webhook signature header: %s', $reason));
+        return new self(sprintf('Malformed webhook signature header: %s', $reason));
     }
 
     #[NoDiscard]
     public static function concurrentClaim(string $eventId): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Webhook event "%s" is currently being processed',
             $eventId,
         ));
@@ -46,7 +48,7 @@ final class WebhookException extends RuntimeException
     #[NoDiscard]
     public static function handlerFailed(string $eventId, string $reason): self
     {
-        return new self(\sprintf(
+        return new self(sprintf(
             'Webhook handler failed for event "%s": %s',
             $eventId,
             $reason,

--- a/extensions/payments/src/Exception/WebhookException.php
+++ b/extensions/payments/src/Exception/WebhookException.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Exception;
+
+use NoDiscard;
+use RuntimeException;
+
+/**
+ * Webhook processing exceptions.
+ */
+final class WebhookException extends RuntimeException
+{
+    #[NoDiscard]
+    public static function invalidSignature(): self
+    {
+        return new self('Webhook signature verification failed');
+    }
+
+    #[NoDiscard]
+    public static function expiredTimestamp(int $age, int $tolerance): self
+    {
+        return new self(\sprintf(
+            'Webhook timestamp too old: %d seconds (tolerance: %d)',
+            $age,
+            $tolerance,
+        ));
+    }
+
+    #[NoDiscard]
+    public static function malformedHeader(string $reason): self
+    {
+        return new self(\sprintf('Malformed webhook signature header: %s', $reason));
+    }
+
+    #[NoDiscard]
+    public static function concurrentClaim(string $eventId): self
+    {
+        return new self(\sprintf(
+            'Webhook event "%s" is currently being processed',
+            $eventId,
+        ));
+    }
+
+    #[NoDiscard]
+    public static function handlerFailed(string $eventId, string $reason): self
+    {
+        return new self(\sprintf(
+            'Webhook handler failed for event "%s": %s',
+            $eventId,
+            $reason,
+        ));
+    }
+}

--- a/extensions/payments/src/Gateway/ParametersHasher.php
+++ b/extensions/payments/src/Gateway/ParametersHasher.php
@@ -6,6 +6,8 @@ namespace Pulsar\Extension\Payments\Gateway;
 
 use NoDiscard;
 
+use function is_array;
+
 /**
  * Canonical parameter hashing utility for idempotency.
  *
@@ -38,7 +40,7 @@ final readonly class ParametersHasher
         ksort($array);
 
         foreach ($array as &$value) {
-            if (\is_array($value)) {
+            if (is_array($value)) {
                 self::sortRecursive($value);
             }
         }

--- a/extensions/payments/src/Gateway/ParametersHasher.php
+++ b/extensions/payments/src/Gateway/ParametersHasher.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Gateway;
+
+use NoDiscard;
+
+/**
+ * Canonical parameter hashing utility for idempotency.
+ *
+ * Produces deterministic SHA-256 hashes by recursively sorting array keys
+ * and using stable JSON encoding.
+ */
+final readonly class ParametersHasher
+{
+    /**
+     * Produce a deterministic SHA-256 hash from operation parameters.
+     *
+     * @param array<string, mixed> $parameters
+     */
+    #[NoDiscard]
+    public static function hash(string $operation, array $parameters): string
+    {
+        $canonical = ['_operation' => $operation, ...$parameters];
+        self::sortRecursive($canonical);
+
+        $json = json_encode($canonical, JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+
+        return hash('sha256', $json);
+    }
+
+    /**
+     * @param array<string, mixed> $array
+     */
+    private static function sortRecursive(array &$array): void
+    {
+        ksort($array);
+
+        foreach ($array as &$value) {
+            if (\is_array($value)) {
+                self::sortRecursive($value);
+            }
+        }
+    }
+}

--- a/extensions/payments/src/Gateway/PaymentGateway.php
+++ b/extensions/payments/src/Gateway/PaymentGateway.php
@@ -28,6 +28,8 @@ use Pulsar\Security\Audit\AuditLogger;
 use Pulsar\Security\Audit\AuditOutcome;
 use Throwable;
 
+use function strlen;
+
 /**
  * Payment gateway orchestrator.
  *
@@ -290,7 +292,7 @@ final readonly class PaymentGateway
      */
     private function validateIdempotencyKey(string $key): void
     {
-        if ($key === '' || \strlen($key) > $this->config->idempotency->maxKeyLength) {
+        if ($key === '' || strlen($key) > $this->config->idempotency->maxKeyLength) {
             throw IdempotencyException::invalidKey(
                 'must be 1-' . $this->config->idempotency->maxKeyLength . ' ASCII printable characters',
             );

--- a/extensions/payments/src/Gateway/PaymentGateway.php
+++ b/extensions/payments/src/Gateway/PaymentGateway.php
@@ -1,0 +1,527 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Gateway;
+
+use Psr\Log\LoggerInterface;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\IdempotencyStoreInterface;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\Charge;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntent;
+use Pulsar\Extension\Payments\Domain\Refund;
+use Pulsar\Extension\Payments\Exception\IdempotencyException;
+use Pulsar\Extension\Payments\Exception\PaymentProviderException;
+use Pulsar\Extension\Payments\Idempotency\IdempotencyClaimStatus;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditLogger;
+use Pulsar\Security\Audit\AuditOutcome;
+use Throwable;
+
+/**
+ * Payment gateway orchestrator.
+ *
+ * Wraps the payment provider with cross-cutting concerns:
+ * idempotency enforcement, audit logging, and metrics.
+ */
+final readonly class PaymentGateway
+{
+    private const string IDEMPOTENCY_KEY_PATTERN = '/^[\x21-\x7E]{1,256}$/';
+
+    public function __construct(
+        private PaymentProviderInterface $provider,
+        private IdempotencyStoreInterface $idempotencyStore,
+        private AuditLogger $auditLogger,
+        private MetricRegistry $metricRegistry,
+        private LoggerInterface $logger,
+        private ClockInterface $clock,
+        private PaymentsConfig $config,
+    ) {}
+
+    /**
+     * Create a payment intent with idempotency enforcement.
+     *
+     * @param array<string, mixed> $metadata
+     *
+     * @throws IdempotencyException
+     * @throws PaymentProviderException
+     */
+    public function createIntent(Money $amount, string $idempotencyKey, array $metadata = []): PaymentIntent
+    {
+        $this->validateIdempotencyKey($idempotencyKey);
+
+        $parametersHash = ParametersHasher::hash('createIntent', [
+            'amount_minor' => $amount->amount,
+            'currency' => $amount->currency->value,
+            'provider' => $this->provider->name(),
+        ]);
+
+        $claim = $this->idempotencyStore->claim(
+            $idempotencyKey,
+            $parametersHash,
+            'createIntent',
+            $this->clock->now(),
+            $this->config->idempotency->ttlSeconds,
+        );
+
+        if ($claim->status === IdempotencyClaimStatus::Mismatch) {
+            throw IdempotencyException::parameterMismatch($idempotencyKey);
+        }
+
+        if ($claim->status === IdempotencyClaimStatus::Replay) {
+            $this->incrementReplayMetric('createIntent');
+
+            /** @var string $payload */
+            $payload = $claim->resultPayload;
+
+            return $this->deserializeIntent($payload);
+        }
+
+        try {
+            $intent = $this->provider->createIntent($amount, $idempotencyKey, $metadata);
+
+            $this->commitResult($idempotencyKey, 'payment_intent', $intent);
+            $this->auditPayment('create_intent', $intent->id, $amount, $intent->status->value);
+            $this->incrementIntentMetric($amount, $intent->status->value);
+
+            return $intent;
+        } catch (Throwable $e) {
+            $this->idempotencyStore->release($idempotencyKey);
+            $this->incrementProviderErrorMetric('createIntent', $e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Capture a payment intent with idempotency enforcement.
+     *
+     * @throws IdempotencyException
+     * @throws PaymentProviderException
+     */
+    public function captureIntent(string $intentId, string $idempotencyKey): Charge
+    {
+        $this->validateIdempotencyKey($idempotencyKey);
+
+        $parametersHash = ParametersHasher::hash('captureIntent', [
+            'intentId' => $intentId,
+            'provider' => $this->provider->name(),
+        ]);
+
+        $claim = $this->idempotencyStore->claim(
+            $idempotencyKey,
+            $parametersHash,
+            'captureIntent',
+            $this->clock->now(),
+            $this->config->idempotency->ttlSeconds,
+        );
+
+        if ($claim->status === IdempotencyClaimStatus::Mismatch) {
+            throw IdempotencyException::parameterMismatch($idempotencyKey);
+        }
+
+        if ($claim->status === IdempotencyClaimStatus::Replay) {
+            $this->incrementReplayMetric('captureIntent');
+
+            /** @var string $payload */
+            $payload = $claim->resultPayload;
+
+            return $this->deserializeCharge($payload);
+        }
+
+        try {
+            $charge = $this->provider->captureIntent($intentId, $idempotencyKey);
+
+            $this->commitResult($idempotencyKey, 'charge', $charge);
+            $this->auditCapture($charge);
+            $this->incrementCaptureMetric($charge);
+
+            return $charge;
+        } catch (Throwable $e) {
+            $this->idempotencyStore->release($idempotencyKey);
+            $this->incrementProviderErrorMetric('captureIntent', $e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Cancel a payment intent with idempotency enforcement.
+     *
+     * @throws IdempotencyException
+     * @throws PaymentProviderException
+     */
+    public function cancelIntent(string $intentId, string $idempotencyKey): PaymentIntent
+    {
+        $this->validateIdempotencyKey($idempotencyKey);
+
+        $parametersHash = ParametersHasher::hash('cancelIntent', [
+            'intentId' => $intentId,
+            'provider' => $this->provider->name(),
+        ]);
+
+        $claim = $this->idempotencyStore->claim(
+            $idempotencyKey,
+            $parametersHash,
+            'cancelIntent',
+            $this->clock->now(),
+            $this->config->idempotency->ttlSeconds,
+        );
+
+        if ($claim->status === IdempotencyClaimStatus::Mismatch) {
+            throw IdempotencyException::parameterMismatch($idempotencyKey);
+        }
+
+        if ($claim->status === IdempotencyClaimStatus::Replay) {
+            $this->incrementReplayMetric('cancelIntent');
+
+            /** @var string $payload */
+            $payload = $claim->resultPayload;
+
+            return $this->deserializeIntent($payload);
+        }
+
+        try {
+            $intent = $this->provider->cancelIntent($intentId, $idempotencyKey);
+
+            $this->commitResult($idempotencyKey, 'payment_intent', $intent);
+            $this->auditPayment('cancel_intent', $intent->id, $intent->amount, $intent->status->value);
+            $this->incrementIntentMetric($intent->amount, $intent->status->value);
+
+            return $intent;
+        } catch (Throwable $e) {
+            $this->idempotencyStore->release($idempotencyKey);
+            $this->incrementProviderErrorMetric('cancelIntent', $e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Refund a charge with idempotency enforcement.
+     *
+     * @throws IdempotencyException
+     * @throws PaymentProviderException
+     */
+    public function refund(string $chargeId, ?Money $amount, string $idempotencyKey): Refund
+    {
+        $this->validateIdempotencyKey($idempotencyKey);
+
+        $parametersHash = ParametersHasher::hash('refund', [
+            'chargeId' => $chargeId,
+            'amount_minor' => $amount?->amount ?? 'full',
+            'currency' => $amount?->currency->value ?? 'full',
+            'provider' => $this->provider->name(),
+        ]);
+
+        $claim = $this->idempotencyStore->claim(
+            $idempotencyKey,
+            $parametersHash,
+            'refund',
+            $this->clock->now(),
+            $this->config->idempotency->ttlSeconds,
+        );
+
+        if ($claim->status === IdempotencyClaimStatus::Mismatch) {
+            throw IdempotencyException::parameterMismatch($idempotencyKey);
+        }
+
+        if ($claim->status === IdempotencyClaimStatus::Replay) {
+            $this->incrementReplayMetric('refund');
+
+            /** @var string $payload */
+            $payload = $claim->resultPayload;
+
+            return $this->deserializeRefund($payload);
+        }
+
+        try {
+            $refund = $this->provider->refund($chargeId, $amount, $idempotencyKey);
+
+            $this->commitResult($idempotencyKey, 'refund', $refund);
+            $this->auditRefund($refund);
+            $this->incrementRefundMetric($refund);
+
+            return $refund;
+        } catch (Throwable $e) {
+            $this->idempotencyStore->release($idempotencyKey);
+            $this->incrementProviderErrorMetric('refund', $e);
+
+            throw $e;
+        }
+    }
+
+    /**
+     * Get a payment intent (read-only, no idempotency).
+     */
+    public function getIntent(string $intentId): PaymentIntent
+    {
+        return $this->provider->getIntent($intentId);
+    }
+
+    /**
+     * Get a charge (read-only, no idempotency).
+     */
+    public function getCharge(string $chargeId): Charge
+    {
+        return $this->provider->getCharge($chargeId);
+    }
+
+    /**
+     * Get a refund (read-only, no idempotency).
+     */
+    public function getRefund(string $refundId): Refund
+    {
+        return $this->provider->getRefund($refundId);
+    }
+
+    /**
+     * @throws IdempotencyException
+     */
+    private function validateIdempotencyKey(string $key): void
+    {
+        if ($key === '' || \strlen($key) > $this->config->idempotency->maxKeyLength) {
+            throw IdempotencyException::invalidKey(
+                'must be 1-' . $this->config->idempotency->maxKeyLength . ' ASCII printable characters',
+            );
+        }
+
+        if (preg_match(self::IDEMPOTENCY_KEY_PATTERN, $key) !== 1) {
+            throw IdempotencyException::invalidKey('contains invalid characters (only ASCII 0x21-0x7E allowed)');
+        }
+    }
+
+    private function commitResult(string $key, string $type, PaymentIntent|Charge|Refund $result): void
+    {
+        $payload = json_encode([
+            'schema_version' => 1,
+            'type' => $type,
+            'data' => $this->serializeResult($result),
+        ], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+
+        try {
+            $this->idempotencyStore->commit($key, $payload);
+        } catch (Throwable $e) {
+            $this->logger->critical('Failed to commit idempotency result', [
+                'key' => $key,
+                'type' => $type,
+                'error' => $e->getMessage(),
+            ]);
+
+            throw IdempotencyException::commitFailed($key);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function serializeResult(PaymentIntent|Charge|Refund $result): array
+    {
+        return match (true) {
+            $result instanceof PaymentIntent => [
+                'id' => $result->id,
+                'amount' => $result->amount->amount,
+                'currency' => $result->amount->currency->value,
+                'status' => $result->status->value,
+                'provider' => $result->provider,
+                'idempotency_key' => $result->idempotencyKey,
+                'created_at' => $result->createdAt->getTimestamp(),
+                'metadata' => $result->metadata,
+            ],
+            $result instanceof Charge => [
+                'id' => $result->id,
+                'intent_id' => $result->intentId,
+                'amount' => $result->amount->amount,
+                'currency' => $result->amount->currency->value,
+                'status' => $result->status->value,
+                'provider' => $result->provider,
+                'created_at' => $result->createdAt->getTimestamp(),
+                'failure_reason' => $result->failureReason,
+                'metadata' => $result->metadata,
+            ],
+            $result instanceof Refund => [
+                'id' => $result->id,
+                'charge_id' => $result->chargeId,
+                'amount' => $result->amount->amount,
+                'currency' => $result->amount->currency->value,
+                'status' => $result->status->value,
+                'provider' => $result->provider,
+                'created_at' => $result->createdAt->getTimestamp(),
+                'failure_reason' => $result->failureReason,
+                'metadata' => $result->metadata,
+            ],
+        };
+    }
+
+    private function deserializeIntent(string $payload): PaymentIntent
+    {
+        /** @var array{data: array<string, mixed>} $envelope */
+        $envelope = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        $data = $envelope['data'];
+
+        return new PaymentIntent(
+            id: (string) $data['id'],
+            amount: Money::of((int) $data['amount'], \Pulsar\Extension\Payments\Domain\Currency::from((string) $data['currency'])),
+            status: \Pulsar\Extension\Payments\Domain\PaymentIntentStatus::from((string) $data['status']),
+            provider: (string) $data['provider'],
+            idempotencyKey: (string) $data['idempotency_key'],
+            createdAt: (new \DateTimeImmutable())->setTimestamp((int) $data['created_at']),
+            metadata: (array) ($data['metadata'] ?? []),
+        );
+    }
+
+    private function deserializeCharge(string $payload): Charge
+    {
+        /** @var array{data: array<string, mixed>} $envelope */
+        $envelope = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        $data = $envelope['data'];
+
+        return new Charge(
+            id: (string) $data['id'],
+            intentId: (string) $data['intent_id'],
+            amount: Money::of((int) $data['amount'], \Pulsar\Extension\Payments\Domain\Currency::from((string) $data['currency'])),
+            status: \Pulsar\Extension\Payments\Domain\ChargeStatus::from((string) $data['status']),
+            provider: (string) $data['provider'],
+            createdAt: (new \DateTimeImmutable())->setTimestamp((int) $data['created_at']),
+            failureReason: $data['failure_reason'] !== null ? (string) $data['failure_reason'] : null,
+            metadata: (array) ($data['metadata'] ?? []),
+        );
+    }
+
+    private function deserializeRefund(string $payload): Refund
+    {
+        /** @var array{data: array<string, mixed>} $envelope */
+        $envelope = json_decode($payload, true, 512, JSON_THROW_ON_ERROR);
+        $data = $envelope['data'];
+
+        return new Refund(
+            id: (string) $data['id'],
+            chargeId: (string) $data['charge_id'],
+            amount: Money::of((int) $data['amount'], \Pulsar\Extension\Payments\Domain\Currency::from((string) $data['currency'])),
+            status: \Pulsar\Extension\Payments\Domain\RefundStatus::from((string) $data['status']),
+            provider: (string) $data['provider'],
+            createdAt: (new \DateTimeImmutable())->setTimestamp((int) $data['created_at']),
+            failureReason: $data['failure_reason'] !== null ? (string) $data['failure_reason'] : null,
+            metadata: (array) ($data['metadata'] ?? []),
+        );
+    }
+
+    private function auditPayment(string $action, string $intentId, Money $amount, string $status): void
+    {
+        $this->auditLogger->log(
+            event: AuditEvent::DataModification,
+            outcome: AuditOutcome::Success,
+            actor: 'payments',
+            action: $action,
+            resource: 'payment_intent:' . $intentId,
+            metadata: [
+                'provider' => $this->provider->name(),
+                'currency' => $amount->currency->value,
+                'amount_minor_units' => $amount->amount,
+                'status' => $status,
+            ],
+        );
+    }
+
+    private function auditCapture(Charge $charge): void
+    {
+        $this->auditLogger->log(
+            event: AuditEvent::DataModification,
+            outcome: AuditOutcome::Success,
+            actor: 'payments',
+            action: 'capture_intent',
+            resource: 'charge:' . $charge->id,
+            metadata: [
+                'provider' => $this->provider->name(),
+                'currency' => $charge->amount->currency->value,
+                'amount_minor_units' => $charge->amount->amount,
+                'intent_id' => $charge->intentId,
+                'status' => $charge->status->value,
+            ],
+        );
+    }
+
+    private function auditRefund(Refund $refund): void
+    {
+        $this->auditLogger->log(
+            event: AuditEvent::DataModification,
+            outcome: AuditOutcome::Success,
+            actor: 'payments',
+            action: 'refund',
+            resource: 'refund:' . $refund->id,
+            metadata: [
+                'provider' => $this->provider->name(),
+                'currency' => $refund->amount->currency->value,
+                'amount_minor_units' => $refund->amount->amount,
+                'charge_id' => $refund->chargeId,
+                'status' => $refund->status->value,
+            ],
+        );
+    }
+
+    private function incrementIntentMetric(Money $amount, string $status): void
+    {
+        $this->metricRegistry->counter(
+            'payments_intents_total',
+            'Total payment intents',
+        )->increment(new LabelSet([
+            'provider' => $this->provider->name(),
+            'currency' => $amount->currency->value,
+            'status' => $status,
+        ]));
+    }
+
+    private function incrementCaptureMetric(Charge $charge): void
+    {
+        $this->metricRegistry->counter(
+            'payments_captures_total',
+            'Total payment captures',
+        )->increment(new LabelSet([
+            'provider' => $this->provider->name(),
+            'currency' => $charge->amount->currency->value,
+            'status' => $charge->status->value,
+        ]));
+    }
+
+    private function incrementRefundMetric(Refund $refund): void
+    {
+        $this->metricRegistry->counter(
+            'payments_refunds_total',
+            'Total payment refunds',
+        )->increment(new LabelSet([
+            'provider' => $this->provider->name(),
+            'currency' => $refund->amount->currency->value,
+            'status' => $refund->status->value,
+        ]));
+    }
+
+    private function incrementProviderErrorMetric(string $operation, Throwable $e): void
+    {
+        $errorType = $e instanceof PaymentProviderException ? $e->errorType : 'unknown';
+
+        $this->metricRegistry->counter(
+            'payments_provider_errors_total',
+            'Total payment provider errors',
+        )->increment(new LabelSet([
+            'provider' => $this->provider->name(),
+            'operation' => $operation,
+            'error_type' => $errorType,
+        ]));
+    }
+
+    private function incrementReplayMetric(string $operation): void
+    {
+        $this->metricRegistry->counter(
+            'payments_idempotency_replays_total',
+            'Total idempotency replays',
+        )->increment(new LabelSet([
+            'provider' => $this->provider->name(),
+            'operation' => $operation,
+        ]));
+    }
+}

--- a/extensions/payments/src/Gateway/PaymentGateway.php
+++ b/extensions/payments/src/Gateway/PaymentGateway.php
@@ -4,15 +4,20 @@ declare(strict_types=1);
 
 namespace Pulsar\Extension\Payments\Gateway;
 
+use DateTimeImmutable;
 use Psr\Log\LoggerInterface;
 use Pulsar\Extension\Payments\Config\PaymentsConfig;
 use Pulsar\Extension\Payments\Contract\ClockInterface;
 use Pulsar\Extension\Payments\Contract\IdempotencyStoreInterface;
 use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
 use Pulsar\Extension\Payments\Domain\Charge;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Currency;
 use Pulsar\Extension\Payments\Domain\Money;
 use Pulsar\Extension\Payments\Domain\PaymentIntent;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
 use Pulsar\Extension\Payments\Domain\Refund;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
 use Pulsar\Extension\Payments\Exception\IdempotencyException;
 use Pulsar\Extension\Payments\Exception\PaymentProviderException;
 use Pulsar\Extension\Payments\Idempotency\IdempotencyClaimStatus;
@@ -366,11 +371,11 @@ final readonly class PaymentGateway
 
         return new PaymentIntent(
             id: (string) $data['id'],
-            amount: Money::of((int) $data['amount'], \Pulsar\Extension\Payments\Domain\Currency::from((string) $data['currency'])),
-            status: \Pulsar\Extension\Payments\Domain\PaymentIntentStatus::from((string) $data['status']),
+            amount: Money::of((int) $data['amount'], Currency::from((string) $data['currency'])),
+            status: PaymentIntentStatus::from((string) $data['status']),
             provider: (string) $data['provider'],
             idempotencyKey: (string) $data['idempotency_key'],
-            createdAt: (new \DateTimeImmutable())->setTimestamp((int) $data['created_at']),
+            createdAt: new DateTimeImmutable('@' . (int) $data['created_at']),
             metadata: (array) ($data['metadata'] ?? []),
         );
     }
@@ -384,10 +389,10 @@ final readonly class PaymentGateway
         return new Charge(
             id: (string) $data['id'],
             intentId: (string) $data['intent_id'],
-            amount: Money::of((int) $data['amount'], \Pulsar\Extension\Payments\Domain\Currency::from((string) $data['currency'])),
-            status: \Pulsar\Extension\Payments\Domain\ChargeStatus::from((string) $data['status']),
+            amount: Money::of((int) $data['amount'], Currency::from((string) $data['currency'])),
+            status: ChargeStatus::from((string) $data['status']),
             provider: (string) $data['provider'],
-            createdAt: (new \DateTimeImmutable())->setTimestamp((int) $data['created_at']),
+            createdAt: new DateTimeImmutable('@' . (int) $data['created_at']),
             failureReason: $data['failure_reason'] !== null ? (string) $data['failure_reason'] : null,
             metadata: (array) ($data['metadata'] ?? []),
         );
@@ -402,10 +407,10 @@ final readonly class PaymentGateway
         return new Refund(
             id: (string) $data['id'],
             chargeId: (string) $data['charge_id'],
-            amount: Money::of((int) $data['amount'], \Pulsar\Extension\Payments\Domain\Currency::from((string) $data['currency'])),
-            status: \Pulsar\Extension\Payments\Domain\RefundStatus::from((string) $data['status']),
+            amount: Money::of((int) $data['amount'], Currency::from((string) $data['currency'])),
+            status: RefundStatus::from((string) $data['status']),
             provider: (string) $data['provider'],
-            createdAt: (new \DateTimeImmutable())->setTimestamp((int) $data['created_at']),
+            createdAt: new DateTimeImmutable('@' . (int) $data['created_at']),
             failureReason: $data['failure_reason'] !== null ? (string) $data['failure_reason'] : null,
             metadata: (array) ($data['metadata'] ?? []),
         );

--- a/extensions/payments/src/Idempotency/IdempotencyClaim.php
+++ b/extensions/payments/src/Idempotency/IdempotencyClaim.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Idempotency;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Result of an idempotency claim attempt.
+ */
+#[Api]
+final readonly class IdempotencyClaim
+{
+    private function __construct(
+        public IdempotencyClaimStatus $status,
+        public ?string $resultPayload,
+    ) {}
+
+    #[NoDiscard]
+    public static function replay(string $resultPayload): self
+    {
+        return new self(IdempotencyClaimStatus::Replay, $resultPayload);
+    }
+
+    #[NoDiscard]
+    public static function claimed(): self
+    {
+        return new self(IdempotencyClaimStatus::Claimed, null);
+    }
+
+    #[NoDiscard]
+    public static function mismatch(): self
+    {
+        return new self(IdempotencyClaimStatus::Mismatch, null);
+    }
+}

--- a/extensions/payments/src/Idempotency/IdempotencyClaimStatus.php
+++ b/extensions/payments/src/Idempotency/IdempotencyClaimStatus.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Idempotency;
+
+use Pulsar\Api\Api;
+
+/**
+ * Status of an idempotency claim.
+ */
+#[Api]
+enum IdempotencyClaimStatus
+{
+    case Replay;
+    case Claimed;
+    case Mismatch;
+}

--- a/extensions/payments/src/Idempotency/InMemoryIdempotencyStore.php
+++ b/extensions/payments/src/Idempotency/InMemoryIdempotencyStore.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Idempotency;
+
+use DateTimeImmutable;
+use Override;
+use Pulsar\Extension\Payments\Contract\IdempotencyStoreInterface;
+use Pulsar\Extension\Payments\Domain\IdempotencyRecord;
+use Pulsar\Extension\Payments\Exception\IdempotencyException;
+
+/**
+ * In-memory idempotency store with Fiber-safe mutex.
+ *
+ * Uses an internal in-flight map to prevent interleaved Fiber execution
+ * from double-processing the same key.
+ */
+final class InMemoryIdempotencyStore implements IdempotencyStoreInterface
+{
+    /** @var array<string, IdempotencyRecord> */
+    private array $records = [];
+
+    /** @var array<string, bool> Fiber-safe in-flight mutex */
+    private array $inFlight = [];
+
+    #[Override]
+    public function claim(
+        string $key,
+        string $parametersHash,
+        string $operation,
+        DateTimeImmutable $now,
+        int $ttlSeconds,
+    ): IdempotencyClaim {
+        // Check for concurrent in-flight claim
+        if (isset($this->inFlight[$key])) {
+            throw IdempotencyException::concurrentClaim($key);
+        }
+
+        // Check for existing record
+        if (isset($this->records[$key])) {
+            $record = $this->records[$key];
+
+            // Expired records are treated as nonexistent
+            if ($record->expiresAt <= $now) {
+                unset($this->records[$key]);
+            } else {
+                // Check parameter hash match
+                if ($record->parametersHash !== $parametersHash) {
+                    return IdempotencyClaim::mismatch();
+                }
+
+                // Replay — return cached result if committed
+                if ($record->resultPayload !== null) {
+                    return IdempotencyClaim::replay($record->resultPayload);
+                }
+
+                // Record exists but not committed — concurrent processing
+                throw IdempotencyException::concurrentClaim($key);
+            }
+        }
+
+        // Claim the key
+        $this->inFlight[$key] = true;
+        $this->records[$key] = new IdempotencyRecord(
+            key: $key,
+            parametersHash: $parametersHash,
+            operation: $operation,
+            createdAt: $now,
+            expiresAt: $now->modify('+' . $ttlSeconds . ' seconds'),
+        );
+
+        return IdempotencyClaim::claimed();
+    }
+
+    #[Override]
+    public function commit(string $key, string $resultPayload): void
+    {
+        if (isset($this->records[$key])) {
+            $record = $this->records[$key];
+            $this->records[$key] = new IdempotencyRecord(
+                key: $record->key,
+                parametersHash: $record->parametersHash,
+                operation: $record->operation,
+                createdAt: $record->createdAt,
+                expiresAt: $record->expiresAt,
+                resultPayload: $resultPayload,
+            );
+        }
+
+        unset($this->inFlight[$key]);
+    }
+
+    #[Override]
+    public function release(string $key): void
+    {
+        unset($this->inFlight[$key], $this->records[$key]);
+    }
+
+    #[Override]
+    public function prune(DateTimeImmutable $before): int
+    {
+        $pruned = 0;
+
+        foreach ($this->records as $key => $record) {
+            if ($record->expiresAt <= $before) {
+                unset($this->records[$key]);
+                $pruned++;
+            }
+        }
+
+        return $pruned;
+    }
+}

--- a/extensions/payments/src/PaymentsExtension.php
+++ b/extensions/payments/src/PaymentsExtension.php
@@ -1,0 +1,53 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments;
+
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ExtensionInterface;
+use Pulsar\Extensibility\ServiceProviderInterface;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Controller\WebhookController;
+use Pulsar\Routing\Router;
+
+/**
+ * Vendor-agnostic payments extension.
+ *
+ * Provides payment processing, webhook verification, and idempotency
+ * enforcement without external SDK dependencies.
+ */
+final class PaymentsExtension implements ExtensionInterface
+{
+    public function name(): string
+    {
+        return 'pulsar/payments';
+    }
+
+    public function register(ContainerInterface $container): void
+    {
+        // Service provider handles all bindings
+    }
+
+    public function boot(ContainerInterface $container, Router $router): void
+    {
+        /** @var PaymentsConfig $config */
+        $config = $container->get(PaymentsConfig::class);
+
+        $router->post(
+            $config->webhook->path,
+            [WebhookController::class, 'handle'],
+            'payments.webhook',
+        );
+    }
+
+    /**
+     * @return list<class-string<ServiceProviderInterface>>
+     */
+    public function providers(): array
+    {
+        return [
+            PaymentsServiceProvider::class,
+        ];
+    }
+}

--- a/extensions/payments/src/PaymentsServiceProvider.php
+++ b/extensions/payments/src/PaymentsServiceProvider.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments;
+
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ServiceProviderInterface;
+use Pulsar\Extension\Payments\Clock\SystemClock;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\IdempotencyStoreInterface;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Contract\WebhookEventLogInterface;
+use Pulsar\Extension\Payments\Contract\WebhookVerifierInterface;
+use Pulsar\Extension\Payments\Controller\WebhookController;
+use Pulsar\Extension\Payments\Gateway\PaymentGateway;
+use Pulsar\Extension\Payments\Idempotency\InMemoryIdempotencyStore;
+use Pulsar\Extension\Payments\Provider\NullProvider;
+use Pulsar\Extension\Payments\Provider\SimulatorProvider;
+use Pulsar\Extension\Payments\Webhook\HmacWebhookVerifier;
+use Pulsar\Extension\Payments\Webhook\InMemoryWebhookEventLog;
+use Pulsar\Extension\Payments\Webhook\WebhookProcessor;
+
+/**
+ * Service provider for the payments extension.
+ *
+ * Binds all payment services to the container based on configuration.
+ */
+final class PaymentsServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerInterface $container): void
+    {
+        // Clock
+        $container->bind(ClockInterface::class, SystemClock::class);
+
+        // Config
+        $container->bind(PaymentsConfig::class, static function () use ($container): PaymentsConfig {
+            /** @var array<string, mixed> $configData */
+            $configData = [];
+
+            if ($container->has('config.payments')) {
+                /** @var array<string, mixed> $configData */
+                $configData = $container->get('config.payments');
+            }
+
+            return PaymentsConfig::fromArray($configData);
+        });
+
+        // Provider
+        $container->bind(PaymentProviderInterface::class, static function () use ($container): PaymentProviderInterface {
+            /** @var PaymentsConfig $config */
+            $config = $container->get(PaymentsConfig::class);
+
+            /** @var ClockInterface $clock */
+            $clock = $container->get(ClockInterface::class);
+
+            return match ($config->provider) {
+                'null' => new NullProvider($clock),
+                'simulator' => new SimulatorProvider($clock),
+                default => $container->get($config->provider),
+            };
+        });
+
+        // Idempotency store
+        $container->bind(IdempotencyStoreInterface::class, static function () use ($container): IdempotencyStoreInterface {
+            /** @var PaymentsConfig $config */
+            $config = $container->get(PaymentsConfig::class);
+
+            return match ($config->idempotency->store) {
+                'memory' => new InMemoryIdempotencyStore(),
+                default => $container->get($config->idempotency->store),
+            };
+        });
+
+        // Webhook event log
+        $container->bind(WebhookEventLogInterface::class, static function () use ($container): WebhookEventLogInterface {
+            /** @var PaymentsConfig $config */
+            $config = $container->get(PaymentsConfig::class);
+
+            return match ($config->webhookLog->store) {
+                'memory' => new InMemoryWebhookEventLog(),
+                default => $container->get($config->webhookLog->store),
+            };
+        });
+
+        // Webhook verifier
+        $container->bind(WebhookVerifierInterface::class, HmacWebhookVerifier::class);
+
+        // Gateway
+        $container->bind(PaymentGateway::class, PaymentGateway::class);
+
+        // Webhook processor
+        $container->bind(WebhookProcessor::class, WebhookProcessor::class);
+
+        // Controller
+        $container->bind(WebhookController::class, WebhookController::class);
+    }
+
+    public function provides(): array
+    {
+        return [
+            ClockInterface::class,
+            PaymentsConfig::class,
+            PaymentProviderInterface::class,
+            IdempotencyStoreInterface::class,
+            WebhookEventLogInterface::class,
+            WebhookVerifierInterface::class,
+            PaymentGateway::class,
+            WebhookProcessor::class,
+            WebhookController::class,
+        ];
+    }
+}

--- a/extensions/payments/src/Provider/NullProvider.php
+++ b/extensions/payments/src/Provider/NullProvider.php
@@ -1,0 +1,127 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Provider;
+
+use DateTimeImmutable;
+use Override;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\Charge;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntent;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+use Pulsar\Extension\Payments\Domain\Refund;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+
+/**
+ * No-op success provider for testing and development.
+ *
+ * All operations succeed immediately with deterministic IDs.
+ */
+final readonly class NullProvider implements PaymentProviderInterface
+{
+    /** @var array<string, PaymentIntent> */
+    private array $intents;
+
+    /** @var array<string, Charge> */
+    private array $charges;
+
+    /** @var array<string, Refund> */
+    private array $refunds;
+
+    public function __construct(
+        private ClockInterface $clock,
+    ) {
+        $this->intents = [];
+        $this->charges = [];
+        $this->refunds = [];
+    }
+
+    #[Override]
+    public function name(): string
+    {
+        return 'null';
+    }
+
+    #[Override]
+    public function createIntent(Money $amount, string $idempotencyKey, array $metadata = []): PaymentIntent
+    {
+        return new PaymentIntent(
+            id: self::generateId('null', 'create_intent', $idempotencyKey),
+            amount: $amount,
+            status: PaymentIntentStatus::Created,
+            provider: $this->name(),
+            idempotencyKey: $idempotencyKey,
+            createdAt: $this->clock->now(),
+            metadata: $metadata,
+        );
+    }
+
+    #[Override]
+    public function captureIntent(string $intentId, string $idempotencyKey): Charge
+    {
+        return new Charge(
+            id: self::generateId('null', 'capture_intent', $idempotencyKey, $intentId),
+            intentId: $intentId,
+            amount: Money::of(0, \Pulsar\Extension\Payments\Domain\Currency::USD),
+            status: ChargeStatus::Succeeded,
+            provider: $this->name(),
+            createdAt: $this->clock->now(),
+        );
+    }
+
+    #[Override]
+    public function cancelIntent(string $intentId, string $idempotencyKey): PaymentIntent
+    {
+        return new PaymentIntent(
+            id: $intentId,
+            amount: Money::of(0, \Pulsar\Extension\Payments\Domain\Currency::USD),
+            status: PaymentIntentStatus::Cancelled,
+            provider: $this->name(),
+            idempotencyKey: $idempotencyKey,
+            createdAt: $this->clock->now(),
+        );
+    }
+
+    #[Override]
+    public function refund(string $chargeId, ?Money $amount, string $idempotencyKey): Refund
+    {
+        return new Refund(
+            id: self::generateId('null', 'refund', $idempotencyKey, $chargeId),
+            chargeId: $chargeId,
+            amount: $amount ?? Money::of(0, \Pulsar\Extension\Payments\Domain\Currency::USD),
+            status: RefundStatus::Succeeded,
+            provider: $this->name(),
+            createdAt: $this->clock->now(),
+        );
+    }
+
+    #[Override]
+    public function getIntent(string $intentId): PaymentIntent
+    {
+        throw PaymentException::notFound('PaymentIntent', $intentId);
+    }
+
+    #[Override]
+    public function getCharge(string $chargeId): Charge
+    {
+        throw PaymentException::notFound('Charge', $chargeId);
+    }
+
+    #[Override]
+    public function getRefund(string $refundId): Refund
+    {
+        throw PaymentException::notFound('Refund', $refundId);
+    }
+
+    private static function generateId(string $provider, string $operation, string $idempotencyKey, string $resourceId = ''): string
+    {
+        $input = $provider . ':' . $operation . ':' . $idempotencyKey . ':' . $resourceId;
+
+        return \substr(hash('sha256', $input), 0, 32);
+    }
+}

--- a/extensions/payments/src/Provider/NullProvider.php
+++ b/extensions/payments/src/Provider/NullProvider.php
@@ -4,12 +4,12 @@ declare(strict_types=1);
 
 namespace Pulsar\Extension\Payments\Provider;
 
-use DateTimeImmutable;
 use Override;
 use Pulsar\Extension\Payments\Contract\ClockInterface;
 use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
 use Pulsar\Extension\Payments\Domain\Charge;
 use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Currency;
 use Pulsar\Extension\Payments\Domain\Money;
 use Pulsar\Extension\Payments\Domain\PaymentIntent;
 use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
@@ -24,22 +24,9 @@ use Pulsar\Extension\Payments\Exception\PaymentException;
  */
 final readonly class NullProvider implements PaymentProviderInterface
 {
-    /** @var array<string, PaymentIntent> */
-    private array $intents;
-
-    /** @var array<string, Charge> */
-    private array $charges;
-
-    /** @var array<string, Refund> */
-    private array $refunds;
-
     public function __construct(
         private ClockInterface $clock,
-    ) {
-        $this->intents = [];
-        $this->charges = [];
-        $this->refunds = [];
-    }
+    ) {}
 
     #[Override]
     public function name(): string
@@ -67,7 +54,7 @@ final readonly class NullProvider implements PaymentProviderInterface
         return new Charge(
             id: self::generateId('null', 'capture_intent', $idempotencyKey, $intentId),
             intentId: $intentId,
-            amount: Money::of(0, \Pulsar\Extension\Payments\Domain\Currency::USD),
+            amount: Money::of(0, Currency::USD),
             status: ChargeStatus::Succeeded,
             provider: $this->name(),
             createdAt: $this->clock->now(),
@@ -79,7 +66,7 @@ final readonly class NullProvider implements PaymentProviderInterface
     {
         return new PaymentIntent(
             id: $intentId,
-            amount: Money::of(0, \Pulsar\Extension\Payments\Domain\Currency::USD),
+            amount: Money::of(0, Currency::USD),
             status: PaymentIntentStatus::Cancelled,
             provider: $this->name(),
             idempotencyKey: $idempotencyKey,
@@ -93,7 +80,7 @@ final readonly class NullProvider implements PaymentProviderInterface
         return new Refund(
             id: self::generateId('null', 'refund', $idempotencyKey, $chargeId),
             chargeId: $chargeId,
-            amount: $amount ?? Money::of(0, \Pulsar\Extension\Payments\Domain\Currency::USD),
+            amount: $amount ?? Money::of(0, Currency::USD),
             status: RefundStatus::Succeeded,
             provider: $this->name(),
             createdAt: $this->clock->now(),

--- a/extensions/payments/src/Provider/NullProvider.php
+++ b/extensions/payments/src/Provider/NullProvider.php
@@ -17,6 +17,8 @@ use Pulsar\Extension\Payments\Domain\Refund;
 use Pulsar\Extension\Payments\Domain\RefundStatus;
 use Pulsar\Extension\Payments\Exception\PaymentException;
 
+use function substr;
+
 /**
  * No-op success provider for testing and development.
  *
@@ -38,7 +40,7 @@ final readonly class NullProvider implements PaymentProviderInterface
     public function createIntent(Money $amount, string $idempotencyKey, array $metadata = []): PaymentIntent
     {
         return new PaymentIntent(
-            id: self::generateId('null', 'create_intent', $idempotencyKey),
+            id: self::generateId('create_intent', $idempotencyKey),
             amount: $amount,
             status: PaymentIntentStatus::Created,
             provider: $this->name(),
@@ -52,7 +54,7 @@ final readonly class NullProvider implements PaymentProviderInterface
     public function captureIntent(string $intentId, string $idempotencyKey): Charge
     {
         return new Charge(
-            id: self::generateId('null', 'capture_intent', $idempotencyKey, $intentId),
+            id: self::generateId('capture_intent', $idempotencyKey, $intentId),
             intentId: $intentId,
             amount: Money::of(0, Currency::USD),
             status: ChargeStatus::Succeeded,
@@ -78,7 +80,7 @@ final readonly class NullProvider implements PaymentProviderInterface
     public function refund(string $chargeId, ?Money $amount, string $idempotencyKey): Refund
     {
         return new Refund(
-            id: self::generateId('null', 'refund', $idempotencyKey, $chargeId),
+            id: self::generateId('refund', $idempotencyKey, $chargeId),
             chargeId: $chargeId,
             amount: $amount ?? Money::of(0, Currency::USD),
             status: RefundStatus::Succeeded,
@@ -105,10 +107,10 @@ final readonly class NullProvider implements PaymentProviderInterface
         throw PaymentException::notFound('Refund', $refundId);
     }
 
-    private static function generateId(string $provider, string $operation, string $idempotencyKey, string $resourceId = ''): string
+    private static function generateId(string $operation, string $idempotencyKey, string $resourceId = ''): string
     {
-        $input = $provider . ':' . $operation . ':' . $idempotencyKey . ':' . $resourceId;
+        $input = 'null:' . $operation . ':' . $idempotencyKey . ':' . $resourceId;
 
-        return \substr(hash('sha256', $input), 0, 32);
+        return substr(hash('sha256', $input), 0, 32);
     }
 }

--- a/extensions/payments/src/Provider/SimulatorProvider.php
+++ b/extensions/payments/src/Provider/SimulatorProvider.php
@@ -4,13 +4,11 @@ declare(strict_types=1);
 
 namespace Pulsar\Extension\Payments\Provider;
 
-use DateTimeImmutable;
 use Override;
 use Pulsar\Extension\Payments\Contract\ClockInterface;
 use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
 use Pulsar\Extension\Payments\Domain\Charge;
 use Pulsar\Extension\Payments\Domain\ChargeStatus;
-use Pulsar\Extension\Payments\Domain\Currency;
 use Pulsar\Extension\Payments\Domain\Money;
 use Pulsar\Extension\Payments\Domain\PaymentIntent;
 use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;

--- a/extensions/payments/src/Provider/SimulatorProvider.php
+++ b/extensions/payments/src/Provider/SimulatorProvider.php
@@ -1,0 +1,203 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Provider;
+
+use DateTimeImmutable;
+use Override;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\Charge;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntent;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+use Pulsar\Extension\Payments\Domain\Refund;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+use Pulsar\Extension\Payments\Exception\PaymentProviderException;
+
+/**
+ * Deterministic test vector provider for integration testing.
+ *
+ * Test vectors (by amount in minor units):
+ * - 9999: Decline (insufficient_funds)
+ * - 9998: Decline (card_expired)
+ * - 9997: Decline (card_declined)
+ * - 9996: Decline (processing_error)
+ * - 9995: Decline (fraud_suspected)
+ * - 9994: Timeout exception
+ * - 9993: Network error exception
+ * - 9992: Rate limited exception
+ * - 4242: Success, then dispute after capture
+ * - 3030: Success, but refund fails
+ * - All others: Success
+ */
+final class SimulatorProvider implements PaymentProviderInterface
+{
+    /** @var array<string, PaymentIntent> */
+    private array $intents = [];
+
+    /** @var array<string, Charge> */
+    private array $charges = [];
+
+    /** @var array<string, Refund> */
+    private array $refunds = [];
+
+    /** @var array<string, bool> chargeId => dispute flag for 4242 amounts */
+    private array $disputeFlags = [];
+
+    /** @var array<string, bool> chargeId => refund-fail flag for 3030 amounts */
+    private array $refundFailFlags = [];
+
+    public function __construct(
+        private readonly ClockInterface $clock,
+    ) {}
+
+    #[Override]
+    public function name(): string
+    {
+        return 'simulator';
+    }
+
+    #[Override]
+    public function createIntent(Money $amount, string $idempotencyKey, array $metadata = []): PaymentIntent
+    {
+        $this->applyTestVector($amount->amount);
+
+        $id = self::generateId('simulator', 'create_intent', $idempotencyKey);
+        $intent = new PaymentIntent(
+            id: $id,
+            amount: $amount,
+            status: PaymentIntentStatus::Created,
+            provider: $this->name(),
+            idempotencyKey: $idempotencyKey,
+            createdAt: $this->clock->now(),
+            metadata: $metadata,
+        );
+
+        $this->intents[$id] = $intent;
+
+        return $intent;
+    }
+
+    #[Override]
+    public function captureIntent(string $intentId, string $idempotencyKey): Charge
+    {
+        $intent = $this->intents[$intentId] ?? throw PaymentException::notFound('PaymentIntent', $intentId);
+
+        $chargeId = self::generateId('simulator', 'capture_intent', $idempotencyKey, $intentId);
+        $charge = new Charge(
+            id: $chargeId,
+            intentId: $intentId,
+            amount: $intent->amount,
+            status: ChargeStatus::Succeeded,
+            provider: $this->name(),
+            createdAt: $this->clock->now(),
+        );
+
+        $this->charges[$chargeId] = $charge;
+        $this->intents[$intentId] = $intent->transitionTo(PaymentIntentStatus::Captured);
+
+        // Flag for dispute if 4242
+        if ($intent->amount->amount === 4242) {
+            $this->disputeFlags[$chargeId] = true;
+        }
+
+        // Flag for refund failure if 3030
+        if ($intent->amount->amount === 3030) {
+            $this->refundFailFlags[$chargeId] = true;
+        }
+
+        return $charge;
+    }
+
+    #[Override]
+    public function cancelIntent(string $intentId, string $idempotencyKey): PaymentIntent
+    {
+        $intent = $this->intents[$intentId] ?? throw PaymentException::notFound('PaymentIntent', $intentId);
+
+        $cancelled = $intent->transitionTo(PaymentIntentStatus::Cancelled);
+        $this->intents[$intentId] = $cancelled;
+
+        return $cancelled;
+    }
+
+    #[Override]
+    public function refund(string $chargeId, ?Money $amount, string $idempotencyKey): Refund
+    {
+        $charge = $this->charges[$chargeId] ?? throw PaymentException::notFound('Charge', $chargeId);
+
+        if (isset($this->refundFailFlags[$chargeId])) {
+            throw PaymentProviderException::refundFailed('simulated_refund_failure');
+        }
+
+        $refundAmount = $amount ?? $charge->amount;
+        $refundId = self::generateId('simulator', 'refund', $idempotencyKey, $chargeId);
+        $refund = new Refund(
+            id: $refundId,
+            chargeId: $chargeId,
+            amount: $refundAmount,
+            status: RefundStatus::Succeeded,
+            provider: $this->name(),
+            createdAt: $this->clock->now(),
+        );
+
+        $this->refunds[$refundId] = $refund;
+
+        return $refund;
+    }
+
+    #[Override]
+    public function getIntent(string $intentId): PaymentIntent
+    {
+        return $this->intents[$intentId] ?? throw PaymentException::notFound('PaymentIntent', $intentId);
+    }
+
+    #[Override]
+    public function getCharge(string $chargeId): Charge
+    {
+        return $this->charges[$chargeId] ?? throw PaymentException::notFound('Charge', $chargeId);
+    }
+
+    #[Override]
+    public function getRefund(string $refundId): Refund
+    {
+        return $this->refunds[$refundId] ?? throw PaymentException::notFound('Refund', $refundId);
+    }
+
+    /**
+     * Check if a charge has been flagged for dispute (4242 test vector).
+     */
+    public function hasDisputeFlag(string $chargeId): bool
+    {
+        return isset($this->disputeFlags[$chargeId]);
+    }
+
+    /**
+     * @throws PaymentProviderException On test vector amounts
+     */
+    private function applyTestVector(int $amount): void
+    {
+        match ($amount) {
+            9999 => throw PaymentProviderException::declined('insufficient_funds'),
+            9998 => throw PaymentProviderException::declined('card_expired'),
+            9997 => throw PaymentProviderException::declined('card_declined'),
+            9996 => throw PaymentProviderException::declined('processing_error'),
+            9995 => throw PaymentProviderException::declined('fraud_suspected'),
+            9994 => throw PaymentProviderException::timeout(),
+            9993 => throw PaymentProviderException::networkError(),
+            9992 => throw PaymentProviderException::rateLimited(),
+            default => null,
+        };
+    }
+
+    private static function generateId(string $provider, string $operation, string $idempotencyKey, string $resourceId = ''): string
+    {
+        $input = $provider . ':' . $operation . ':' . $idempotencyKey . ':' . $resourceId;
+
+        return \substr(hash('sha256', $input), 0, 32);
+    }
+}

--- a/extensions/payments/src/Provider/SimulatorProvider.php
+++ b/extensions/payments/src/Provider/SimulatorProvider.php
@@ -17,6 +17,8 @@ use Pulsar\Extension\Payments\Domain\RefundStatus;
 use Pulsar\Extension\Payments\Exception\PaymentException;
 use Pulsar\Extension\Payments\Exception\PaymentProviderException;
 
+use function substr;
+
 /**
  * Deterministic test vector provider for integration testing.
  *
@@ -65,7 +67,7 @@ final class SimulatorProvider implements PaymentProviderInterface
     {
         $this->applyTestVector($amount->amount);
 
-        $id = self::generateId('simulator', 'create_intent', $idempotencyKey);
+        $id = self::generateId('create_intent', $idempotencyKey);
         $intent = new PaymentIntent(
             id: $id,
             amount: $amount,
@@ -86,7 +88,7 @@ final class SimulatorProvider implements PaymentProviderInterface
     {
         $intent = $this->intents[$intentId] ?? throw PaymentException::notFound('PaymentIntent', $intentId);
 
-        $chargeId = self::generateId('simulator', 'capture_intent', $idempotencyKey, $intentId);
+        $chargeId = self::generateId('capture_intent', $idempotencyKey, $intentId);
         $charge = new Charge(
             id: $chargeId,
             intentId: $intentId,
@@ -133,7 +135,7 @@ final class SimulatorProvider implements PaymentProviderInterface
         }
 
         $refundAmount = $amount ?? $charge->amount;
-        $refundId = self::generateId('simulator', 'refund', $idempotencyKey, $chargeId);
+        $refundId = self::generateId('refund', $idempotencyKey, $chargeId);
         $refund = new Refund(
             id: $refundId,
             chargeId: $chargeId,
@@ -192,10 +194,10 @@ final class SimulatorProvider implements PaymentProviderInterface
         };
     }
 
-    private static function generateId(string $provider, string $operation, string $idempotencyKey, string $resourceId = ''): string
+    private static function generateId(string $operation, string $idempotencyKey, string $resourceId = ''): string
     {
-        $input = $provider . ':' . $operation . ':' . $idempotencyKey . ':' . $resourceId;
+        $input = 'simulator:' . $operation . ':' . $idempotencyKey . ':' . $resourceId;
 
-        return \substr(hash('sha256', $input), 0, 32);
+        return substr(hash('sha256', $input), 0, 32);
     }
 }

--- a/extensions/payments/src/Webhook/HmacWebhookVerifier.php
+++ b/extensions/payments/src/Webhook/HmacWebhookVerifier.php
@@ -9,6 +9,10 @@ use Pulsar\Extension\Payments\Contract\ClockInterface;
 use Pulsar\Extension\Payments\Contract\WebhookVerifierInterface;
 use Pulsar\Extension\Payments\Exception\WebhookException;
 
+use function abs;
+use function str_starts_with;
+use function substr;
+
 /**
  * HMAC-SHA256 webhook signature verifier.
  *
@@ -34,7 +38,7 @@ final readonly class HmacWebhookVerifier implements WebhookVerifierInterface
 
         // Check timestamp tolerance
         $now = $this->clock->now()->getTimestamp();
-        $age = \abs($now - $timestamp);
+        $age = abs($now - $timestamp);
 
         if ($age > $toleranceSeconds) {
             throw WebhookException::expiredTimestamp($age, $toleranceSeconds);
@@ -72,14 +76,14 @@ final readonly class HmacWebhookVerifier implements WebhookVerifierInterface
         foreach ($parts as $part) {
             $part = trim($part);
 
-            if (\str_starts_with($part, 't=')) {
-                $value = \substr($part, 2);
+            if (str_starts_with($part, 't=')) {
+                $value = substr($part, 2);
                 if (!ctype_digit($value) || $value === '') {
                     throw WebhookException::malformedHeader('invalid timestamp');
                 }
                 $timestamp = (int) $value;
-            } elseif (\str_starts_with($part, 'v1=')) {
-                $value = \substr($part, 3);
+            } elseif (str_starts_with($part, 'v1=')) {
+                $value = substr($part, 3);
                 if ($value !== '') {
                     $signatures[] = $value;
                 }

--- a/extensions/payments/src/Webhook/HmacWebhookVerifier.php
+++ b/extensions/payments/src/Webhook/HmacWebhookVerifier.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Webhook;
+
+use Override;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\WebhookVerifierInterface;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+
+/**
+ * HMAC-SHA256 webhook signature verifier.
+ *
+ * Header format: t={unix_timestamp},v1={hex_signature}[,v1={hex_signature}...]
+ * Multiple v1= values are allowed for secret rotation.
+ */
+final readonly class HmacWebhookVerifier implements WebhookVerifierInterface
+{
+    public function __construct(
+        private ClockInterface $clock,
+    ) {}
+
+    #[Override]
+    public function verify(
+        string $payload,
+        string $signatureHeader,
+        string $secret,
+        int $toleranceSeconds,
+    ): void {
+        $parsed = self::parseHeader($signatureHeader);
+        $timestamp = $parsed['timestamp'];
+        $signatures = $parsed['signatures'];
+
+        // Check timestamp tolerance
+        $now = $this->clock->now()->getTimestamp();
+        $age = \abs($now - $timestamp);
+
+        if ($age > $toleranceSeconds) {
+            throw WebhookException::expiredTimestamp($age, $toleranceSeconds);
+        }
+
+        // Compute expected signature
+        $signedPayload = $timestamp . '.' . $payload;
+        $expected = hash_hmac('sha256', $signedPayload, $secret);
+
+        // Check each candidate with constant-time comparison
+        foreach ($signatures as $candidate) {
+            if (hash_equals($expected, $candidate)) {
+                return;
+            }
+        }
+
+        throw WebhookException::invalidSignature();
+    }
+
+    /**
+     * @return array{timestamp: int, signatures: list<string>}
+     *
+     * @throws WebhookException
+     */
+    private static function parseHeader(string $header): array
+    {
+        if ($header === '') {
+            throw WebhookException::malformedHeader('empty header');
+        }
+
+        $parts = explode(',', $header);
+        $timestamp = null;
+        $signatures = [];
+
+        foreach ($parts as $part) {
+            $part = trim($part);
+
+            if (\str_starts_with($part, 't=')) {
+                $value = \substr($part, 2);
+                if (!ctype_digit($value) || $value === '') {
+                    throw WebhookException::malformedHeader('invalid timestamp');
+                }
+                $timestamp = (int) $value;
+            } elseif (\str_starts_with($part, 'v1=')) {
+                $value = \substr($part, 3);
+                if ($value !== '') {
+                    $signatures[] = $value;
+                }
+            }
+        }
+
+        if ($timestamp === null) {
+            throw WebhookException::malformedHeader('missing timestamp');
+        }
+
+        if ($signatures === []) {
+            throw WebhookException::malformedHeader('no v1 signatures');
+        }
+
+        return ['timestamp' => $timestamp, 'signatures' => $signatures];
+    }
+}

--- a/extensions/payments/src/Webhook/InMemoryWebhookEventLog.php
+++ b/extensions/payments/src/Webhook/InMemoryWebhookEventLog.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Webhook;
+
+use DateTimeImmutable;
+use Override;
+use Pulsar\Extension\Payments\Contract\WebhookEventLogInterface;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+
+/**
+ * In-memory webhook replay prevention store with Fiber-safe mutex.
+ */
+final class InMemoryWebhookEventLog implements WebhookEventLogInterface
+{
+    /** @var array<string, DateTimeImmutable> eventId => processedAt */
+    private array $processed = [];
+
+    /** @var array<string, DateTimeImmutable> eventId => expiresAt */
+    private array $expiry = [];
+
+    /** @var array<string, bool> Fiber-safe in-flight mutex */
+    private array $inFlight = [];
+
+    #[Override]
+    public function claim(string $eventId, DateTimeImmutable $now, int $ttlSeconds): WebhookClaim
+    {
+        // Check for concurrent in-flight claim
+        if (isset($this->inFlight[$eventId])) {
+            throw WebhookException::concurrentClaim($eventId);
+        }
+
+        // Check for already-processed event
+        if (isset($this->processed[$eventId])) {
+            // Check if expired
+            if (isset($this->expiry[$eventId]) && $this->expiry[$eventId] <= $now) {
+                unset($this->processed[$eventId], $this->expiry[$eventId]);
+            } else {
+                return WebhookClaim::replay($this->processed[$eventId]);
+            }
+        }
+
+        // Claim the event
+        $this->inFlight[$eventId] = true;
+
+        return WebhookClaim::claimed();
+    }
+
+    #[Override]
+    public function commit(string $eventId): void
+    {
+        $now = new DateTimeImmutable();
+        $this->processed[$eventId] = $now;
+
+        // Use the current time + a long TTL for expiry tracking
+        // The actual TTL was specified in claim(), but we need to store it somehow
+        // For simplicity, commit records the current time and the prune handles cleanup
+        if (!isset($this->expiry[$eventId])) {
+            // Default 72h expiry if not set during claim
+            $this->expiry[$eventId] = $now->modify('+259200 seconds');
+        }
+
+        unset($this->inFlight[$eventId]);
+    }
+
+    #[Override]
+    public function release(string $eventId): void
+    {
+        unset($this->inFlight[$eventId]);
+    }
+
+    #[Override]
+    public function prune(DateTimeImmutable $before): int
+    {
+        $pruned = 0;
+
+        foreach ($this->expiry as $eventId => $expiresAt) {
+            if ($expiresAt <= $before) {
+                unset($this->processed[$eventId], $this->expiry[$eventId]);
+                $pruned++;
+            }
+        }
+
+        return $pruned;
+    }
+}

--- a/extensions/payments/src/Webhook/WebhookClaim.php
+++ b/extensions/payments/src/Webhook/WebhookClaim.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Webhook;
+
+use DateTimeImmutable;
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Result of a webhook event claim attempt.
+ */
+#[Api]
+final readonly class WebhookClaim
+{
+    private function __construct(
+        public WebhookClaimStatus $status,
+        public ?DateTimeImmutable $processedAt,
+    ) {}
+
+    #[NoDiscard]
+    public static function replay(DateTimeImmutable $processedAt): self
+    {
+        return new self(WebhookClaimStatus::Replay, $processedAt);
+    }
+
+    #[NoDiscard]
+    public static function claimed(): self
+    {
+        return new self(WebhookClaimStatus::Claimed, null);
+    }
+}

--- a/extensions/payments/src/Webhook/WebhookClaimStatus.php
+++ b/extensions/payments/src/Webhook/WebhookClaimStatus.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Webhook;
+
+use Pulsar\Api\Api;
+
+/**
+ * Status of a webhook event claim.
+ */
+#[Api]
+enum WebhookClaimStatus
+{
+    case Replay;
+    case Claimed;
+}

--- a/extensions/payments/src/Webhook/WebhookProcessor.php
+++ b/extensions/payments/src/Webhook/WebhookProcessor.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\Payments\Webhook;
+
+use Psr\Log\LoggerInterface;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\WebhookEventLogInterface;
+use Pulsar\Extension\Payments\Contract\WebhookHandlerInterface;
+use Pulsar\Extension\Payments\Contract\WebhookVerifierInterface;
+use Pulsar\Extension\Payments\Domain\WebhookEvent;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Throwable;
+
+/**
+ * Webhook processor: verify + deduplicate + dispatch.
+ *
+ * Uses record-after-success ordering to ensure failed dispatches are
+ * retried by the vendor (never silently dropped).
+ */
+final readonly class WebhookProcessor
+{
+    public function __construct(
+        private WebhookVerifierInterface $verifier,
+        private WebhookEventLogInterface $eventLog,
+        private WebhookHandlerInterface $handler,
+        private ClockInterface $clock,
+        private MetricRegistry $metricRegistry,
+        private LoggerInterface $logger,
+        private PaymentsConfig $config,
+    ) {}
+
+    /**
+     * Process an incoming webhook request.
+     *
+     * @param string $rawBody Raw request body bytes
+     * @param string $signatureHeader Signature header value
+     */
+    public function process(string $rawBody, string $signatureHeader): Response
+    {
+        $webhookConfig = $this->config->webhook;
+        $provider = $this->config->provider;
+
+        // 1. Verify signature
+        try {
+            $this->verifier->verify(
+                $rawBody,
+                $signatureHeader,
+                $webhookConfig->secret,
+                $webhookConfig->toleranceSeconds,
+            );
+        } catch (Throwable $e) {
+            $this->incrementWebhookMetric($provider, 'unknown', 'invalid_sig');
+            $this->logger->warning('Webhook signature verification failed', [
+                'error' => $e->getMessage(),
+            ]);
+
+            return Response::json(
+                ['status' => 'invalid_signature'],
+                ResponseStatus::Forbidden,
+            );
+        }
+
+        // 2. Parse event
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        $event = WebhookEvent::fromArray($decoded);
+
+        // 3. Claim event for deduplication
+        $claim = $this->eventLog->claim(
+            $event->id,
+            $this->clock->now(),
+            $this->config->webhookLog->ttlSeconds,
+        );
+
+        if ($claim->status === WebhookClaimStatus::Replay) {
+            $this->incrementWebhookMetric($provider, $event->type->value, 'replay');
+
+            return Response::json(['status' => 'already_processed']);
+        }
+
+        // 4. Dispatch to handler
+        try {
+            $this->handler->handle($event);
+            $this->eventLog->commit($event->id);
+            $this->incrementWebhookMetric($provider, $event->type->value, 'ok');
+
+            return Response::json(['status' => 'processed']);
+        } catch (Throwable $e) {
+            $this->eventLog->release($event->id);
+            $this->incrementWebhookMetric($provider, $event->type->value, 'handler_error');
+            $this->metricRegistry->counter(
+                'payments_webhook_handler_errors_total',
+                'Total webhook handler errors',
+            )->increment(new LabelSet([
+                'provider' => $provider,
+                'event_type' => $event->type->value,
+            ]));
+
+            $this->logger->error('Webhook handler failed', [
+                'event_id' => $event->id,
+                'event_type' => $event->type->value,
+                'error' => $e->getMessage(),
+            ]);
+
+            return Response::json(
+                ['status' => 'handler_error'],
+                ResponseStatus::InternalServerError,
+            );
+        }
+    }
+
+    private function incrementWebhookMetric(string $provider, string $eventType, string $status): void
+    {
+        $this->metricRegistry->counter(
+            'payments_webhooks_total',
+            'Total webhook events processed',
+        )->increment(new LabelSet([
+            'provider' => $provider,
+            'event_type' => $eventType,
+            'status' => $status,
+        ]));
+    }
+}

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -50,3 +50,4 @@ exclude:
     paths:
       - composer.json
       - extensions/example/composer.json
+      - extensions/payments/composer.json

--- a/src/Extensibility/ExtensionManifest.php
+++ b/src/Extensibility/ExtensionManifest.php
@@ -95,7 +95,7 @@ readonly class ExtensionManifest
         $pulsarData = $data['pulsar'] ?? [];
         $pulsar = PulsarVersionConfig::fromArray($pulsarData);
 
-        /** @var array{services?: list<string>, commands?: list<string>, routes?: bool, middleware?: list<string>} $providesData */
+        /** @var array<string, mixed> $providesData */
         $providesData = $data['provides'] ?? [];
         $provides = ProvidesConfig::fromArray($providesData);
 

--- a/src/Extensibility/Manifest/ProvidesConfig.php
+++ b/src/Extensibility/Manifest/ProvidesConfig.php
@@ -5,6 +5,8 @@ declare(strict_types=1);
 namespace Pulsar\Extensibility\Manifest;
 
 use function array_is_list;
+use function is_array;
+use function is_bool;
 
 use NoDiscard;
 use Pulsar\Api\Api;
@@ -32,7 +34,7 @@ readonly class ProvidesConfig
     /**
      * Create from manifest array data.
      *
-     * @param array{services?: list<string>, commands?: list<string>, routes?: bool, middleware?: list<string>} $data
+     * @param array<string, mixed> $data
      */
     #[NoDiscard]
     public static function fromArray(array $data): self
@@ -40,23 +42,39 @@ readonly class ProvidesConfig
         $services = $data['services'] ?? [];
         $commands = $data['commands'] ?? [];
         $middleware = $data['middleware'] ?? [];
+        $routes = $data['routes'] ?? false;
+
+        if (!is_array($services)) {
+            throw ManifestException::invalidFieldType('provides.services', 'list', 'non-array', '');
+        }
+
+        if (!is_array($commands)) {
+            throw ManifestException::invalidFieldType('provides.commands', 'list', 'non-array', '');
+        }
+
+        if (!is_array($middleware)) {
+            throw ManifestException::invalidFieldType('provides.middleware', 'list', 'non-array', '');
+        }
 
         if ($services !== [] && !array_is_list($services)) {
             throw ManifestException::invalidFieldType('provides.services', 'list', 'associative array', '');
         }
+        /** @var list<string> $services */
 
         if ($commands !== [] && !array_is_list($commands)) {
             throw ManifestException::invalidFieldType('provides.commands', 'list', 'associative array', '');
         }
+        /** @var list<string> $commands */
 
         if ($middleware !== [] && !array_is_list($middleware)) {
             throw ManifestException::invalidFieldType('provides.middleware', 'list', 'associative array', '');
         }
+        /** @var list<string> $middleware */
 
         return new self(
             services: $services,
             commands: $commands,
-            routes: $data['routes'] ?? false,
+            routes: is_bool($routes) ? $routes : false,
             middleware: $middleware,
         );
     }

--- a/tests/Unit/Cache/CacheAllowedClassesTest.php
+++ b/tests/Unit/Cache/CacheAllowedClassesTest.php
@@ -1,0 +1,156 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Cache;
+
+use function dirname;
+use function file_put_contents;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+use function mkdir;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Cache\CacheAllowedClasses;
+
+use function sys_get_temp_dir;
+use function unlink;
+
+#[CoversClass(CacheAllowedClasses::class)]
+final class CacheAllowedClassesTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pulsar_cache_test_' . uniqid();
+        mkdir($this->tempDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        // Clean up temp files
+        $files = glob($this->tempDir . DIRECTORY_SEPARATOR . '*');
+        if ($files !== false) {
+            foreach ($files as $file) {
+                unlink($file);
+            }
+        }
+
+        rmdir($this->tempDir);
+    }
+
+    #[Test]
+    public function scanReturnsEligibleClasses(): void
+    {
+        $vendorPath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'vendor';
+        $srcPath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'src';
+
+        $result = CacheAllowedClasses::scan($vendorPath, $srcPath);
+
+        // Result is a sorted list — verify every entry is from an eligible namespace
+        foreach ($result as $class) {
+            $inEligible = str_starts_with($class, 'Pulsar\\Config\\')
+                || str_starts_with($class, 'Pulsar\\Cache\\')
+                || str_starts_with($class, 'Pulsar\\Routing\\')
+                || str_starts_with($class, 'Pulsar\\Http\\');
+            self::assertTrue($inEligible, "Class {$class} should be in an eligible namespace");
+        }
+
+        // scan() must return a list (possibly empty if no eligible classes)
+        self::assertSame(array_values($result), $result);
+    }
+
+    #[Test]
+    public function scanReturnsSortedResults(): void
+    {
+        $vendorPath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'vendor';
+        $srcPath = dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'src';
+
+        $result = CacheAllowedClasses::scan($vendorPath, $srcPath);
+
+        $sorted = $result;
+        sort($sorted);
+        self::assertSame($sorted, $result);
+    }
+
+    #[Test]
+    public function saveAndLoadRoundTrip(): void
+    {
+        /** @var class-string $a */
+        $a = trim('Pulsar\\Cache\\SomeClass');
+        /** @var class-string $b */
+        $b = trim('Pulsar\\Http\\AnotherClass');
+        $classes = [$a, $b];
+
+        CacheAllowedClasses::save($this->tempDir, $classes);
+
+        $loaded = CacheAllowedClasses::load($this->tempDir);
+
+        self::assertSame($classes, $loaded);
+    }
+
+    #[Test]
+    public function loadReturnsNullWhenFileDoesNotExist(): void
+    {
+        $result = CacheAllowedClasses::load($this->tempDir);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function loadReturnsNullForInvalidJson(): void
+    {
+        file_put_contents($this->tempDir . DIRECTORY_SEPARATOR . 'allowed_classes.json', 'not json');
+
+        $result = CacheAllowedClasses::load($this->tempDir);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function loadReturnsNullForNonListArray(): void
+    {
+        $data = json_encode(['key' => 'value'], JSON_THROW_ON_ERROR);
+        file_put_contents($this->tempDir . DIRECTORY_SEPARATOR . 'allowed_classes.json', $data);
+
+        $result = CacheAllowedClasses::load($this->tempDir);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function loadReturnsNullForNonArrayJson(): void
+    {
+        file_put_contents($this->tempDir . DIRECTORY_SEPARATOR . 'allowed_classes.json', '"just a string"');
+
+        $result = CacheAllowedClasses::load($this->tempDir);
+
+        self::assertNull($result);
+    }
+
+    #[Test]
+    public function saveCreatesFormattedJsonFile(): void
+    {
+        /** @var class-string $a */
+        $a = trim('Pulsar\\Cache\\A');
+        /** @var class-string $b */
+        $b = trim('Pulsar\\Http\\B');
+        $classes = [$a, $b];
+
+        CacheAllowedClasses::save($this->tempDir, $classes);
+
+        $content = file_get_contents($this->tempDir . DIRECTORY_SEPARATOR . 'allowed_classes.json');
+        self::assertNotFalse($content);
+
+        // Should be pretty-printed
+        self::assertStringContainsString("\n", $content);
+
+        // Should not contain forward-slash escaping (unescaped slashes flag)
+        self::assertStringNotContainsString('\\/', $content);
+    }
+}

--- a/tests/Unit/Cache/CacheLockTest.php
+++ b/tests/Unit/Cache/CacheLockTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Cache;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Cache\CacheException;
+use Pulsar\Cache\CacheLock;
+
+#[CoversClass(CacheLock::class)]
+final class CacheLockTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pulsar_cache_lock_test_' . bin2hex(random_bytes(8));
+        mkdir($this->tempDir, 0o750, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    #[Test]
+    public function acquireCreatesLockFile(): void
+    {
+        $lock = new CacheLock($this->tempDir);
+        $lock->acquire();
+
+        self::assertFileExists($this->tempDir . DIRECTORY_SEPARATOR . '.lock');
+
+        $lock->release();
+    }
+
+    #[Test]
+    public function acquireAndReleaseCompleteWithoutError(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $lock = new CacheLock($this->tempDir);
+        $lock->acquire();
+        $lock->release();
+    }
+
+    #[Test]
+    public function releaseWithoutAcquireIsNoOp(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $lock = new CacheLock($this->tempDir);
+        $lock->release();
+    }
+
+    #[Test]
+    public function releaseCanBeCalledMultipleTimesSafely(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $lock = new CacheLock($this->tempDir);
+        $lock->acquire();
+        $lock->release();
+        $lock->release();
+    }
+
+    #[Test]
+    public function acquireCreatesCacheDirIfMissing(): void
+    {
+        $nestedDir = $this->tempDir . DIRECTORY_SEPARATOR . 'nested' . DIRECTORY_SEPARATOR . 'cache';
+        $lock = new CacheLock($nestedDir);
+        $lock->acquire();
+
+        self::assertDirectoryExists($nestedDir);
+        self::assertFileExists($nestedDir . DIRECTORY_SEPARATOR . '.lock');
+
+        $lock->release();
+    }
+
+    #[Test]
+    public function destructorReleasesLock(): void
+    {
+        $lock = new CacheLock($this->tempDir);
+        $lock->acquire();
+
+        $lockFilePath = $this->tempDir . DIRECTORY_SEPARATOR . '.lock';
+        self::assertFileExists($lockFilePath);
+
+        // Destroying the object should release the lock
+        unset($lock);
+
+        // After destruction, we should be able to acquire the lock again
+        $lock2 = new CacheLock($this->tempDir);
+        $lock2->acquire();
+
+        self::assertFileExists($lockFilePath);
+
+        $lock2->release();
+    }
+
+    #[Test]
+    public function lockCanBeReacquiredAfterRelease(): void
+    {
+        $this->expectNotToPerformAssertions();
+
+        $lock = new CacheLock($this->tempDir);
+
+        $lock->acquire();
+        $lock->release();
+
+        $lock->acquire();
+        $lock->release();
+    }
+
+    #[Test]
+    public function acquireWorksWithExistingDirectory(): void
+    {
+        self::assertDirectoryExists($this->tempDir);
+
+        $lock = new CacheLock($this->tempDir);
+        $lock->acquire();
+
+        self::assertFileExists($this->tempDir . DIRECTORY_SEPARATOR . '.lock');
+
+        $lock->release();
+    }
+
+    #[Test]
+    public function acquireThrowsCacheExceptionWhenDirectoryCannotBeCreated(): void
+    {
+        // Create a regular file where the cache directory should be,
+        // so mkdir() inside acquire() cannot create the directory.
+        $blockingFile = $this->tempDir . DIRECTORY_SEPARATOR . 'blocked';
+        file_put_contents($blockingFile, '');
+
+        // Point the lock at a path UNDER the blocking file (file cannot be a directory)
+        $invalidDir = $blockingFile . DIRECTORY_SEPARATOR . 'sub';
+
+        $lock = new CacheLock($invalidDir);
+
+        $caughtException = null;
+
+        // Suppress the expected mkdir() warning from the source code
+        set_error_handler(static fn(): bool => true);
+
+        try {
+            $lock->acquire();
+        } catch (CacheException $e) {
+            $caughtException = $e;
+        } finally {
+            restore_error_handler();
+        }
+
+        self::assertNotNull($caughtException);
+        self::assertStringContainsString('Failed to acquire cache lock', $caughtException->getMessage());
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } else {
+                unlink($path);
+            }
+        }
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/Config/DiskConfigTest.php
+++ b/tests/Unit/Config/DiskConfigTest.php
@@ -1,0 +1,145 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\DiskConfig;
+use Pulsar\Config\StorageDriver;
+
+#[CoversClass(DiskConfig::class)]
+final class DiskConfigTest extends TestCase
+{
+    #[Test]
+    public function it_has_sensible_defaults(): void
+    {
+        $config = new DiskConfig(name: 'local', driver: StorageDriver::Local);
+
+        self::assertSame('local', $config->name);
+        self::assertSame(StorageDriver::Local, $config->driver);
+        self::assertSame('', $config->root);
+        self::assertSame('private', $config->visibility);
+        self::assertSame('', $config->region);
+        self::assertSame('', $config->bucket);
+        self::assertSame('', $config->prefix);
+        self::assertNull($config->endpoint);
+        self::assertFalse($config->usePathStyle);
+    }
+
+    #[Test]
+    public function it_creates_local_disk_from_array(): void
+    {
+        $result = DiskConfig::fromArray('uploads', [
+            'driver' => 'local',
+            'root' => 'storage/uploads',
+            'visibility' => 'public',
+        ]);
+
+        self::assertSame('uploads', $result->name);
+        self::assertSame(StorageDriver::Local, $result->driver);
+        self::assertSame('storage/uploads', $result->root);
+        self::assertSame('public', $result->visibility);
+        self::assertSame('', $result->region);
+        self::assertSame('', $result->bucket);
+        self::assertSame('', $result->prefix);
+        self::assertNull($result->endpoint);
+        self::assertFalse($result->usePathStyle);
+    }
+
+    #[Test]
+    public function it_creates_s3_disk_from_array(): void
+    {
+        $result = DiskConfig::fromArray('s3', [
+            'driver' => 's3',
+            'root' => '',
+            'visibility' => 'private',
+            'region' => 'us-east-1',
+            'bucket' => 'my-bucket',
+            'prefix' => 'app/',
+            'endpoint' => 'https://s3.amazonaws.com',
+            'use_path_style' => true,
+        ]);
+
+        self::assertSame('s3', $result->name);
+        self::assertSame(StorageDriver::S3, $result->driver);
+        self::assertSame('', $result->root);
+        self::assertSame('private', $result->visibility);
+        self::assertSame('us-east-1', $result->region);
+        self::assertSame('my-bucket', $result->bucket);
+        self::assertSame('app/', $result->prefix);
+        self::assertSame('https://s3.amazonaws.com', $result->endpoint);
+        self::assertTrue($result->usePathStyle);
+    }
+
+    #[Test]
+    public function it_uses_defaults_when_array_is_empty(): void
+    {
+        $result = DiskConfig::fromArray('default', []);
+
+        self::assertSame('default', $result->name);
+        self::assertSame(StorageDriver::Local, $result->driver);
+        self::assertSame('', $result->root);
+        self::assertSame('private', $result->visibility);
+        self::assertSame('', $result->region);
+        self::assertSame('', $result->bucket);
+        self::assertSame('', $result->prefix);
+        self::assertNull($result->endpoint);
+        self::assertFalse($result->usePathStyle);
+    }
+
+    #[Test]
+    public function it_creates_memory_disk_from_array(): void
+    {
+        $result = DiskConfig::fromArray('testing', [
+            'driver' => 'memory',
+        ]);
+
+        self::assertSame('testing', $result->name);
+        self::assertSame(StorageDriver::Memory, $result->driver);
+    }
+
+    #[Test]
+    public function it_defaults_driver_to_local_for_non_string_value(): void
+    {
+        $result = DiskConfig::fromArray('broken', [
+            'driver' => 123,
+        ]);
+
+        self::assertSame(StorageDriver::Local, $result->driver);
+    }
+
+    #[Test]
+    public function it_defaults_string_fields_for_non_string_values(): void
+    {
+        $result = DiskConfig::fromArray('broken', [
+            'driver' => 'local',
+            'root' => 123,
+            'visibility' => false,
+            'region' => [],
+            'bucket' => null,
+            'prefix' => 456,
+            'endpoint' => 789,
+        ]);
+
+        self::assertSame('', $result->root);
+        self::assertSame('private', $result->visibility);
+        self::assertSame('', $result->region);
+        self::assertSame('', $result->bucket);
+        self::assertSame('', $result->prefix);
+        self::assertNull($result->endpoint);
+    }
+
+    #[Test]
+    public function it_handles_null_endpoint_in_array(): void
+    {
+        $result = DiskConfig::fromArray('disk', [
+            'driver' => 'local',
+            'endpoint' => null,
+        ]);
+
+        self::assertNull($result->endpoint);
+    }
+}

--- a/tests/Unit/Config/StudioCollectorConfigTest.php
+++ b/tests/Unit/Config/StudioCollectorConfigTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Config\StudioCollectorConfig;
+
+#[CoversClass(StudioCollectorConfig::class)]
+final class StudioCollectorConfigTest extends TestCase
+{
+    /** @var list<string> Env vars set during tests, to be cleaned up */
+    private array $envVarsToClean = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envVarsToClean as $key) {
+            putenv($key);
+        }
+
+        $this->envVarsToClean = [];
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        putenv("{$key}={$value}");
+        $this->envVarsToClean[] = $key;
+    }
+
+    #[Test]
+    public function it_has_sensible_defaults(): void
+    {
+        $config = new StudioCollectorConfig();
+
+        self::assertTrue($config->http);
+        self::assertTrue($config->database);
+        self::assertTrue($config->logs);
+        self::assertTrue($config->exceptions);
+        self::assertTrue($config->scheduler);
+        self::assertTrue($config->featureFlags);
+        self::assertTrue($config->queue);
+        self::assertTrue($config->benchmark);
+        self::assertTrue($config->runtime);
+        self::assertFalse($config->storeRawSql);
+        self::assertFalse($config->redactTableNames);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_full_data(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioCollectorConfig::fromArray([
+            'http' => ['enabled' => false],
+            'database' => [
+                'enabled' => false,
+                'store_raw_sql' => true,
+                'redact_table_names' => true,
+            ],
+            'logs' => ['enabled' => false],
+            'exceptions' => ['enabled' => false],
+            'scheduler' => ['enabled' => false],
+            'feature_flags' => ['enabled' => false],
+            'queue' => ['enabled' => false],
+            'benchmark' => ['enabled' => false],
+            'runtime' => ['enabled' => false],
+        ], $env);
+
+        self::assertFalse($result->http);
+        self::assertFalse($result->database);
+        self::assertFalse($result->logs);
+        self::assertFalse($result->exceptions);
+        self::assertFalse($result->scheduler);
+        self::assertFalse($result->featureFlags);
+        self::assertFalse($result->queue);
+        self::assertFalse($result->benchmark);
+        self::assertFalse($result->runtime);
+        self::assertTrue($result->storeRawSql);
+        self::assertTrue($result->redactTableNames);
+    }
+
+    #[Test]
+    public function it_uses_defaults_when_array_is_empty(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioCollectorConfig::fromArray([], $env);
+
+        self::assertTrue($result->http);
+        self::assertTrue($result->database);
+        self::assertTrue($result->logs);
+        self::assertTrue($result->exceptions);
+        self::assertTrue($result->scheduler);
+        self::assertTrue($result->featureFlags);
+        self::assertTrue($result->queue);
+        self::assertTrue($result->benchmark);
+        self::assertTrue($result->runtime);
+        self::assertFalse($result->storeRawSql);
+        self::assertFalse($result->redactTableNames);
+    }
+
+    #[Test]
+    public function env_override_for_store_raw_sql_true(): void
+    {
+        $this->setEnv('STUDIO_STORE_RAW_SQL', 'true');
+
+        $env = Environment::load(null);
+
+        $result = StudioCollectorConfig::fromArray([
+            'database' => ['store_raw_sql' => false],
+        ], $env);
+
+        self::assertTrue($result->storeRawSql);
+    }
+
+    #[Test]
+    public function env_override_for_store_raw_sql_false(): void
+    {
+        $this->setEnv('STUDIO_STORE_RAW_SQL', 'false');
+
+        $env = Environment::load(null);
+
+        $result = StudioCollectorConfig::fromArray([
+            'database' => ['store_raw_sql' => true],
+        ], $env);
+
+        self::assertFalse($result->storeRawSql);
+    }
+
+    #[Test]
+    public function it_handles_partial_collector_data(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioCollectorConfig::fromArray([
+            'http' => ['enabled' => false],
+            'logs' => ['enabled' => false],
+        ], $env);
+
+        self::assertFalse($result->http);
+        self::assertTrue($result->database);
+        self::assertFalse($result->logs);
+        self::assertTrue($result->exceptions);
+        self::assertTrue($result->scheduler);
+        self::assertTrue($result->featureFlags);
+        self::assertTrue($result->queue);
+        self::assertTrue($result->benchmark);
+        self::assertTrue($result->runtime);
+    }
+
+    #[Test]
+    public function it_handles_empty_sub_arrays(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioCollectorConfig::fromArray([
+            'http' => [],
+            'database' => [],
+            'logs' => [],
+            'exceptions' => [],
+            'scheduler' => [],
+            'feature_flags' => [],
+            'queue' => [],
+            'benchmark' => [],
+            'runtime' => [],
+        ], $env);
+
+        self::assertTrue($result->http);
+        self::assertTrue($result->database);
+        self::assertTrue($result->logs);
+        self::assertTrue($result->exceptions);
+        self::assertTrue($result->scheduler);
+        self::assertTrue($result->featureFlags);
+        self::assertTrue($result->queue);
+        self::assertTrue($result->benchmark);
+        self::assertTrue($result->runtime);
+        self::assertFalse($result->storeRawSql);
+        self::assertFalse($result->redactTableNames);
+    }
+}

--- a/tests/Unit/Config/StudioConfigTest.php
+++ b/tests/Unit/Config/StudioConfigTest.php
@@ -1,0 +1,237 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Config\StudioCollectorConfig;
+use Pulsar\Config\StudioConfig;
+use Pulsar\Config\StudioRetentionConfig;
+use Pulsar\Config\StudioSecurityConfig;
+use Pulsar\Config\StudioServerConfig;
+
+#[CoversClass(StudioConfig::class)]
+final class StudioConfigTest extends TestCase
+{
+    /** @var list<string> Env vars set during tests, to be cleaned up */
+    private array $envVarsToClean = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envVarsToClean as $key) {
+            putenv($key);
+        }
+
+        $this->envVarsToClean = [];
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        putenv("{$key}={$value}");
+        $this->envVarsToClean[] = $key;
+    }
+
+    #[Test]
+    public function it_has_sensible_defaults(): void
+    {
+        $config = new StudioConfig();
+
+        self::assertTrue($config->enabled);
+        self::assertSame('storage/studio/studio.sqlite', $config->storagePath);
+        self::assertInstanceOf(StudioRetentionConfig::class, $config->retention);
+        self::assertInstanceOf(StudioSecurityConfig::class, $config->security);
+        self::assertInstanceOf(StudioServerConfig::class, $config->server);
+        self::assertInstanceOf(StudioCollectorConfig::class, $config->collectors);
+        self::assertSame(1.0, $config->samplingRate);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_full_data(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'enabled' => false,
+            'storage_path' => 'custom/path/studio.sqlite',
+            'retention' => [
+                'max_age_days' => 14,
+                'max_size_mb' => 1024,
+                'vacuum_interval_hours' => 6,
+            ],
+            'security' => [
+                'auth_required' => true,
+                'username' => 'admin',
+                'password' => 'secret',
+            ],
+            'server' => [
+                'host' => '0.0.0.0',
+                'port' => 9090,
+            ],
+            'collectors' => [
+                'http' => ['enabled' => false],
+                'database' => ['enabled' => false],
+            ],
+            'sampling_rate' => 0.5,
+        ], $env);
+
+        self::assertFalse($result->enabled);
+        self::assertSame('custom/path/studio.sqlite', $result->storagePath);
+        self::assertSame(14, $result->retention->maxAgeDays);
+        self::assertSame(1024, $result->retention->maxSizeMb);
+        self::assertTrue($result->security->authRequired);
+        self::assertSame('admin', $result->security->username);
+        self::assertSame('0.0.0.0', $result->server->host);
+        self::assertSame(9090, $result->server->port);
+        self::assertFalse($result->collectors->http);
+        self::assertFalse($result->collectors->database);
+        self::assertSame(0.5, $result->samplingRate);
+    }
+
+    #[Test]
+    public function it_uses_defaults_when_array_is_empty(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([], $env);
+
+        self::assertTrue($result->enabled);
+        self::assertSame('storage/studio/studio.sqlite', $result->storagePath);
+        self::assertSame(7, $result->retention->maxAgeDays);
+        self::assertFalse($result->security->authRequired);
+        self::assertSame('127.0.0.1', $result->server->host);
+        self::assertTrue($result->collectors->http);
+        self::assertSame(1.0, $result->samplingRate);
+    }
+
+    #[Test]
+    public function env_override_for_enabled_true(): void
+    {
+        $this->setEnv('STUDIO_ENABLED', 'true');
+
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'enabled' => false,
+        ], $env);
+
+        self::assertTrue($result->enabled);
+    }
+
+    #[Test]
+    public function env_override_for_enabled_false(): void
+    {
+        $this->setEnv('STUDIO_ENABLED', 'false');
+
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'enabled' => true,
+        ], $env);
+
+        self::assertFalse($result->enabled);
+    }
+
+    #[Test]
+    public function env_override_for_storage_path(): void
+    {
+        $this->setEnv('STUDIO_STORAGE_PATH', '/tmp/studio.sqlite');
+
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'storage_path' => 'original/path.sqlite',
+        ], $env);
+
+        self::assertSame('/tmp/studio.sqlite', $result->storagePath);
+    }
+
+    #[Test]
+    public function env_override_for_sampling_rate(): void
+    {
+        $this->setEnv('STUDIO_SAMPLING_RATE', '0.25');
+
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'sampling_rate' => 1.0,
+        ], $env);
+
+        self::assertSame(0.25, $result->samplingRate);
+    }
+
+    #[Test]
+    public function sampling_rate_is_clamped_to_zero(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'sampling_rate' => -0.5,
+        ], $env);
+
+        self::assertSame(0.0, $result->samplingRate);
+    }
+
+    #[Test]
+    public function sampling_rate_is_clamped_to_one(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'sampling_rate' => 2.0,
+        ], $env);
+
+        self::assertSame(1.0, $result->samplingRate);
+    }
+
+    #[Test]
+    public function sampling_rate_handles_numeric_string(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'sampling_rate' => '0.75',
+        ], $env);
+
+        self::assertSame(0.75, $result->samplingRate);
+    }
+
+    #[Test]
+    public function sampling_rate_defaults_for_non_numeric_value(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'sampling_rate' => 'invalid',
+        ], $env);
+
+        self::assertSame(1.0, $result->samplingRate);
+    }
+
+    #[Test]
+    public function sampling_rate_env_override_is_clamped(): void
+    {
+        $this->setEnv('STUDIO_SAMPLING_RATE', '5.0');
+
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([], $env);
+
+        self::assertSame(1.0, $result->samplingRate);
+    }
+
+    #[Test]
+    public function it_handles_integer_sampling_rate(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioConfig::fromArray([
+            'sampling_rate' => 1,
+        ], $env);
+
+        self::assertSame(1.0, $result->samplingRate);
+    }
+}

--- a/tests/Unit/Config/StudioRetentionConfigTest.php
+++ b/tests/Unit/Config/StudioRetentionConfigTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Config\StudioRetentionConfig;
+
+#[CoversClass(StudioRetentionConfig::class)]
+final class StudioRetentionConfigTest extends TestCase
+{
+    /** @var list<string> Env vars set during tests, to be cleaned up */
+    private array $envVarsToClean = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envVarsToClean as $key) {
+            putenv($key);
+        }
+
+        $this->envVarsToClean = [];
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        putenv("{$key}={$value}");
+        $this->envVarsToClean[] = $key;
+    }
+
+    #[Test]
+    public function it_has_sensible_defaults(): void
+    {
+        $config = new StudioRetentionConfig();
+
+        self::assertSame(7, $config->maxAgeDays);
+        self::assertSame(500, $config->maxSizeMb);
+        self::assertSame(24, $config->vacuumIntervalHours);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_full_data(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioRetentionConfig::fromArray([
+            'max_age_days' => 30,
+            'max_size_mb' => 1024,
+            'vacuum_interval_hours' => 12,
+        ], $env);
+
+        self::assertSame(30, $result->maxAgeDays);
+        self::assertSame(1024, $result->maxSizeMb);
+        self::assertSame(12, $result->vacuumIntervalHours);
+    }
+
+    #[Test]
+    public function it_uses_defaults_when_array_is_empty(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioRetentionConfig::fromArray([], $env);
+
+        self::assertSame(7, $result->maxAgeDays);
+        self::assertSame(500, $result->maxSizeMb);
+        self::assertSame(24, $result->vacuumIntervalHours);
+    }
+
+    #[Test]
+    public function env_override_for_retention_days(): void
+    {
+        $this->setEnv('STUDIO_RETENTION_DAYS', '14');
+
+        $env = Environment::load(null);
+
+        $result = StudioRetentionConfig::fromArray([
+            'max_age_days' => 30,
+        ], $env);
+
+        self::assertSame(14, $result->maxAgeDays);
+    }
+
+    #[Test]
+    public function it_handles_numeric_string_values(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioRetentionConfig::fromArray([
+            'max_age_days' => '15',
+            'max_size_mb' => '2048',
+            'vacuum_interval_hours' => '48',
+        ], $env);
+
+        self::assertSame(15, $result->maxAgeDays);
+        self::assertSame(2048, $result->maxSizeMb);
+        self::assertSame(48, $result->vacuumIntervalHours);
+    }
+
+    #[Test]
+    public function it_falls_back_to_default_for_non_numeric_values(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioRetentionConfig::fromArray([
+            'max_age_days' => 'invalid',
+            'max_size_mb' => 'invalid',
+            'vacuum_interval_hours' => 'invalid',
+        ], $env);
+
+        self::assertSame(7, $result->maxAgeDays);
+        self::assertSame(500, $result->maxSizeMb);
+        self::assertSame(24, $result->vacuumIntervalHours);
+    }
+
+    #[Test]
+    public function env_override_takes_precedence_over_array(): void
+    {
+        $this->setEnv('STUDIO_RETENTION_DAYS', '3');
+
+        $env = Environment::load(null);
+
+        $result = StudioRetentionConfig::fromArray([
+            'max_age_days' => 60,
+        ], $env);
+
+        self::assertSame(3, $result->maxAgeDays);
+    }
+}

--- a/tests/Unit/Config/StudioSecurityConfigTest.php
+++ b/tests/Unit/Config/StudioSecurityConfigTest.php
@@ -1,0 +1,152 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Config\StudioSecurityConfig;
+
+#[CoversClass(StudioSecurityConfig::class)]
+final class StudioSecurityConfigTest extends TestCase
+{
+    /** @var list<string> Env vars set during tests, to be cleaned up */
+    private array $envVarsToClean = [];
+
+    protected function tearDown(): void
+    {
+        foreach ($this->envVarsToClean as $key) {
+            putenv($key);
+        }
+
+        $this->envVarsToClean = [];
+    }
+
+    private function setEnv(string $key, string $value): void
+    {
+        putenv("{$key}={$value}");
+        $this->envVarsToClean[] = $key;
+    }
+
+    #[Test]
+    public function it_has_sensible_defaults(): void
+    {
+        $config = new StudioSecurityConfig();
+
+        self::assertFalse($config->authRequired);
+        self::assertNull($config->username);
+        self::assertNull($config->password);
+        self::assertSame(['127.0.0.1/8', '::1/128'], $config->allowedCidrs);
+        self::assertFalse($config->productionConfirm);
+    }
+
+    #[Test]
+    public function it_creates_from_array_with_full_data(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([
+            'auth_required' => true,
+            'username' => 'admin',
+            'password' => 'secret',
+            'allowed_cidrs' => ['10.0.0.0/8', '192.168.0.0/16'],
+            'production_confirm' => true,
+        ], $env);
+
+        self::assertTrue($result->authRequired);
+        self::assertSame('admin', $result->username);
+        self::assertSame('secret', $result->password);
+        self::assertSame(['10.0.0.0/8', '192.168.0.0/16'], $result->allowedCidrs);
+        self::assertTrue($result->productionConfirm);
+    }
+
+    #[Test]
+    public function it_uses_defaults_when_array_is_empty(): void
+    {
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([], $env);
+
+        self::assertFalse($result->authRequired);
+        self::assertNull($result->username);
+        self::assertNull($result->password);
+        self::assertSame(['127.0.0.1/8', '::1/128'], $result->allowedCidrs);
+        self::assertFalse($result->productionConfirm);
+    }
+
+    #[Test]
+    public function env_override_for_username(): void
+    {
+        $this->setEnv('STUDIO_USERNAME', 'env_admin');
+
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([
+            'username' => 'array_admin',
+        ], $env);
+
+        self::assertSame('env_admin', $result->username);
+    }
+
+    #[Test]
+    public function env_override_for_password(): void
+    {
+        $this->setEnv('STUDIO_PASSWORD', 'env_secret');
+
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([
+            'password' => 'array_secret',
+        ], $env);
+
+        self::assertSame('env_secret', $result->password);
+    }
+
+    #[Test]
+    public function env_override_for_production_confirm_true(): void
+    {
+        $this->setEnv('STUDIO_PRODUCTION_CONFIRM', 'true');
+
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([
+            'production_confirm' => false,
+        ], $env);
+
+        self::assertTrue($result->productionConfirm);
+    }
+
+    #[Test]
+    public function env_override_for_production_confirm_false(): void
+    {
+        $this->setEnv('STUDIO_PRODUCTION_CONFIRM', 'false');
+
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([
+            'production_confirm' => true,
+        ], $env);
+
+        self::assertFalse($result->productionConfirm);
+    }
+
+    #[Test]
+    public function env_overrides_take_precedence_for_credentials(): void
+    {
+        $this->setEnv('STUDIO_USERNAME', 'env_user');
+        $this->setEnv('STUDIO_PASSWORD', 'env_pass');
+
+        $env = Environment::load(null);
+
+        $result = StudioSecurityConfig::fromArray([
+            'username' => 'file_user',
+            'password' => 'file_pass',
+        ], $env);
+
+        self::assertSame('env_user', $result->username);
+        self::assertSame('env_pass', $result->password);
+    }
+}

--- a/tests/Unit/Console/ApplicationTest.php
+++ b/tests/Unit/Console/ApplicationTest.php
@@ -16,6 +16,7 @@ use Pulsar\Console\Input\ArrayInput;
 use Pulsar\Console\InputInterface;
 use Pulsar\Console\Output\BufferedOutput;
 use Pulsar\Console\OutputInterface;
+use Pulsar\Console\Verbosity;
 use Pulsar\Core\Kernel;
 use RuntimeException;
 
@@ -180,6 +181,112 @@ final class ApplicationTest extends TestCase
         self::assertSame($this->kernel, $this->application->kernel());
     }
 
+    #[Test]
+    public function doRunSetsQuietVerbosity(): void
+    {
+        $input = new ArrayInput(null, [], ['quiet' => true]);
+        $output = new BufferedOutput();
+
+        $this->application->doRun($input, $output);
+
+        self::assertSame(Verbosity::Quiet, $output->verbosity);
+    }
+
+    #[Test]
+    public function doRunSetsVerboseVerbosity(): void
+    {
+        $input = new ArrayInput(null, [], ['v' => true]);
+        $output = new BufferedOutput();
+
+        $this->application->doRun($input, $output);
+
+        self::assertSame(Verbosity::Verbose, $output->verbosity);
+    }
+
+    #[Test]
+    public function doRunSetsDebugVerbosity(): void
+    {
+        $input = new ArrayInput(null, [], ['vvv' => true]);
+        $output = new BufferedOutput();
+
+        $this->application->doRun($input, $output);
+
+        self::assertSame(Verbosity::Debug, $output->verbosity);
+    }
+
+    #[Test]
+    public function doRunShowsHelpForSpecificCommand(): void
+    {
+        $command = $this->createCommandWithArgs('greet', 'Say hello');
+
+        $this->application->add($command);
+
+        $input = new ArrayInput('greet', [], ['help' => true]);
+        $output = new BufferedOutput();
+
+        $exitCode = $this->application->doRun($input, $output);
+
+        $content = $output->buffer;
+        self::assertStringContainsString('Description:', $content);
+        self::assertStringContainsString('Say hello', $content);
+        self::assertStringContainsString('Usage:', $content);
+        self::assertSame(ExitCode::Success->value, $exitCode);
+    }
+
+    #[Test]
+    public function doRunShowsVersionWithShortOption(): void
+    {
+        $input = new ArrayInput(null, [], ['V' => true]);
+        $output = new BufferedOutput();
+
+        $exitCode = $this->application->doRun($input, $output);
+
+        self::assertStringContainsString('Pulsar Framework', $output->buffer);
+        self::assertSame(ExitCode::Success->value, $exitCode);
+    }
+
+    #[Test]
+    public function doRunShowsCommandExceptionTraceInVerboseMode(): void
+    {
+        $command = new class implements CommandInterface {
+            public string $name = 'fail';
+            public string $description = 'Fails';
+
+            public function execute(InputInterface $input, OutputInterface $output): int
+            {
+                throw new RuntimeException('Verbose failure');
+            }
+        };
+
+        $this->application->add($command);
+
+        $input = new ArrayInput('fail', [], ['verbose' => true]);
+        $output = new BufferedOutput();
+
+        $exitCode = $this->application->doRun($input, $output);
+
+        self::assertSame(ExitCode::Error->value, $exitCode);
+        self::assertStringContainsString('Verbose failure', $output->errorBuffer);
+    }
+
+    #[Test]
+    public function doRunListsGroupedCommandsInHelp(): void
+    {
+        $this->application->add($this->createCommand('cache:clear', 'Clear cache'));
+        $this->application->add($this->createCommand('cache:warmup', 'Warm cache'));
+        $this->application->add($this->createCommand('migrate', 'Run migrations'));
+
+        $input = new ArrayInput(null);
+        $output = new BufferedOutput();
+
+        $this->application->doRun($input, $output);
+
+        $content = $output->buffer;
+        self::assertStringContainsString('cache', $content);
+        self::assertStringContainsString('cache:clear', $content);
+        self::assertStringContainsString('migrate', $content);
+    }
+
     private function createCommand(string $name, string $description): CommandInterface
     {
         return new class ($name, $description) extends Command {
@@ -194,6 +301,31 @@ final class ApplicationTest extends TestCase
             {
                 $this->name = $this->commandName;
                 $this->description = $this->commandDescription;
+            }
+
+            public function execute(InputInterface $input, OutputInterface $output): int
+            {
+                return ExitCode::Success->value;
+            }
+        };
+    }
+
+    private function createCommandWithArgs(string $name, string $description): Command
+    {
+        return new class ($name, $description) extends Command {
+            public function __construct(
+                private readonly string $commandName,
+                private readonly string $commandDescription,
+            ) {
+                parent::__construct();
+            }
+
+            protected function configure(): void
+            {
+                $this->name = $this->commandName;
+                $this->description = $this->commandDescription;
+                $this->addArgument('name', 'The name to greet', true);
+                $this->addOption('shout', 'Shout the greeting', 's');
             }
 
             public function execute(InputInterface $input, OutputInterface $output): int

--- a/tests/Unit/Container/ContainerTest.php
+++ b/tests/Unit/Container/ContainerTest.php
@@ -255,6 +255,124 @@ final class ContainerTest extends TestCase
         self::assertContains('a', $instances);
         self::assertContains('b', $instances);
     }
+
+    #[Test]
+    public function forgetInstanceRemovesCachedInstance(): void
+    {
+        $container = new Container();
+        $container->instance('service', new stdClass());
+
+        self::assertTrue($container->has('service'));
+
+        $container->forgetInstance('service');
+
+        self::assertFalse($container->has('service'));
+    }
+
+    #[Test]
+    public function setResolutionHintsLoadsHints(): void
+    {
+        $container = new Container();
+        $container->setResolutionHints([
+            ServiceStub::class => [
+                ['name' => 'dependency', 'type' => DependencyStub::class],
+            ],
+        ]);
+
+        self::assertNotEmpty($container->resolutionHints);
+    }
+
+    #[Test]
+    public function setResolutionHintsNullClearsHints(): void
+    {
+        $container = new Container();
+        $container->setResolutionHints([
+            ServiceStub::class => [
+                ['name' => 'dependency', 'type' => DependencyStub::class],
+            ],
+        ]);
+
+        $container->setResolutionHints(null);
+
+        self::assertEmpty($container->resolutionHints);
+    }
+
+    #[Test]
+    public function buildFromHintsResolvesWithCachedHints(): void
+    {
+        $container = new Container();
+        $container->bind(DependencyStub::class, DependencyStub::class);
+        $container->bind(ServiceStub::class, ServiceStub::class);
+
+        $container->setResolutionHints([
+            ServiceStub::class => [
+                ['name' => 'dependency', 'type' => DependencyStub::class],
+            ],
+        ]);
+
+        $service = $container->get(ServiceStub::class);
+
+        self::assertInstanceOf(ServiceStub::class, $service);
+        self::assertInstanceOf(DependencyStub::class, $service->dependency);
+    }
+
+    #[Test]
+    public function buildFallsBackToReflectionWhenHintsFail(): void
+    {
+        $container = new Container();
+        $container->bind(DependencyStub::class, DependencyStub::class);
+        $container->bind(ServiceStub::class, ServiceStub::class);
+
+        // Set invalid hints — type doesn't exist in container
+        /** @var class-string $bogus */
+        $bogus = trim('NonExistentClass');
+        $container->setResolutionHints([
+            ServiceStub::class => [
+                ['name' => 'dependency', 'type' => $bogus],
+            ],
+        ]);
+
+        // Should still resolve via reflection fallback
+        $service = $container->get(ServiceStub::class);
+
+        self::assertInstanceOf(ServiceStub::class, $service);
+    }
+
+    #[Test]
+    public function untypedParameterWithoutDefaultThrows(): void
+    {
+        $container = new Container();
+        $container->bind(UntypedParamStub::class, UntypedParamStub::class);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('no type hint');
+
+        $_ = $container->get(UntypedParamStub::class);
+    }
+
+    #[Test]
+    public function builtinTypeParameterWithoutDefaultThrows(): void
+    {
+        $container = new Container();
+        $container->bind(BuiltinTypeStub::class, BuiltinTypeStub::class);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('non-class type');
+
+        $_ = $container->get(BuiltinTypeStub::class);
+    }
+
+    #[Test]
+    public function uninstantiableClassThrows(): void
+    {
+        $container = new Container();
+        $container->bind(AbstractStub::class, AbstractStub::class);
+
+        $this->expectException(ContainerException::class);
+        $this->expectExceptionMessage('not instantiable');
+
+        $_ = $container->get(AbstractStub::class);
+    }
 }
 
 // Test stubs
@@ -280,3 +398,24 @@ class NullableDependencyStub
         public readonly ?DependencyStub $dependency = null,
     ) {}
 }
+
+class UntypedParamStub
+{
+    /** @var mixed */
+    public $value;
+
+    /** @param mixed $value */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+}
+
+class BuiltinTypeStub
+{
+    public function __construct(
+        public readonly int $count,
+    ) {}
+}
+
+abstract class AbstractStub {}

--- a/tests/Unit/Database/Exception/DatabaseExceptionTest.php
+++ b/tests/Unit/Database/Exception/DatabaseExceptionTest.php
@@ -1,0 +1,181 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Database\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Database\Exception\DatabaseException;
+use RuntimeException;
+
+#[CoversClass(DatabaseException::class)]
+final class DatabaseExceptionTest extends TestCase
+{
+    #[Test]
+    public function extendsRuntimeException(): void
+    {
+        $exception = DatabaseException::emptyResult();
+
+        self::assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    #[Test]
+    public function connectionFailedContainsName(): void
+    {
+        $exception = DatabaseException::connectionFailed('primary');
+
+        self::assertSame('Failed to connect to database "primary"', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function connectionFailedChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('Connection refused');
+        $exception = DatabaseException::connectionFailed('primary', $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+        self::assertStringContainsString('primary', $exception->getMessage());
+    }
+
+    #[Test]
+    public function connectionNotConfiguredContainsName(): void
+    {
+        $exception = DatabaseException::connectionNotConfigured('analytics');
+
+        self::assertSame('Database connection "analytics" is not configured', $exception->getMessage());
+    }
+
+    #[Test]
+    public function queryFailedContainsSql(): void
+    {
+        $exception = DatabaseException::queryFailed('SELECT * FROM users');
+
+        self::assertSame('Query failed: SELECT * FROM users', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function queryFailedChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('Deadlock detected');
+        $exception = DatabaseException::queryFailed('INSERT INTO orders', $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function prepareErrorContainsSql(): void
+    {
+        $exception = DatabaseException::prepareError('SELECT ? FROM ??');
+
+        self::assertSame('Failed to prepare statement: SELECT ? FROM ??', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function prepareErrorChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('Syntax error');
+        $exception = DatabaseException::prepareError('INVALID SQL', $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function emptyResultHasFixedMessage(): void
+    {
+        $exception = DatabaseException::emptyResult();
+
+        self::assertSame('Query returned an empty result set', $exception->getMessage());
+    }
+
+    #[Test]
+    public function columnNotFoundContainsColumnName(): void
+    {
+        $exception = DatabaseException::columnNotFound('email');
+
+        self::assertSame('Column "email" not found in row', $exception->getMessage());
+    }
+
+    #[Test]
+    public function typeCastFailedContainsColumnAndType(): void
+    {
+        $exception = DatabaseException::typeCastFailed('age', 'int');
+
+        self::assertSame('Cannot cast column "age" to int', $exception->getMessage());
+    }
+
+    #[Test]
+    public function transactionAlreadyFinishedHasFixedMessage(): void
+    {
+        $exception = DatabaseException::transactionAlreadyFinished();
+
+        self::assertSame('Transaction has already been committed or rolled back', $exception->getMessage());
+    }
+
+    #[Test]
+    public function migrationFailedContainsVersionAndDirection(): void
+    {
+        $exception = DatabaseException::migrationFailed('20240101_000001', 'up');
+
+        self::assertSame('Migration 20240101_000001 (up) failed', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function migrationFailedChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('Table already exists');
+        $exception = DatabaseException::migrationFailed('20240101_000001', 'up', $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function migrationTableErrorContainsReason(): void
+    {
+        $exception = DatabaseException::migrationTableError('permission denied');
+
+        self::assertSame('Migration table error: permission denied', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function migrationTableErrorChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('Access denied');
+        $exception = DatabaseException::migrationTableError('cannot create table', $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function migrationNotFoundContainsVersion(): void
+    {
+        $exception = DatabaseException::migrationNotFound('20240601_123456');
+
+        self::assertSame('Migration "20240601_123456" not found', $exception->getMessage());
+    }
+
+    #[Test]
+    public function duplicateMigrationVersionContainsVersion(): void
+    {
+        $exception = DatabaseException::duplicateMigrationVersion('20240101_000001');
+
+        self::assertSame('Duplicate migration version: 20240101_000001', $exception->getMessage());
+    }
+
+    #[Test]
+    public function migrationFileInvalidContainsPath(): void
+    {
+        $exception = DatabaseException::migrationFileInvalid('/migrations/bad_file.php');
+
+        self::assertSame(
+            'Migration file "/migrations/bad_file.php" must return a MigrationInterface instance',
+            $exception->getMessage(),
+        );
+    }
+}

--- a/tests/Unit/Database/RowTest.php
+++ b/tests/Unit/Database/RowTest.php
@@ -294,4 +294,72 @@ final class RowTest extends TestCase
 
         self::assertSame(0, $row->getInt('count'));
     }
+
+    #[Test]
+    public function getNullableIntCastsStringToInt(): void
+    {
+        $row = new Row(['count' => '42']);
+
+        self::assertSame(42, $row->getNullableInt('count'));
+    }
+
+    #[Test]
+    public function getNullableIntThrowsOnInvalidValue(): void
+    {
+        $row = new Row(['count' => 'abc']);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Cannot cast column "count" to int');
+
+        $row->getNullableInt('count');
+    }
+
+    #[Test]
+    public function getNullableStringCastsIntToString(): void
+    {
+        $row = new Row(['id' => 42]);
+
+        self::assertSame('42', $row->getNullableString('id'));
+    }
+
+    #[Test]
+    public function getNullableStringCastsFloatToString(): void
+    {
+        $row = new Row(['price' => 9.99]);
+
+        self::assertSame('9.99', $row->getNullableString('price'));
+    }
+
+    #[Test]
+    public function getNullableStringThrowsOnInvalidValue(): void
+    {
+        $row = new Row(['data' => []]);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Cannot cast column "data" to string');
+
+        $row->getNullableString('data');
+    }
+
+    #[Test]
+    public function getFloatThrowsOnNull(): void
+    {
+        $row = new Row(['value' => null]);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Cannot cast column "value" to float');
+
+        $row->getFloat('value');
+    }
+
+    #[Test]
+    public function getIntThrowsOnEmptyString(): void
+    {
+        $row = new Row(['value' => '']);
+
+        $this->expectException(DatabaseException::class);
+        $this->expectExceptionMessage('Cannot cast column "value" to int');
+
+        $row->getInt('value');
+    }
 }

--- a/tests/Unit/Deploy/Check/CacheSettingsCheckTest.php
+++ b/tests/Unit/Deploy/Check/CacheSettingsCheckTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Deploy\Check;
+
+use function bin2hex;
+
+use const DIRECTORY_SEPARATOR;
+
+use function is_dir;
+use function is_file;
+use function mkdir;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Cache\CacheManifest;
+use Pulsar\Cache\FrameworkCache;
+use Pulsar\Deploy\Check\CacheSettingsCheck;
+use Pulsar\Deploy\CheckSeverity;
+use Pulsar\Security\Crypto\MasterKey;
+
+use function random_bytes;
+use function rmdir;
+use function sodium_bin2hex;
+use function unlink;
+
+#[CoversClass(CacheSettingsCheck::class)]
+final class CacheSettingsCheckTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . DIRECTORY_SEPARATOR . 'pulsar_cache_check_test_' . bin2hex(random_bytes(8));
+        mkdir($this->tempDir, 0o750, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $this->removeDirectory($this->tempDir);
+    }
+
+    #[Test]
+    public function it_returns_name(): void
+    {
+        $check = new CacheSettingsCheck($this->buildColdCache());
+
+        self::assertSame('cache-settings', $check->getName());
+    }
+
+    #[Test]
+    public function it_returns_description(): void
+    {
+        $check = new CacheSettingsCheck($this->buildColdCache());
+
+        self::assertSame('Validates the framework cache is warm for production performance', $check->getDescription());
+    }
+
+    #[Test]
+    public function it_passes_when_cache_is_warm(): void
+    {
+        $check = new CacheSettingsCheck($this->buildWarmCache());
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertSame('Framework cache is warm', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_when_cache_warm_in_staging(): void
+    {
+        $check = new CacheSettingsCheck($this->buildWarmCache());
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+    }
+
+    #[Test]
+    public function it_warns_when_cache_cold_in_production(): void
+    {
+        $check = new CacheSettingsCheck($this->buildColdCache());
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('Framework cache is not warm', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_warns_when_cache_cold_in_staging(): void
+    {
+        $check = new CacheSettingsCheck($this->buildColdCache());
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('Framework cache is not warm', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_passes_when_cache_cold_in_local(): void
+    {
+        $check = new CacheSettingsCheck($this->buildColdCache());
+
+        $result = $check->check('local');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('not required in local', $result->message);
+    }
+
+    #[Test]
+    public function production_recommendations_mention_optimize_command(): void
+    {
+        $check = new CacheSettingsCheck($this->buildColdCache());
+
+        $result = $check->check('production');
+
+        $joined = implode(' ', $result->recommendations);
+        self::assertStringContainsString('php bin/pulsar optimize', $joined);
+    }
+
+    /**
+     * Build a FrameworkCache that points to an empty temp dir (no manifest = cold).
+     */
+    private function buildColdCache(): FrameworkCache
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+
+        return new FrameworkCache($this->tempDir, $masterKey);
+    }
+
+    /**
+     * Build a FrameworkCache with a valid signed manifest (warm).
+     */
+    private function buildWarmCache(): FrameworkCache
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $cache = new FrameworkCache($this->tempDir, $masterKey);
+
+        // Create the cache directory structure and write a valid signed manifest
+        $cachePath = $cache->cachePath();
+        if (!is_dir($cachePath)) {
+            mkdir($cachePath, 0o750, true);
+        }
+
+        $hmacKey = $masterKey->deriveSubKey(7, 'fw_cache');
+
+        CacheManifest::write(
+            cachePath: $cachePath,
+            hmacKey: $hmacKey,
+            schemaVersion: 1,
+            frameworkVersion: '1.0.0',
+            appEnv: 'production',
+            invalidationKey: 'test-key',
+            allowedClassesHash: 'test-hash',
+            caches: [],
+            strict: false,
+            encrypted: false,
+        );
+
+        return $cache;
+    }
+
+    private function removeDirectory(string $dir): void
+    {
+        if (!is_dir($dir)) {
+            return;
+        }
+
+        $items = scandir($dir);
+
+        if ($items === false) {
+            return;
+        }
+
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+
+            $path = $dir . DIRECTORY_SEPARATOR . $item;
+
+            if (is_dir($path)) {
+                $this->removeDirectory($path);
+            } elseif (is_file($path)) {
+                unlink($path);
+            }
+        }
+
+        rmdir($dir);
+    }
+}

--- a/tests/Unit/Deploy/Check/HealthEndpointCheckTest.php
+++ b/tests/Unit/Deploy/Check/HealthEndpointCheckTest.php
@@ -1,0 +1,173 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Deploy\Check;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Deploy\Check\HealthEndpointCheck;
+use Pulsar\Deploy\CheckSeverity;
+use Pulsar\Http\Method;
+use Pulsar\Routing\Route;
+use Pulsar\Routing\Router;
+
+#[CoversClass(HealthEndpointCheck::class)]
+final class HealthEndpointCheckTest extends TestCase
+{
+    #[Test]
+    public function it_returns_name(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter());
+
+        self::assertSame('health-endpoint', $check->getName());
+    }
+
+    #[Test]
+    public function it_returns_description(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter());
+
+        self::assertSame('Validates a health check endpoint is registered for monitoring', $check->getDescription());
+    }
+
+    #[Test]
+    public function it_passes_when_health_endpoint_exists(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter('/health'));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('Health endpoint found', $result->message);
+        self::assertStringContainsString('/health', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_with_healthz_endpoint(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter('/healthz'));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('/healthz', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_with_health_check_endpoint(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter('/health-check'));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('/health-check', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_with_health_sub_path(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter('/health/live'));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('/health/live', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_when_health_endpoint_exists_in_staging(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter('/health'));
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+    }
+
+    #[Test]
+    public function it_warns_when_no_health_endpoint_in_production(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter());
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('No health check endpoint found', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_warns_when_no_health_endpoint_in_staging(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter());
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('No health check endpoint found', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_passes_when_no_health_endpoint_in_local(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter());
+
+        $result = $check->check('local');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('not required in local', $result->message);
+    }
+
+    #[Test]
+    public function production_recommendations_mention_health_route(): void
+    {
+        $check = new HealthEndpointCheck($this->buildRouter());
+
+        $result = $check->check('production');
+
+        $joined = implode(' ', $result->recommendations);
+        self::assertStringContainsString('/health', $joined);
+        self::assertStringContainsString('200', $joined);
+    }
+
+    #[Test]
+    public function it_does_not_match_unrelated_routes(): void
+    {
+        $router = new Router();
+        $router->add(new Route(
+            methods: [Method::GET],
+            path: '/api/users',
+            handler: self::class,
+        ));
+        $router->add(new Route(
+            methods: [Method::GET],
+            path: '/dashboard',
+            handler: self::class,
+        ));
+
+        $check = new HealthEndpointCheck($router);
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+    }
+
+    private function buildRouter(?string $healthPath = null): Router
+    {
+        $router = new Router();
+
+        if ($healthPath !== null) {
+            $router->add(new Route(
+                methods: [Method::GET],
+                path: $healthPath,
+                handler: self::class,
+            ));
+        }
+
+        return $router;
+    }
+}

--- a/tests/Unit/Deploy/Check/IntegrityCheckTest.php
+++ b/tests/Unit/Deploy/Check/IntegrityCheckTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Deploy\Check;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\IntegrityConfig;
+use Pulsar\Config\IntegrityPolicyMode;
+use Pulsar\Deploy\Check\IntegrityCheck;
+use Pulsar\Deploy\CheckSeverity;
+
+#[CoversClass(IntegrityCheck::class)]
+final class IntegrityCheckTest extends TestCase
+{
+    #[Test]
+    public function it_returns_name(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: true));
+
+        self::assertSame('integrity', $check->getName());
+    }
+
+    #[Test]
+    public function it_returns_description(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: true));
+
+        self::assertSame('Validates file integrity verification is enabled', $check->getDescription());
+    }
+
+    #[Test]
+    public function it_passes_when_integrity_is_enabled(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: true, mode: IntegrityPolicyMode::Strict));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('Integrity verification is enabled', $result->message);
+        self::assertStringContainsString('strict', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_when_integrity_enabled_in_staging(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: true));
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+    }
+
+    #[Test]
+    public function it_warns_when_integrity_disabled_in_production(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('File integrity verification is disabled', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_warns_when_integrity_disabled_in_staging(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('File integrity verification is disabled', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_passes_when_integrity_disabled_in_local(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('local');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('not required in local', $result->message);
+    }
+
+    #[Test]
+    public function production_recommendations_mention_config_and_manifest(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('production');
+
+        $joined = implode(' ', $result->recommendations);
+        self::assertStringContainsString('config/integrity.php', $joined);
+        self::assertStringContainsString('php bin/pulsar optimize', $joined);
+    }
+
+    #[Test]
+    public function it_includes_warn_mode_in_pass_message(): void
+    {
+        $check = new IntegrityCheck($this->buildConfig(enabled: true, mode: IntegrityPolicyMode::Warn));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('warn', $result->message);
+    }
+
+    private function buildConfig(bool $enabled, IntegrityPolicyMode $mode = IntegrityPolicyMode::Warn): IntegrityConfig
+    {
+        return new IntegrityConfig(
+            enabled: $enabled,
+            mode: $mode,
+        );
+    }
+}

--- a/tests/Unit/Deploy/Check/RateLimitCheckTest.php
+++ b/tests/Unit/Deploy/Check/RateLimitCheckTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Deploy\Check;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\CsrfConfig;
+use Pulsar\Config\RateLimitConfig;
+use Pulsar\Config\SecurityConfig;
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Config\SessionConfig;
+use Pulsar\Deploy\Check\RateLimitCheck;
+use Pulsar\Deploy\CheckSeverity;
+
+#[CoversClass(RateLimitCheck::class)]
+final class RateLimitCheckTest extends TestCase
+{
+    #[Test]
+    public function it_returns_name(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: true));
+
+        self::assertSame('rate-limiting', $check->getName());
+    }
+
+    #[Test]
+    public function it_returns_description(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: true));
+
+        self::assertSame('Validates rate limiting is enabled for the target environment', $check->getDescription());
+    }
+
+    #[Test]
+    public function it_passes_when_rate_limiting_is_enabled(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: true, limit: 100, window: 60));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('Rate limiting is enabled', $result->message);
+        self::assertStringContainsString('100', $result->message);
+        self::assertStringContainsString('60', $result->message);
+    }
+
+    #[Test]
+    public function it_passes_when_rate_limiting_enabled_in_staging(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: true));
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+    }
+
+    #[Test]
+    public function it_warns_when_rate_limiting_disabled_in_production(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('Rate limiting is not enabled', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_warns_when_rate_limiting_disabled_in_staging(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('Rate limiting is not enabled', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function it_passes_when_rate_limiting_disabled_in_local(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('local');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('not required in local', $result->message);
+    }
+
+    #[Test]
+    public function production_recommendations_mention_config_and_routes(): void
+    {
+        $check = new RateLimitCheck($this->buildConfig(enabled: false));
+
+        $result = $check->check('production');
+
+        $joined = implode(' ', $result->recommendations);
+        self::assertStringContainsString('config/security.php', $joined);
+        self::assertStringContainsString('authentication endpoints', $joined);
+    }
+
+    private function buildConfig(bool $enabled, int $limit = 60, int $window = 60): SecurityConfig
+    {
+        return new SecurityConfig(
+            session: new SessionConfig(
+                cookieName: 'PULSAR_SESSION',
+                lifetime: 7200,
+                cookieHttpOnly: true,
+                cookieSecure: true,
+                cookieSameSite: 'Strict',
+                regenerateOnPrivilegeChange: true,
+            ),
+            csrf: new CsrfConfig(
+                enabled: true,
+                tokenLength: 32,
+                headerName: 'X-CSRF-Token',
+                formFieldName: '_csrf_token',
+            ),
+            headers: new SecurityHeadersConfig(headers: []),
+            rateLimit: new RateLimitConfig(
+                enabled: $enabled,
+                defaultLimit: $limit,
+                defaultWindow: $window,
+            ),
+        );
+    }
+}

--- a/tests/Unit/Deploy/Check/SecurityHeadersReadinessCheckTest.php
+++ b/tests/Unit/Deploy/Check/SecurityHeadersReadinessCheckTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Deploy\Check;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\SecurityHeadersConfig;
+use Pulsar\Deploy\Check\SecurityHeadersReadinessCheck;
+use Pulsar\Deploy\CheckSeverity;
+
+#[CoversClass(SecurityHeadersReadinessCheck::class)]
+final class SecurityHeadersReadinessCheckTest extends TestCase
+{
+    #[Test]
+    public function getNameReturnsSecurityHeaders(): void
+    {
+        $check = new SecurityHeadersReadinessCheck(new SecurityHeadersConfig(headers: []));
+
+        self::assertSame('security-headers', $check->getName());
+    }
+
+    #[Test]
+    public function getDescriptionReturnsExpectedText(): void
+    {
+        $check = new SecurityHeadersReadinessCheck(new SecurityHeadersConfig(headers: []));
+
+        self::assertStringContainsString('X-Content-Type-Options', $check->getDescription());
+        self::assertStringContainsString('X-Frame-Options', $check->getDescription());
+    }
+
+    #[Test]
+    public function passesWhenBothHeadersPresent(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'X-Content-Type-Options' => 'nosniff',
+            'X-Frame-Options' => 'DENY',
+        ]);
+        $check = new SecurityHeadersReadinessCheck($config);
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+        self::assertStringContainsString('configured', $result->message);
+    }
+
+    #[Test]
+    public function errorsWhenBothMissingInProduction(): void
+    {
+        $check = new SecurityHeadersReadinessCheck(new SecurityHeadersConfig(headers: []));
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Error, $result->severity);
+        self::assertStringContainsString('X-Content-Type-Options', $result->message);
+        self::assertStringContainsString('X-Frame-Options', $result->message);
+        self::assertNotEmpty($result->recommendations);
+    }
+
+    #[Test]
+    public function warnsWhenBothMissingInStaging(): void
+    {
+        $check = new SecurityHeadersReadinessCheck(new SecurityHeadersConfig(headers: []));
+
+        $result = $check->check('staging');
+
+        self::assertSame(CheckSeverity::Warning, $result->severity);
+        self::assertStringContainsString('Missing security headers', $result->message);
+    }
+
+    #[Test]
+    public function passesInLocalEnvironmentEvenWithMissingHeaders(): void
+    {
+        $check = new SecurityHeadersReadinessCheck(new SecurityHeadersConfig(headers: []));
+
+        $result = $check->check('local');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+    }
+
+    #[Test]
+    public function errorsWhenOnlyContentTypeOptionsMissingInProduction(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'X-Frame-Options' => 'DENY',
+        ]);
+        $check = new SecurityHeadersReadinessCheck($config);
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Error, $result->severity);
+        self::assertStringContainsString('X-Content-Type-Options', $result->message);
+        self::assertCount(1, $result->recommendations);
+        self::assertStringContainsString('nosniff', $result->recommendations[0]);
+    }
+
+    #[Test]
+    public function errorsWhenOnlyFrameOptionsMissingInProduction(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'X-Content-Type-Options' => 'nosniff',
+        ]);
+        $check = new SecurityHeadersReadinessCheck($config);
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Error, $result->severity);
+        self::assertStringContainsString('X-Frame-Options', $result->message);
+        self::assertCount(1, $result->recommendations);
+        self::assertStringContainsString('clickjacking', $result->recommendations[0]);
+    }
+
+    #[Test]
+    public function headerMatchIsCaseInsensitive(): void
+    {
+        $config = new SecurityHeadersConfig(headers: [
+            'x-content-type-options' => 'nosniff',
+            'x-frame-options' => 'SAMEORIGIN',
+        ]);
+        $check = new SecurityHeadersReadinessCheck($config);
+
+        $result = $check->check('production');
+
+        self::assertSame(CheckSeverity::Pass, $result->severity);
+    }
+
+    #[Test]
+    public function bothMissingRecommendationsCoverBothHeaders(): void
+    {
+        $check = new SecurityHeadersReadinessCheck(new SecurityHeadersConfig(headers: []));
+
+        $result = $check->check('production');
+
+        self::assertCount(2, $result->recommendations);
+        $joined = implode(' ', $result->recommendations);
+        self::assertStringContainsString('nosniff', $joined);
+        self::assertStringContainsString('clickjacking', $joined);
+    }
+}

--- a/tests/Unit/ErrorHandling/HttpExceptionTest.php
+++ b/tests/Unit/ErrorHandling/HttpExceptionTest.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\ErrorHandling;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\ErrorHandling\HttpException;
+use Pulsar\Http\ResponseStatus;
+use RuntimeException;
+
+#[CoversClass(HttpException::class)]
+final class HttpExceptionTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsStatusCodeAndMessage(): void
+    {
+        $exception = new HttpException(ResponseStatus::NotFound, 'Page not found');
+
+        self::assertSame(ResponseStatus::NotFound, $exception->getStatusCode());
+        self::assertSame('Page not found', $exception->getMessage());
+        self::assertSame(404, $exception->getCode());
+    }
+
+    #[Test]
+    public function constructorSetsHeaders(): void
+    {
+        $headers = ['X-Retry-After' => '300'];
+        $exception = new HttpException(ResponseStatus::ServiceUnavailable, 'Busy', $headers);
+
+        self::assertSame($headers, $exception->getHeaders());
+    }
+
+    #[Test]
+    public function constructorSetsPreviousException(): void
+    {
+        $previous = new RuntimeException('root cause');
+        $exception = new HttpException(ResponseStatus::InternalServerError, 'fail', [], $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function notFoundFactory(): void
+    {
+        $exception = HttpException::notFound();
+
+        self::assertSame(ResponseStatus::NotFound, $exception->getStatusCode());
+        self::assertSame('Not Found', $exception->getMessage());
+    }
+
+    #[Test]
+    public function notFoundFactoryWithCustomMessage(): void
+    {
+        $exception = HttpException::notFound('Custom 404');
+
+        self::assertSame('Custom 404', $exception->getMessage());
+    }
+
+    #[Test]
+    public function forbiddenFactory(): void
+    {
+        $exception = HttpException::forbidden();
+
+        self::assertSame(ResponseStatus::Forbidden, $exception->getStatusCode());
+        self::assertSame('Forbidden', $exception->getMessage());
+    }
+
+    #[Test]
+    public function badRequestFactory(): void
+    {
+        $exception = HttpException::badRequest();
+
+        self::assertSame(ResponseStatus::BadRequest, $exception->getStatusCode());
+        self::assertSame('Bad Request', $exception->getMessage());
+    }
+
+    #[Test]
+    public function serviceUnavailableFactory(): void
+    {
+        $exception = HttpException::serviceUnavailable();
+
+        self::assertSame(ResponseStatus::ServiceUnavailable, $exception->getStatusCode());
+        self::assertSame('Service Unavailable', $exception->getMessage());
+    }
+
+    #[Test]
+    public function getHeadersDefaultsToEmptyArray(): void
+    {
+        $exception = HttpException::notFound();
+
+        self::assertSame([], $exception->getHeaders());
+    }
+}

--- a/tests/Unit/Extensibility/Exception/DependencyExceptionTest.php
+++ b/tests/Unit/Extensibility/Exception/DependencyExceptionTest.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extensibility\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extensibility\Exception\DependencyException;
+use Pulsar\Extensibility\Exception\ExtensionException;
+use RuntimeException;
+
+#[CoversClass(DependencyException::class)]
+final class DependencyExceptionTest extends TestCase
+{
+    #[Test]
+    public function extendsExtensionException(): void
+    {
+        $exception = DependencyException::unresolvable('conflict');
+
+        self::assertInstanceOf(ExtensionException::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    #[Test]
+    public function missingDependencyContainsExtensionAndDependency(): void
+    {
+        $exception = DependencyException::missingDependency('acme/billing', 'acme/core');
+
+        self::assertSame(
+            'Extension "acme/billing" requires extension "acme/core" which is not available',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function versionMismatchContainsAllDetails(): void
+    {
+        $exception = DependencyException::versionMismatch(
+            'acme/billing',
+            'acme/core',
+            '^2.0',
+            '1.5.0',
+        );
+
+        self::assertSame(
+            'Extension "acme/billing" requires "acme/core" version ^2.0, but version 1.5.0 is available',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function circularDependencyContainsChain(): void
+    {
+        $exception = DependencyException::circularDependency(['A', 'B', 'C', 'A']);
+
+        self::assertSame(
+            'Circular dependency detected: A -> B -> C -> A',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function circularDependencyWithTwoElements(): void
+    {
+        $exception = DependencyException::circularDependency(['X', 'X']);
+
+        self::assertSame(
+            'Circular dependency detected: X -> X',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function unresolvableContainsReason(): void
+    {
+        $exception = DependencyException::unresolvable('conflicting version constraints');
+
+        self::assertSame(
+            'Unable to resolve extension dependencies: conflicting version constraints',
+            $exception->getMessage(),
+        );
+    }
+}

--- a/tests/Unit/Extensibility/Exception/ExtensionExceptionTest.php
+++ b/tests/Unit/Extensibility/Exception/ExtensionExceptionTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extensibility\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extensibility\Exception\ExtensionException;
+use RuntimeException;
+
+#[CoversClass(ExtensionException::class)]
+final class ExtensionExceptionTest extends TestCase
+{
+    #[Test]
+    public function extendsRuntimeException(): void
+    {
+        $exception = ExtensionException::notFound('acme/billing');
+
+        self::assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    #[Test]
+    public function notFoundContainsName(): void
+    {
+        $exception = ExtensionException::notFound('acme/billing');
+
+        self::assertSame('Extension "acme/billing" not found', $exception->getMessage());
+    }
+
+    #[Test]
+    public function alreadyRegisteredContainsName(): void
+    {
+        $exception = ExtensionException::alreadyRegistered('acme/billing');
+
+        self::assertSame('Extension "acme/billing" is already registered', $exception->getMessage());
+    }
+
+    #[Test]
+    public function invalidExtensionClassContainsClass(): void
+    {
+        $exception = ExtensionException::invalidExtensionClass('Acme\\InvalidExtension');
+
+        self::assertSame(
+            'Extension class "Acme\\InvalidExtension" must implement ExtensionInterface',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function invalidStateContainsAllDetails(): void
+    {
+        $exception = ExtensionException::invalidState('acme/billing', 'registered', 'booted');
+
+        self::assertSame(
+            'Extension "acme/billing" is in state "registered" but expected "booted"',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function bootFailedContainsNameAndReason(): void
+    {
+        $exception = ExtensionException::bootFailed('acme/billing', 'missing config');
+
+        self::assertSame(
+            'Failed to boot extension "acme/billing": missing config',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function registrationFailedContainsNameAndReason(): void
+    {
+        $exception = ExtensionException::registrationFailed('acme/billing', 'duplicate service ID');
+
+        self::assertSame(
+            'Failed to register extension "acme/billing": duplicate service ID',
+            $exception->getMessage(),
+        );
+    }
+}

--- a/tests/Unit/Extensibility/Exception/ManifestExceptionTest.php
+++ b/tests/Unit/Extensibility/Exception/ManifestExceptionTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extensibility\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extensibility\Exception\ExtensionException;
+use Pulsar\Extensibility\Exception\ManifestException;
+use RuntimeException;
+
+#[CoversClass(ManifestException::class)]
+final class ManifestExceptionTest extends TestCase
+{
+    #[Test]
+    public function extendsExtensionException(): void
+    {
+        $exception = ManifestException::fileNotFound('/tmp/pulsar.json');
+
+        self::assertInstanceOf(ExtensionException::class, $exception);
+        self::assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    #[Test]
+    public function fileNotFoundContainsPath(): void
+    {
+        $exception = ManifestException::fileNotFound('/extensions/acme/pulsar.json');
+
+        self::assertSame('Manifest file not found: /extensions/acme/pulsar.json', $exception->getMessage());
+    }
+
+    #[Test]
+    public function invalidJsonContainsPathAndError(): void
+    {
+        $exception = ManifestException::invalidJson('/ext/pulsar.json', 'Syntax error');
+
+        self::assertSame('Invalid JSON in manifest "/ext/pulsar.json": Syntax error', $exception->getMessage());
+    }
+
+    #[Test]
+    public function missingFieldContainsFieldAndPath(): void
+    {
+        $exception = ManifestException::missingField('name', '/ext/pulsar.json');
+
+        self::assertSame('Missing required field "name" in manifest: /ext/pulsar.json', $exception->getMessage());
+    }
+
+    #[Test]
+    public function invalidFieldTypeContainsAllDetails(): void
+    {
+        $exception = ManifestException::invalidFieldType('version', 'string', 'integer', '/ext/pulsar.json');
+
+        self::assertSame(
+            'Invalid type for field "version" in manifest "/ext/pulsar.json": expected string, got integer',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function invalidVersionContainsVersionAndPath(): void
+    {
+        $exception = ManifestException::invalidVersion('not-semver', '/ext/pulsar.json');
+
+        self::assertSame(
+            'Invalid version format "not-semver" in manifest: /ext/pulsar.json',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function extensionClassNotFoundContainsClassAndPath(): void
+    {
+        $exception = ManifestException::extensionClassNotFound('Acme\\Extension', '/ext/pulsar.json');
+
+        self::assertSame(
+            'Extension class "Acme\\Extension" not found for manifest: /ext/pulsar.json',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function incompatibleFrameworkVersionWithMaxConstraint(): void
+    {
+        $exception = ManifestException::incompatibleFrameworkVersion(
+            'acme/billing',
+            '1.0.0',
+            '2.0.0',
+            '3.0.0',
+        );
+
+        self::assertSame(
+            'Extension "acme/billing" requires Pulsar 1.0.0 - 2.0.0, but version 3.0.0 is installed',
+            $exception->getMessage(),
+        );
+    }
+
+    #[Test]
+    public function incompatibleFrameworkVersionWithoutMaxConstraint(): void
+    {
+        $exception = ManifestException::incompatibleFrameworkVersion(
+            'acme/billing',
+            '2.0.0',
+            null,
+            '1.5.0',
+        );
+
+        self::assertSame(
+            'Extension "acme/billing" requires Pulsar >= 2.0.0, but version 1.5.0 is installed',
+            $exception->getMessage(),
+        );
+    }
+}

--- a/tests/Unit/Extensibility/Manifest/ProvidesConfigTest.php
+++ b/tests/Unit/Extensibility/Manifest/ProvidesConfigTest.php
@@ -1,0 +1,158 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extensibility\Manifest;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extensibility\Exception\ManifestException;
+use Pulsar\Extensibility\Manifest\ProvidesConfig;
+
+#[CoversClass(ProvidesConfig::class)]
+final class ProvidesConfigTest extends TestCase
+{
+    #[Test]
+    public function constructorDefaults(): void
+    {
+        $config = new ProvidesConfig();
+
+        self::assertSame([], $config->services);
+        self::assertSame([], $config->commands);
+        self::assertFalse($config->routes);
+        self::assertSame([], $config->middleware);
+    }
+
+    #[Test]
+    public function fromArrayWithAllFields(): void
+    {
+        $config = ProvidesConfig::fromArray([
+            'services' => ['App\\Service\\FooService'],
+            'commands' => ['App\\Command\\BarCommand'],
+            'routes' => true,
+            'middleware' => ['App\\Middleware\\AuthMiddleware'],
+        ]);
+
+        self::assertSame(['App\\Service\\FooService'], $config->services);
+        self::assertSame(['App\\Command\\BarCommand'], $config->commands);
+        self::assertTrue($config->routes);
+        self::assertSame(['App\\Middleware\\AuthMiddleware'], $config->middleware);
+    }
+
+    #[Test]
+    public function fromArrayWithDefaults(): void
+    {
+        $config = ProvidesConfig::fromArray([]);
+
+        self::assertSame([], $config->services);
+        self::assertSame([], $config->commands);
+        self::assertFalse($config->routes);
+        self::assertSame([], $config->middleware);
+    }
+
+    #[Test]
+    public function fromArrayThrowsOnAssociativeServices(): void
+    {
+        $this->expectException(ManifestException::class);
+        $this->expectExceptionMessage('provides.services');
+
+        $_ = ProvidesConfig::fromArray([
+            'services' => ['key' => 'value'],
+        ]);
+    }
+
+    #[Test]
+    public function fromArrayThrowsOnAssociativeCommands(): void
+    {
+        $this->expectException(ManifestException::class);
+        $this->expectExceptionMessage('provides.commands');
+
+        $_ = ProvidesConfig::fromArray([
+            'commands' => ['key' => 'value'],
+        ]);
+    }
+
+    #[Test]
+    public function fromArrayThrowsOnAssociativeMiddleware(): void
+    {
+        $this->expectException(ManifestException::class);
+        $this->expectExceptionMessage('provides.middleware');
+
+        $_ = ProvidesConfig::fromArray([
+            'middleware' => ['key' => 'value'],
+        ]);
+    }
+
+    #[Test]
+    public function hasServicesReturnsTrueWhenNonEmpty(): void
+    {
+        $config = new ProvidesConfig(services: ['SomeService']);
+
+        self::assertTrue($config->hasServices());
+    }
+
+    #[Test]
+    public function hasServicesReturnsFalseWhenEmpty(): void
+    {
+        $config = new ProvidesConfig();
+
+        self::assertFalse($config->hasServices());
+    }
+
+    #[Test]
+    public function hasCommandsReturnsTrueWhenNonEmpty(): void
+    {
+        $config = new ProvidesConfig(commands: ['SomeCommand']);
+
+        self::assertTrue($config->hasCommands());
+    }
+
+    #[Test]
+    public function hasRoutesReturnsTrueWhenEnabled(): void
+    {
+        $config = new ProvidesConfig(routes: true);
+
+        self::assertTrue($config->hasRoutes());
+    }
+
+    #[Test]
+    public function hasRoutesReturnsFalseWhenDisabled(): void
+    {
+        $config = new ProvidesConfig(routes: false);
+
+        self::assertFalse($config->hasRoutes());
+    }
+
+    #[Test]
+    public function hasMiddlewareReturnsTrueWhenNonEmpty(): void
+    {
+        $config = new ProvidesConfig(middleware: ['SomeMiddleware']);
+
+        self::assertTrue($config->hasMiddleware());
+    }
+
+    #[Test]
+    public function providesAnythingReturnsTrueWithServices(): void
+    {
+        $config = new ProvidesConfig(services: ['SomeService']);
+
+        self::assertTrue($config->providesAnything());
+    }
+
+    #[Test]
+    public function providesAnythingReturnsTrueWithRoutes(): void
+    {
+        $config = new ProvidesConfig(routes: true);
+
+        self::assertTrue($config->providesAnything());
+    }
+
+    #[Test]
+    public function providesAnythingReturnsFalseWhenEmpty(): void
+    {
+        $config = new ProvidesConfig();
+
+        self::assertFalse($config->providesAnything());
+    }
+}

--- a/tests/Unit/Extensibility/Manifest/PulsarVersionConfigTest.php
+++ b/tests/Unit/Extensibility/Manifest/PulsarVersionConfigTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extensibility\Manifest;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extensibility\Manifest\PulsarVersionConfig;
+
+#[CoversClass(PulsarVersionConfig::class)]
+final class PulsarVersionConfigTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsProperties(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0', '2.0.0');
+
+        self::assertSame('1.0.0', $config->minVersion);
+        self::assertSame('2.0.0', $config->maxVersion);
+    }
+
+    #[Test]
+    public function constructorDefaultsMaxVersionToNull(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0');
+
+        self::assertNull($config->maxVersion);
+    }
+
+    #[Test]
+    public function fromArrayWithAllFields(): void
+    {
+        $config = PulsarVersionConfig::fromArray([
+            'min_version' => '1.0.0',
+            'max_version' => '2.0.0',
+        ]);
+
+        self::assertSame('1.0.0', $config->minVersion);
+        self::assertSame('2.0.0', $config->maxVersion);
+    }
+
+    #[Test]
+    public function fromArrayWithDefaults(): void
+    {
+        $config = PulsarVersionConfig::fromArray([]);
+
+        self::assertSame('0.0.0', $config->minVersion);
+        self::assertNull($config->maxVersion);
+    }
+
+    #[Test]
+    public function isSatisfiedByWithinRange(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0', '2.0.0');
+
+        self::assertTrue($config->isSatisfiedBy('1.5.0'));
+        self::assertTrue($config->isSatisfiedBy('1.0.0'));
+        self::assertTrue($config->isSatisfiedBy('2.0.0'));
+    }
+
+    #[Test]
+    public function isSatisfiedByBelowMinimum(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0', '2.0.0');
+
+        self::assertFalse($config->isSatisfiedBy('0.9.0'));
+    }
+
+    #[Test]
+    public function isSatisfiedByAboveMaximum(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0', '2.0.0');
+
+        self::assertFalse($config->isSatisfiedBy('2.1.0'));
+    }
+
+    #[Test]
+    public function isSatisfiedByWithNoMaxVersion(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0');
+
+        self::assertTrue($config->isSatisfiedBy('99.0.0'));
+        self::assertFalse($config->isSatisfiedBy('0.9.0'));
+    }
+
+    #[Test]
+    public function isSatisfiedByCurrentDelegatesToIsSatisfiedBy(): void
+    {
+        $config = new PulsarVersionConfig('0.0.1');
+
+        self::assertTrue($config->isSatisfiedByCurrent());
+    }
+
+    #[Test]
+    public function toStringWithMaxVersion(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0', '2.0.0');
+
+        self::assertSame('1.0.0 - 2.0.0', $config->toString());
+    }
+
+    #[Test]
+    public function toStringWithoutMaxVersion(): void
+    {
+        $config = new PulsarVersionConfig('1.0.0');
+
+        self::assertSame('>= 1.0.0', $config->toString());
+    }
+}

--- a/tests/Unit/Extension/Payments/Clock/ClockTest.php
+++ b/tests/Unit/Extension/Payments/Clock/ClockTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Clock;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Clock\SystemClock;
+
+#[CoversClass(FixedClock::class)]
+#[CoversClass(SystemClock::class)]
+final class ClockTest extends TestCase
+{
+    #[Test]
+    public function fixedClockReturnsInjectedTime(): void
+    {
+        $time = new DateTimeImmutable('2025-06-01T12:00:00Z');
+        $clock = new FixedClock($time);
+
+        self::assertSame($time, $clock->now());
+    }
+
+    #[Test]
+    public function fixedClockAdvanceMovesForward(): void
+    {
+        $clock = new FixedClock(new DateTimeImmutable('2025-01-01T00:00:00Z'));
+        $clock->advance(60);
+
+        self::assertSame('2025-01-01T00:01:00+00:00', $clock->now()->format('c'));
+    }
+
+    #[Test]
+    public function fixedClockSetReplacesTime(): void
+    {
+        $clock = new FixedClock(new DateTimeImmutable('2025-01-01T00:00:00Z'));
+        $newTime = new DateTimeImmutable('2026-06-15T10:30:00Z');
+        $clock->set($newTime);
+
+        self::assertSame($newTime, $clock->now());
+    }
+
+    #[Test]
+    public function systemClockReturnsCurrentTime(): void
+    {
+        $clock = new SystemClock();
+        $before = new DateTimeImmutable();
+        $now = $clock->now();
+        $after = new DateTimeImmutable();
+
+        self::assertGreaterThanOrEqual($before->getTimestamp(), $now->getTimestamp());
+        self::assertLessThanOrEqual($after->getTimestamp(), $now->getTimestamp());
+    }
+}

--- a/tests/Unit/Extension/Payments/Config/PaymentsConfigTest.php
+++ b/tests/Unit/Extension/Payments/Config/PaymentsConfigTest.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Config\IdempotencyConfig;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Config\WebhookConfig;
+use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+
+#[CoversClass(PaymentsConfig::class)]
+#[CoversClass(WebhookConfig::class)]
+#[CoversClass(IdempotencyConfig::class)]
+#[CoversClass(WebhookLogConfig::class)]
+final class PaymentsConfigTest extends TestCase
+{
+    #[Test]
+    public function fromArrayWithDefaults(): void
+    {
+        $config = PaymentsConfig::fromArray([]);
+
+        self::assertSame('null', $config->provider);
+        self::assertSame('USD', $config->defaultCurrency);
+
+        // Webhook defaults
+        self::assertSame('', $config->webhook->secret);
+        self::assertSame('/webhooks/payments', $config->webhook->path);
+        self::assertSame(300, $config->webhook->toleranceSeconds);
+        self::assertSame('X-Payments-Signature', $config->webhook->signatureHeader);
+
+        // Idempotency defaults
+        self::assertSame(86400, $config->idempotency->ttlSeconds);
+        self::assertSame('memory', $config->idempotency->store);
+        self::assertSame(256, $config->idempotency->maxKeyLength);
+
+        // Webhook log defaults
+        self::assertSame(259200, $config->webhookLog->ttlSeconds);
+        self::assertSame('memory', $config->webhookLog->store);
+    }
+
+    #[Test]
+    public function fromArrayWithOverrides(): void
+    {
+        $config = PaymentsConfig::fromArray([
+            'provider' => 'simulator',
+            'default_currency' => 'EUR',
+            'webhook' => [
+                'secret' => 'my-secret',
+                'path' => '/hooks/pay',
+                'tolerance_seconds' => 600,
+                'signature_header' => 'X-Custom-Sig',
+            ],
+            'idempotency' => [
+                'ttl_seconds' => 1800,
+                'store' => 'redis',
+                'max_key_length' => 128,
+            ],
+            'webhook_log' => [
+                'ttl_seconds' => 86400,
+                'store' => 'database',
+            ],
+        ]);
+
+        self::assertSame('simulator', $config->provider);
+        self::assertSame('EUR', $config->defaultCurrency);
+        self::assertSame('my-secret', $config->webhook->secret);
+        self::assertSame('/hooks/pay', $config->webhook->path);
+        self::assertSame(600, $config->webhook->toleranceSeconds);
+        self::assertSame('X-Custom-Sig', $config->webhook->signatureHeader);
+        self::assertSame(1800, $config->idempotency->ttlSeconds);
+        self::assertSame('redis', $config->idempotency->store);
+        self::assertSame(128, $config->idempotency->maxKeyLength);
+        self::assertSame(86400, $config->webhookLog->ttlSeconds);
+        self::assertSame('database', $config->webhookLog->store);
+    }
+
+    #[Test]
+    public function webhookConfigFromArray(): void
+    {
+        $config = WebhookConfig::fromArray([
+            'secret' => 'sec',
+            'path' => '/wh',
+        ]);
+
+        self::assertSame('sec', $config->secret);
+        self::assertSame('/wh', $config->path);
+        self::assertSame(300, $config->toleranceSeconds);
+    }
+
+    #[Test]
+    public function idempotencyConfigFromArray(): void
+    {
+        $config = IdempotencyConfig::fromArray([
+            'ttl_seconds' => 900,
+        ]);
+
+        self::assertSame(900, $config->ttlSeconds);
+        self::assertSame('memory', $config->store);
+        self::assertSame(256, $config->maxKeyLength);
+    }
+
+    #[Test]
+    public function webhookLogConfigFromArray(): void
+    {
+        $config = WebhookLogConfig::fromArray([]);
+
+        self::assertSame(259200, $config->ttlSeconds);
+        self::assertSame('memory', $config->store);
+    }
+}

--- a/tests/Unit/Extension/Payments/Contract/PaymentProviderContractTestCase.php
+++ b/tests/Unit/Extension/Payments/Contract/PaymentProviderContractTestCase.php
@@ -1,0 +1,66 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Contract;
+
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+
+/**
+ * Abstract contract test for PaymentProviderInterface implementations.
+ *
+ * Subclasses provide the provider instance; this class verifies the contract.
+ */
+abstract class PaymentProviderContractTestCase extends TestCase
+{
+    abstract protected function createProvider(): PaymentProviderInterface;
+
+    #[Test]
+    public function nameReturnsNonEmptyString(): void
+    {
+        $provider = $this->createProvider();
+
+        self::assertNotEmpty($provider->name());
+    }
+
+    #[Test]
+    public function createIntentReturnsCreatedStatus(): void
+    {
+        $provider = $this->createProvider();
+        $amount = Money::of(5000, Currency::USD);
+
+        $intent = $provider->createIntent($amount, 'idem-create-1');
+
+        self::assertSame(PaymentIntentStatus::Created, $intent->status);
+        self::assertSame($provider->name(), $intent->provider);
+        self::assertNotEmpty($intent->id);
+    }
+
+    #[Test]
+    public function createIntentPreservesMetadata(): void
+    {
+        $provider = $this->createProvider();
+        $amount = Money::of(2000, Currency::EUR);
+
+        $intent = $provider->createIntent($amount, 'idem-create-meta', ['order_id' => '123']);
+
+        self::assertSame(['order_id' => '123'], $intent->metadata);
+    }
+
+    #[Test]
+    public function cancelIntentReturnsCancelledStatus(): void
+    {
+        $provider = $this->createProvider();
+        $amount = Money::of(3000, Currency::USD);
+
+        $intent = $provider->createIntent($amount, 'idem-cancel-1');
+        $cancelled = $provider->cancelIntent($intent->id, 'idem-cancel-2');
+
+        self::assertSame(PaymentIntentStatus::Cancelled, $cancelled->status);
+    }
+}

--- a/tests/Unit/Extension/Payments/Controller/WebhookControllerTest.php
+++ b/tests/Unit/Extension/Payments/Controller/WebhookControllerTest.php
@@ -1,0 +1,136 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Controller;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Config\IdempotencyConfig;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Config\WebhookConfig;
+use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+use Pulsar\Extension\Payments\Contract\WebhookHandlerInterface;
+use Pulsar\Extension\Payments\Controller\WebhookController;
+use Pulsar\Extension\Payments\Domain\WebhookEvent;
+use Pulsar\Extension\Payments\Webhook\HmacWebhookVerifier;
+use Pulsar\Extension\Payments\Webhook\InMemoryWebhookEventLog;
+use Pulsar\Extension\Payments\Webhook\WebhookProcessor;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Observability\Metrics\MetricRegistry;
+
+#[CoversClass(WebhookController::class)]
+final class WebhookControllerTest extends TestCase
+{
+    #[Test]
+    public function handleExtractsSignatureAndDelegatesToProcessor(): void
+    {
+        $secret = 'test-webhook-secret';
+        $timestamp = 1735689600;
+        $body = '{"id":"evt_1","type":"payment_intent.created","created_at":1000,"data":{}}';
+        $signature = hash_hmac('sha256', $timestamp . '.' . $body, $secret);
+        $signatureHeader = 't=' . $timestamp . ',v1=' . $signature;
+
+        $clock = new FixedClock(new DateTimeImmutable('@' . $timestamp));
+        $handler = new class implements WebhookHandlerInterface {
+            public bool $called = false;
+
+            public function handle(WebhookEvent $event): void
+            {
+                $this->called = true;
+            }
+        };
+
+        $config = $this->createConfig($secret);
+        $processor = new WebhookProcessor(
+            verifier: new HmacWebhookVerifier($clock),
+            eventLog: new InMemoryWebhookEventLog(),
+            handler: $handler,
+            clock: $clock,
+            metricRegistry: new MetricRegistry(),
+            logger: new NullLogger(),
+            config: $config,
+        );
+
+        $controller = new WebhookController($processor, $config);
+
+        $request = new Request(
+            method: Method::POST,
+            uri: '/webhooks/payments',
+            path: '/webhooks/payments',
+            queryString: '',
+            headers: new HeaderBag(['X-Payments-Signature' => $signatureHeader]),
+            body: $body,
+        );
+
+        $response = $controller->handle($request);
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        self::assertTrue($handler->called);
+    }
+
+    #[Test]
+    public function handleUsesEmptyStringWhenSignatureHeaderMissing(): void
+    {
+        $clock = new FixedClock(new DateTimeImmutable('2025-01-01T00:00:00Z'));
+        $handler = $this->createMock(WebhookHandlerInterface::class);
+        $handler->expects(self::never())->method('handle');
+
+        $config = $this->createConfig('test-secret');
+        $processor = new WebhookProcessor(
+            verifier: new HmacWebhookVerifier($clock),
+            eventLog: new InMemoryWebhookEventLog(),
+            handler: $handler,
+            clock: $clock,
+            metricRegistry: new MetricRegistry(),
+            logger: new NullLogger(),
+            config: $config,
+        );
+
+        $controller = new WebhookController($processor, $config);
+
+        $request = new Request(
+            method: Method::POST,
+            uri: '/webhooks/payments',
+            path: '/webhooks/payments',
+            queryString: '',
+            headers: new HeaderBag([]),
+            body: '{}',
+        );
+
+        $response = $controller->handle($request);
+
+        // Empty signature causes verification failure → 403
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+    }
+
+    private function createConfig(string $secret): PaymentsConfig
+    {
+        return new PaymentsConfig(
+            provider: 'null',
+            defaultCurrency: 'USD',
+            webhook: new WebhookConfig(
+                secret: $secret,
+                path: '/webhooks/payments',
+                toleranceSeconds: 300,
+                signatureHeader: 'X-Payments-Signature',
+            ),
+            idempotency: new IdempotencyConfig(
+                ttlSeconds: 86400,
+                store: 'memory',
+                maxKeyLength: 256,
+            ),
+            webhookLog: new WebhookLogConfig(
+                ttlSeconds: 259200,
+                store: 'memory',
+            ),
+        );
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/ChargeTest.php
+++ b/tests/Unit/Extension/Payments/Domain/ChargeTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Charge;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+
+#[CoversClass(Charge::class)]
+final class ChargeTest extends TestCase
+{
+    #[Test]
+    public function constructsWithAllFields(): void
+    {
+        $now = new DateTimeImmutable();
+        $charge = new Charge(
+            id: 'ch_test',
+            intentId: 'pi_test',
+            amount: Money::of(2000, Currency::USD),
+            status: ChargeStatus::Succeeded,
+            provider: 'test',
+            createdAt: $now,
+            failureReason: null,
+            metadata: ['key' => 'value'],
+        );
+
+        self::assertSame('ch_test', $charge->id);
+        self::assertSame('pi_test', $charge->intentId);
+        self::assertSame(2000, $charge->amount->amount);
+        self::assertSame(ChargeStatus::Succeeded, $charge->status);
+        self::assertSame('test', $charge->provider);
+        self::assertSame($now, $charge->createdAt);
+        self::assertNull($charge->failureReason);
+        self::assertSame(['key' => 'value'], $charge->metadata);
+    }
+
+    #[Test]
+    public function constructsWithFailureReason(): void
+    {
+        $charge = new Charge(
+            id: 'ch_fail',
+            intentId: 'pi_test',
+            amount: Money::of(1000, Currency::EUR),
+            status: ChargeStatus::Failed,
+            provider: 'test',
+            createdAt: new DateTimeImmutable(),
+            failureReason: 'insufficient_funds',
+        );
+
+        self::assertSame('insufficient_funds', $charge->failureReason);
+        self::assertSame(ChargeStatus::Failed, $charge->status);
+    }
+
+    #[Test]
+    public function defaultMetadataIsEmpty(): void
+    {
+        $charge = new Charge(
+            id: 'ch_test',
+            intentId: 'pi_test',
+            amount: Money::of(1000, Currency::USD),
+            status: ChargeStatus::Succeeded,
+            provider: 'test',
+            createdAt: new DateTimeImmutable(),
+        );
+
+        self::assertSame([], $charge->metadata);
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/CurrencyTest.php
+++ b/tests/Unit/Extension/Payments/Domain/CurrencyTest.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Currency;
+
+#[CoversClass(Currency::class)]
+final class CurrencyTest extends TestCase
+{
+    #[Test]
+    public function usdHasTwoMinorDigits(): void
+    {
+        self::assertSame(2, Currency::USD->minorDigits());
+    }
+
+    #[Test]
+    public function jpyHasZeroMinorDigits(): void
+    {
+        self::assertSame(0, Currency::JPY->minorDigits());
+    }
+
+    #[Test]
+    public function bhdHasThreeMinorDigits(): void
+    {
+        self::assertSame(3, Currency::BHD->minorDigits());
+    }
+
+    #[Test]
+    public function kwdHasThreeMinorDigits(): void
+    {
+        self::assertSame(3, Currency::KWD->minorDigits());
+    }
+
+    #[Test]
+    public function hufHasZeroMinorDigits(): void
+    {
+        self::assertSame(0, Currency::HUF->minorDigits());
+    }
+
+    #[Test]
+    public function eurHasTwoMinorDigits(): void
+    {
+        self::assertSame(2, Currency::EUR->minorDigits());
+    }
+
+    #[Test]
+    public function usdSymbolIsDollarSign(): void
+    {
+        self::assertSame('$', Currency::USD->symbol());
+    }
+
+    #[Test]
+    public function eurSymbolIsEuro(): void
+    {
+        self::assertSame('€', Currency::EUR->symbol());
+    }
+
+    #[Test]
+    public function gbpSymbolIsPound(): void
+    {
+        self::assertSame('£', Currency::GBP->symbol());
+    }
+
+    #[Test]
+    public function jpySymbolIsYen(): void
+    {
+        self::assertSame('¥', Currency::JPY->symbol());
+    }
+
+    #[Test]
+    public function currencyValueIsIso4217(): void
+    {
+        self::assertSame('USD', Currency::USD->value);
+        self::assertSame('EUR', Currency::EUR->value);
+        self::assertSame('JPY', Currency::JPY->value);
+        self::assertSame('BHD', Currency::BHD->value);
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/CurrencyTest.php
+++ b/tests/Unit/Extension/Payments/Domain/CurrencyTest.php
@@ -73,11 +73,95 @@ final class CurrencyTest extends TestCase
     }
 
     #[Test]
+    public function chfSymbolIsCHF(): void
+    {
+        self::assertSame('CHF', Currency::CHF->symbol());
+    }
+
+    #[Test]
+    public function sekSymbolIsKr(): void
+    {
+        self::assertSame('kr', Currency::SEK->symbol());
+    }
+
+    #[Test]
+    public function nokSymbolIsKr(): void
+    {
+        self::assertSame('kr', Currency::NOK->symbol());
+    }
+
+    #[Test]
+    public function dkkSymbolIsKr(): void
+    {
+        self::assertSame('kr', Currency::DKK->symbol());
+    }
+
+    #[Test]
+    public function brlSymbolIsReal(): void
+    {
+        self::assertSame('R$', Currency::BRL->symbol());
+    }
+
+    #[Test]
+    public function inrSymbolIsRupee(): void
+    {
+        self::assertSame('₹', Currency::INR->symbol());
+    }
+
+    #[Test]
+    public function zarSymbolIsRand(): void
+    {
+        self::assertSame('R', Currency::ZAR->symbol());
+    }
+
+    #[Test]
+    public function plnSymbolIsZloty(): void
+    {
+        self::assertSame('zł', Currency::PLN->symbol());
+    }
+
+    #[Test]
+    public function czkSymbolIsKoruna(): void
+    {
+        self::assertSame('Kč', Currency::CZK->symbol());
+    }
+
+    #[Test]
+    public function hufSymbolIsForint(): void
+    {
+        self::assertSame('Ft', Currency::HUF->symbol());
+    }
+
+    #[Test]
+    public function bhdSymbolIsCurrencyCode(): void
+    {
+        self::assertSame('BHD', Currency::BHD->symbol());
+    }
+
+    #[Test]
+    public function cadSymbolIsDollar(): void
+    {
+        self::assertSame('$', Currency::CAD->symbol());
+    }
+
+    #[Test]
+    public function audSymbolIsDollar(): void
+    {
+        self::assertSame('$', Currency::AUD->symbol());
+    }
+
+    #[Test]
     public function currencyValueIsIso4217(): void
     {
         self::assertSame('USD', Currency::USD->value);
         self::assertSame('EUR', Currency::EUR->value);
         self::assertSame('JPY', Currency::JPY->value);
         self::assertSame('BHD', Currency::BHD->value);
+    }
+
+    #[Test]
+    public function omrHasThreeMinorDigits(): void
+    {
+        self::assertSame(3, Currency::OMR->minorDigits());
     }
 }

--- a/tests/Unit/Extension/Payments/Domain/DisputeTest.php
+++ b/tests/Unit/Extension/Payments/Domain/DisputeTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Dispute;
+use Pulsar\Extension\Payments\Domain\DisputeReason;
+use Pulsar\Extension\Payments\Domain\DisputeStatus;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+
+#[CoversClass(Dispute::class)]
+#[CoversClass(DisputeStatus::class)]
+final class DisputeTest extends TestCase
+{
+    #[Test]
+    public function transitionFromOpenToUnderReview(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::Open);
+
+        $reviewed = $dispute->transitionTo(DisputeStatus::UnderReview);
+
+        self::assertSame(DisputeStatus::UnderReview, $reviewed->status);
+    }
+
+    #[Test]
+    public function transitionFromOpenToAccepted(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::Open);
+
+        $accepted = $dispute->transitionTo(DisputeStatus::Accepted);
+
+        self::assertSame(DisputeStatus::Accepted, $accepted->status);
+    }
+
+    #[Test]
+    public function transitionFromUnderReviewToWon(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::UnderReview);
+
+        $won = $dispute->transitionTo(DisputeStatus::Won);
+
+        self::assertSame(DisputeStatus::Won, $won->status);
+    }
+
+    #[Test]
+    public function transitionFromUnderReviewToLost(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::UnderReview);
+
+        $lost = $dispute->transitionTo(DisputeStatus::Lost);
+
+        self::assertSame(DisputeStatus::Lost, $lost->status);
+    }
+
+    #[Test]
+    public function invalidTransitionThrows(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::Won);
+
+        $this->expectException(PaymentException::class);
+        $this->expectExceptionMessage('Invalid Dispute transition');
+
+        (void) $dispute->transitionTo(DisputeStatus::Open);
+    }
+
+    #[Test]
+    public function transitionReturnsNewInstance(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::Open);
+
+        $reviewed = $dispute->transitionTo(DisputeStatus::UnderReview);
+
+        self::assertNotSame($dispute, $reviewed);
+        self::assertSame(DisputeStatus::Open, $dispute->status);
+    }
+
+    #[Test]
+    public function cannotTransitionFromAccepted(): void
+    {
+        $dispute = $this->createDispute(DisputeStatus::Accepted);
+
+        $this->expectException(PaymentException::class);
+
+        (void) $dispute->transitionTo(DisputeStatus::Won);
+    }
+
+    private function createDispute(DisputeStatus $status): Dispute
+    {
+        return new Dispute(
+            id: 'dp_test',
+            chargeId: 'ch_test',
+            amount: Money::of(1000, Currency::USD),
+            status: $status,
+            reason: DisputeReason::Fraudulent,
+            provider: 'test',
+            createdAt: new DateTimeImmutable(),
+        );
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/IdempotencyRecordTest.php
+++ b/tests/Unit/Extension/Payments/Domain/IdempotencyRecordTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\IdempotencyRecord;
+
+#[CoversClass(IdempotencyRecord::class)]
+final class IdempotencyRecordTest extends TestCase
+{
+    #[Test]
+    public function constructionSetsAllProperties(): void
+    {
+        $createdAt = new DateTimeImmutable('2025-01-01T00:00:00Z');
+        $expiresAt = new DateTimeImmutable('2025-01-02T00:00:00Z');
+
+        $record = new IdempotencyRecord(
+            key: 'key-1',
+            parametersHash: 'abc123',
+            operation: 'createIntent',
+            createdAt: $createdAt,
+            expiresAt: $expiresAt,
+        );
+
+        self::assertSame('key-1', $record->key);
+        self::assertSame('abc123', $record->parametersHash);
+        self::assertSame('createIntent', $record->operation);
+        self::assertSame($createdAt, $record->createdAt);
+        self::assertSame($expiresAt, $record->expiresAt);
+        self::assertNull($record->resultPayload);
+    }
+
+    #[Test]
+    public function constructionWithResultPayload(): void
+    {
+        $record = new IdempotencyRecord(
+            key: 'key-2',
+            parametersHash: 'def456',
+            operation: 'refund',
+            createdAt: new DateTimeImmutable(),
+            expiresAt: new DateTimeImmutable(),
+            resultPayload: '{"id":"pi_123"}',
+        );
+
+        self::assertSame('{"id":"pi_123"}', $record->resultPayload);
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/MoneyTest.php
+++ b/tests/Unit/Extension/Payments/Domain/MoneyTest.php
@@ -1,0 +1,301 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\RoundingMode;
+use Pulsar\Extension\Payments\Exception\MoneyException;
+
+#[CoversClass(Money::class)]
+final class MoneyTest extends TestCase
+{
+    #[Test]
+    public function ofCreatesMoneyWithPositiveAmount(): void
+    {
+        $money = Money::of(1050, Currency::USD);
+
+        self::assertSame(1050, $money->amount);
+        self::assertSame(Currency::USD, $money->currency);
+    }
+
+    #[Test]
+    public function ofAcceptsZero(): void
+    {
+        $money = Money::of(0, Currency::EUR);
+
+        self::assertSame(0, $money->amount);
+    }
+
+    #[Test]
+    public function ofRejectsNegativeAmount(): void
+    {
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('non-negative');
+
+        (void) Money::of(-1, Currency::USD);
+    }
+
+    #[Test]
+    public function zeroCreatesZeroMoney(): void
+    {
+        $money = Money::zero(Currency::GBP);
+
+        self::assertSame(0, $money->amount);
+        self::assertSame(Currency::GBP, $money->currency);
+        self::assertTrue($money->isZero());
+    }
+
+    #[Test]
+    public function addSameCurrency(): void
+    {
+        $a = Money::of(100, Currency::USD);
+        $b = Money::of(250, Currency::USD);
+
+        $result = $a->add($b);
+
+        self::assertSame(350, $result->amount);
+        self::assertSame(Currency::USD, $result->currency);
+    }
+
+    #[Test]
+    public function addRejectsCrossCurrency(): void
+    {
+        $a = Money::of(100, Currency::USD);
+        $b = Money::of(100, Currency::EUR);
+
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('Currency mismatch');
+
+        (void) $a->add($b);
+    }
+
+    #[Test]
+    public function subtractSameCurrency(): void
+    {
+        $a = Money::of(500, Currency::USD);
+        $b = Money::of(200, Currency::USD);
+
+        $result = $a->subtract($b);
+
+        self::assertSame(300, $result->amount);
+    }
+
+    #[Test]
+    public function subtractRejectsCrossCurrency(): void
+    {
+        $a = Money::of(100, Currency::USD);
+        $b = Money::of(50, Currency::GBP);
+
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('Currency mismatch');
+
+        (void) $a->subtract($b);
+    }
+
+    #[Test]
+    public function subtractRejectsNegativeResult(): void
+    {
+        $a = Money::of(100, Currency::USD);
+        $b = Money::of(200, Currency::USD);
+
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('non-negative');
+
+        (void) $a->subtract($b);
+    }
+
+    #[Test]
+    public function multiplyByPositiveFactor(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $result = $money->multiply(3);
+
+        self::assertSame(300, $result->amount);
+    }
+
+    #[Test]
+    public function multiplyByZero(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $result = $money->multiply(0);
+
+        self::assertSame(0, $result->amount);
+    }
+
+    #[Test]
+    public function multiplyRejectsNegativeFactor(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('non-negative');
+
+        (void) $money->multiply(-1);
+    }
+
+    #[Test]
+    public function percentageWithHalfUp(): void
+    {
+        $money = Money::of(10000, Currency::USD);
+
+        // 25% = 2500 basis points
+        $result = $money->percentage(2500, RoundingMode::HalfUp);
+
+        self::assertSame(2500, $result->amount);
+    }
+
+    #[Test]
+    public function percentageWithRounding(): void
+    {
+        $money = Money::of(333, Currency::USD);
+
+        // 50% of 333 = 166.5 → rounds to 167 with HalfUp
+        $result = $money->percentage(5000, RoundingMode::HalfUp);
+        self::assertSame(167, $result->amount);
+
+        // Floor rounds down
+        $resultFloor = $money->percentage(5000, RoundingMode::Floor);
+        self::assertSame(166, $resultFloor->amount);
+    }
+
+    #[Test]
+    public function percentageRejectsNegativeBasisPoints(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('non-negative');
+
+        (void) $money->percentage(-100);
+    }
+
+    #[Test]
+    public function allocateDistributesEvenly(): void
+    {
+        $money = Money::of(300, Currency::USD);
+
+        $parts = $money->allocate(3);
+
+        self::assertCount(3, $parts);
+        self::assertSame(100, $parts[0]->amount);
+        self::assertSame(100, $parts[1]->amount);
+        self::assertSame(100, $parts[2]->amount);
+    }
+
+    #[Test]
+    public function allocateDistributesRemainderOneUnitAtATime(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $parts = $money->allocate(3);
+
+        self::assertCount(3, $parts);
+        self::assertSame(34, $parts[0]->amount);
+        self::assertSame(33, $parts[1]->amount);
+        self::assertSame(33, $parts[2]->amount);
+
+        // Sum should equal original
+        $sum = $parts[0]->amount + $parts[1]->amount + $parts[2]->amount;
+        self::assertSame(100, $sum);
+    }
+
+    #[Test]
+    public function allocateRejectsZeroParts(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $this->expectException(MoneyException::class);
+        $this->expectExceptionMessage('positive');
+
+        (void) $money->allocate(0);
+    }
+
+    #[Test]
+    public function allocateRejectsNegativeParts(): void
+    {
+        $money = Money::of(100, Currency::USD);
+
+        $this->expectException(MoneyException::class);
+
+        (void) $money->allocate(-1);
+    }
+
+    #[Test]
+    public function formatTwoDecimalCurrency(): void
+    {
+        $money = Money::of(1050, Currency::USD);
+
+        self::assertSame('10.50', $money->format());
+    }
+
+    #[Test]
+    public function formatZeroDecimalCurrency(): void
+    {
+        // JPY has 0 minor digits
+        $money = Money::of(1000, Currency::JPY);
+
+        self::assertSame('1000', $money->format());
+    }
+
+    #[Test]
+    public function formatThreeDecimalCurrency(): void
+    {
+        // BHD has 3 minor digits
+        $money = Money::of(1500, Currency::BHD);
+
+        self::assertSame('1.500', $money->format());
+    }
+
+    #[Test]
+    public function formatSmallAmount(): void
+    {
+        $money = Money::of(5, Currency::USD);
+
+        self::assertSame('0.05', $money->format());
+    }
+
+    #[Test]
+    public function isZeroReturnsTrueForZero(): void
+    {
+        self::assertTrue(Money::of(0, Currency::USD)->isZero());
+    }
+
+    #[Test]
+    public function isZeroReturnsFalseForNonZero(): void
+    {
+        self::assertFalse(Money::of(1, Currency::USD)->isZero());
+    }
+
+    #[Test]
+    public function equalsComparesAmountAndCurrency(): void
+    {
+        $a = Money::of(100, Currency::USD);
+        $b = Money::of(100, Currency::USD);
+        $c = Money::of(200, Currency::USD);
+        $d = Money::of(100, Currency::EUR);
+
+        self::assertTrue($a->equals($b));
+        self::assertFalse($a->equals($c));
+        self::assertFalse($a->equals($d));
+    }
+
+    #[Test]
+    public function addReturnsNewInstance(): void
+    {
+        $a = Money::of(100, Currency::USD);
+        $b = Money::of(50, Currency::USD);
+
+        $result = $a->add($b);
+
+        self::assertNotSame($a, $result);
+        self::assertSame(100, $a->amount);
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/PaymentIntentTest.php
+++ b/tests/Unit/Extension/Payments/Domain/PaymentIntentTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntent;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+
+#[CoversClass(PaymentIntent::class)]
+#[CoversClass(PaymentIntentStatus::class)]
+final class PaymentIntentTest extends TestCase
+{
+    #[Test]
+    public function transitionFromCreatedToCaptured(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Created);
+
+        $captured = $intent->transitionTo(PaymentIntentStatus::Captured);
+
+        self::assertSame(PaymentIntentStatus::Captured, $captured->status);
+        self::assertSame($intent->id, $captured->id);
+    }
+
+    #[Test]
+    public function transitionFromCreatedToCancelled(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Created);
+
+        $cancelled = $intent->transitionTo(PaymentIntentStatus::Cancelled);
+
+        self::assertSame(PaymentIntentStatus::Cancelled, $cancelled->status);
+    }
+
+    #[Test]
+    public function transitionFromCapturedToDisputed(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Captured);
+
+        $disputed = $intent->transitionTo(PaymentIntentStatus::Disputed);
+
+        self::assertSame(PaymentIntentStatus::Disputed, $disputed->status);
+    }
+
+    #[Test]
+    public function transitionFromDisputedToResolved(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Disputed);
+
+        $resolved = $intent->transitionTo(PaymentIntentStatus::Resolved);
+
+        self::assertSame(PaymentIntentStatus::Resolved, $resolved->status);
+    }
+
+    #[Test]
+    public function invalidTransitionThrows(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Cancelled);
+
+        $this->expectException(PaymentException::class);
+        $this->expectExceptionMessage('Invalid PaymentIntent transition');
+
+        (void) $intent->transitionTo(PaymentIntentStatus::Captured);
+    }
+
+    #[Test]
+    public function transitionReturnsNewInstance(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Created);
+
+        $captured = $intent->transitionTo(PaymentIntentStatus::Captured);
+
+        self::assertNotSame($intent, $captured);
+        self::assertSame(PaymentIntentStatus::Created, $intent->status);
+    }
+
+    #[Test]
+    public function cannotTransitionFromResolvedToAnything(): void
+    {
+        $intent = $this->createIntent(PaymentIntentStatus::Resolved);
+
+        $this->expectException(PaymentException::class);
+
+        (void) $intent->transitionTo(PaymentIntentStatus::Created);
+    }
+
+    #[Test]
+    public function metadataIsPreserved(): void
+    {
+        $intent = new PaymentIntent(
+            id: 'pi_test',
+            amount: Money::of(1000, Currency::USD),
+            status: PaymentIntentStatus::Created,
+            provider: 'test',
+            idempotencyKey: 'key-1',
+            createdAt: new DateTimeImmutable(),
+            metadata: ['order_id' => '12345'],
+        );
+
+        self::assertSame(['order_id' => '12345'], $intent->metadata);
+    }
+
+    private function createIntent(PaymentIntentStatus $status): PaymentIntent
+    {
+        return new PaymentIntent(
+            id: 'pi_test',
+            amount: Money::of(1000, Currency::USD),
+            status: $status,
+            provider: 'test',
+            idempotencyKey: 'key-1',
+            createdAt: new DateTimeImmutable(),
+        );
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/RefundTest.php
+++ b/tests/Unit/Extension/Payments/Domain/RefundTest.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\Refund;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
+
+#[CoversClass(Refund::class)]
+final class RefundTest extends TestCase
+{
+    #[Test]
+    public function constructsWithAllFields(): void
+    {
+        $now = new DateTimeImmutable();
+        $refund = new Refund(
+            id: 'rf_test',
+            chargeId: 'ch_test',
+            amount: Money::of(500, Currency::USD),
+            status: RefundStatus::Succeeded,
+            provider: 'test',
+            createdAt: $now,
+            failureReason: null,
+            metadata: ['reason' => 'customer_request'],
+        );
+
+        self::assertSame('rf_test', $refund->id);
+        self::assertSame('ch_test', $refund->chargeId);
+        self::assertSame(500, $refund->amount->amount);
+        self::assertSame(RefundStatus::Succeeded, $refund->status);
+        self::assertSame('test', $refund->provider);
+        self::assertSame($now, $refund->createdAt);
+        self::assertNull($refund->failureReason);
+        self::assertSame(['reason' => 'customer_request'], $refund->metadata);
+    }
+
+    #[Test]
+    public function constructsWithFailureReason(): void
+    {
+        $refund = new Refund(
+            id: 'rf_fail',
+            chargeId: 'ch_test',
+            amount: Money::of(1000, Currency::EUR),
+            status: RefundStatus::Failed,
+            provider: 'test',
+            createdAt: new DateTimeImmutable(),
+            failureReason: 'insufficient_balance',
+        );
+
+        self::assertSame('insufficient_balance', $refund->failureReason);
+        self::assertSame(RefundStatus::Failed, $refund->status);
+    }
+}

--- a/tests/Unit/Extension/Payments/Domain/WebhookEventTest.php
+++ b/tests/Unit/Extension/Payments/Domain/WebhookEventTest.php
@@ -1,0 +1,47 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\WebhookEvent;
+use Pulsar\Extension\Payments\Domain\WebhookEventType;
+
+#[CoversClass(WebhookEvent::class)]
+final class WebhookEventTest extends TestCase
+{
+    #[Test]
+    public function fromArrayBuildsEvent(): void
+    {
+        $payload = [
+            'id' => 'evt_123',
+            'type' => 'payment_intent.created',
+            'created_at' => 1700000000,
+            'data' => ['intent_id' => 'pi_test'],
+        ];
+
+        $event = WebhookEvent::fromArray($payload);
+
+        self::assertSame('evt_123', $event->id);
+        self::assertSame(WebhookEventType::PaymentIntentCreated, $event->type);
+        self::assertSame(1700000000, $event->createdAt->getTimestamp());
+        self::assertSame(['intent_id' => 'pi_test'], $event->data);
+    }
+
+    #[Test]
+    public function fromArrayWithDefaultData(): void
+    {
+        $payload = [
+            'id' => 'evt_456',
+            'type' => 'charge.failed',
+            'created_at' => 1700000000,
+        ];
+
+        $event = WebhookEvent::fromArray($payload);
+
+        self::assertSame([], $event->data);
+    }
+}

--- a/tests/Unit/Extension/Payments/Exception/PaymentExceptionTest.php
+++ b/tests/Unit/Extension/Payments/Exception/PaymentExceptionTest.php
@@ -7,11 +7,13 @@ namespace Pulsar\Tests\Unit\Extension\Payments\Exception;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Domain\Currency;
 use Pulsar\Extension\Payments\Exception\IdempotencyException;
 use Pulsar\Extension\Payments\Exception\MoneyException;
 use Pulsar\Extension\Payments\Exception\PaymentException;
 use Pulsar\Extension\Payments\Exception\PaymentProviderException;
 use Pulsar\Extension\Payments\Exception\WebhookException;
+use RuntimeException;
 
 #[CoversClass(PaymentException::class)]
 #[CoversClass(PaymentProviderException::class)]
@@ -125,8 +127,8 @@ final class PaymentExceptionTest extends TestCase
     public function moneyExceptionCurrencyMismatch(): void
     {
         $e = MoneyException::currencyMismatch(
-            \Pulsar\Extension\Payments\Domain\Currency::USD,
-            \Pulsar\Extension\Payments\Domain\Currency::EUR,
+            Currency::USD,
+            Currency::EUR,
         );
 
         self::assertStringContainsString('USD', $e->getMessage());
@@ -139,5 +141,76 @@ final class PaymentExceptionTest extends TestCase
         $e = MoneyException::negativeAmount(-5);
 
         self::assertStringContainsString('-5', $e->getMessage());
+    }
+
+    #[Test]
+    public function moneyExceptionInvalidParts(): void
+    {
+        $e = MoneyException::invalidParts(0);
+
+        self::assertStringContainsString('0', $e->getMessage());
+        self::assertStringContainsString('positive', $e->getMessage());
+    }
+
+    #[Test]
+    public function moneyExceptionNegativeMultiplier(): void
+    {
+        $e = MoneyException::negativeMultiplier(-2);
+
+        self::assertStringContainsString('-2', $e->getMessage());
+    }
+
+    #[Test]
+    public function moneyExceptionInvalidBasisPoints(): void
+    {
+        $e = MoneyException::invalidBasisPoints(-100);
+
+        self::assertStringContainsString('-100', $e->getMessage());
+    }
+
+    #[Test]
+    public function paymentProviderExceptionProviderError(): void
+    {
+        $previous = new RuntimeException('original');
+        $e = PaymentProviderException::providerError('something broke', $previous);
+
+        self::assertSame('provider_error', $e->errorType);
+        self::assertStringContainsString('something broke', $e->getMessage());
+        self::assertSame($previous, $e->getPrevious());
+    }
+
+    #[Test]
+    public function paymentProviderExceptionRefundFailed(): void
+    {
+        $e = PaymentProviderException::refundFailed('card_not_found');
+
+        self::assertSame('refund_failed', $e->errorType);
+        self::assertStringContainsString('card_not_found', $e->getMessage());
+    }
+
+    #[Test]
+    public function idempotencyExceptionCommitFailed(): void
+    {
+        $e = IdempotencyException::commitFailed('key-x');
+
+        self::assertStringContainsString('key-x', $e->getMessage());
+        self::assertStringContainsString('commit', strtolower($e->getMessage()));
+    }
+
+    #[Test]
+    public function webhookExceptionHandlerFailed(): void
+    {
+        $e = WebhookException::handlerFailed('evt_42', 'db timeout');
+
+        self::assertStringContainsString('evt_42', $e->getMessage());
+        self::assertStringContainsString('db timeout', $e->getMessage());
+    }
+
+    #[Test]
+    public function webhookExceptionMalformedHeader(): void
+    {
+        $e = WebhookException::malformedHeader('missing t= field');
+
+        self::assertStringContainsString('missing t= field', $e->getMessage());
     }
 }

--- a/tests/Unit/Extension/Payments/Exception/PaymentExceptionTest.php
+++ b/tests/Unit/Extension/Payments/Exception/PaymentExceptionTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Exception\IdempotencyException;
+use Pulsar\Extension\Payments\Exception\MoneyException;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+use Pulsar\Extension\Payments\Exception\PaymentProviderException;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+
+#[CoversClass(PaymentException::class)]
+#[CoversClass(PaymentProviderException::class)]
+#[CoversClass(IdempotencyException::class)]
+#[CoversClass(WebhookException::class)]
+#[CoversClass(MoneyException::class)]
+final class PaymentExceptionTest extends TestCase
+{
+    #[Test]
+    public function paymentExceptionInvalidTransition(): void
+    {
+        $e = PaymentException::invalidTransition('PaymentIntent', 'cancelled', 'captured');
+
+        self::assertStringContainsString('Invalid PaymentIntent transition', $e->getMessage());
+        self::assertStringContainsString('cancelled', $e->getMessage());
+        self::assertStringContainsString('captured', $e->getMessage());
+    }
+
+    #[Test]
+    public function paymentExceptionNotFound(): void
+    {
+        $e = PaymentException::notFound('Charge', 'ch_123');
+
+        self::assertStringContainsString('not found', $e->getMessage());
+        self::assertStringContainsString('ch_123', $e->getMessage());
+    }
+
+    #[Test]
+    public function paymentProviderExceptionDeclined(): void
+    {
+        $e = PaymentProviderException::declined('insufficient_funds');
+
+        self::assertStringContainsString('insufficient_funds', $e->getMessage());
+        self::assertSame('declined', $e->errorType);
+    }
+
+    #[Test]
+    public function paymentProviderExceptionTimeout(): void
+    {
+        $e = PaymentProviderException::timeout();
+
+        self::assertSame('timeout', $e->errorType);
+    }
+
+    #[Test]
+    public function paymentProviderExceptionNetworkError(): void
+    {
+        $e = PaymentProviderException::networkError();
+
+        self::assertSame('network_error', $e->errorType);
+    }
+
+    #[Test]
+    public function paymentProviderExceptionRateLimited(): void
+    {
+        $e = PaymentProviderException::rateLimited();
+
+        self::assertSame('rate_limited', $e->errorType);
+    }
+
+    #[Test]
+    public function idempotencyExceptionParameterMismatch(): void
+    {
+        $e = IdempotencyException::parameterMismatch('key-1');
+
+        self::assertStringContainsString('different parameters', $e->getMessage());
+    }
+
+    #[Test]
+    public function idempotencyExceptionConcurrentClaim(): void
+    {
+        $e = IdempotencyException::concurrentClaim('key-2');
+
+        self::assertStringContainsString('currently being processed', $e->getMessage());
+    }
+
+    #[Test]
+    public function idempotencyExceptionInvalidKey(): void
+    {
+        $e = IdempotencyException::invalidKey('too long');
+
+        self::assertStringContainsString('too long', $e->getMessage());
+    }
+
+    #[Test]
+    public function webhookExceptionInvalidSignature(): void
+    {
+        $e = WebhookException::invalidSignature();
+
+        self::assertStringContainsString('signature', $e->getMessage());
+    }
+
+    #[Test]
+    public function webhookExceptionExpiredTimestamp(): void
+    {
+        $e = WebhookException::expiredTimestamp(600, 300);
+
+        self::assertStringContainsString('600', $e->getMessage());
+        self::assertStringContainsString('300', $e->getMessage());
+    }
+
+    #[Test]
+    public function webhookExceptionConcurrentClaim(): void
+    {
+        $e = WebhookException::concurrentClaim('evt_1');
+
+        self::assertStringContainsString('currently being processed', $e->getMessage());
+    }
+
+    #[Test]
+    public function moneyExceptionCurrencyMismatch(): void
+    {
+        $e = MoneyException::currencyMismatch(
+            \Pulsar\Extension\Payments\Domain\Currency::USD,
+            \Pulsar\Extension\Payments\Domain\Currency::EUR,
+        );
+
+        self::assertStringContainsString('USD', $e->getMessage());
+        self::assertStringContainsString('EUR', $e->getMessage());
+    }
+
+    #[Test]
+    public function moneyExceptionNegativeAmount(): void
+    {
+        $e = MoneyException::negativeAmount(-5);
+
+        self::assertStringContainsString('-5', $e->getMessage());
+    }
+}

--- a/tests/Unit/Extension/Payments/Gateway/ParametersHasherTest.php
+++ b/tests/Unit/Extension/Payments/Gateway/ParametersHasherTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Gateway;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Gateway\ParametersHasher;
+
+use function strlen;
+
+#[CoversClass(ParametersHasher::class)]
+final class ParametersHasherTest extends TestCase
+{
+    #[Test]
+    public function identicalParametersProduceSameHash(): void
+    {
+        $hash1 = ParametersHasher::hash('createIntent', [
+            'amount_minor' => 5000,
+            'currency' => 'USD',
+            'provider' => 'test',
+        ]);
+
+        $hash2 = ParametersHasher::hash('createIntent', [
+            'amount_minor' => 5000,
+            'currency' => 'USD',
+            'provider' => 'test',
+        ]);
+
+        self::assertSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function differentArrayOrderProducesSameHash(): void
+    {
+        $hash1 = ParametersHasher::hash('createIntent', [
+            'currency' => 'USD',
+            'amount_minor' => 5000,
+            'provider' => 'test',
+        ]);
+
+        $hash2 = ParametersHasher::hash('createIntent', [
+            'provider' => 'test',
+            'amount_minor' => 5000,
+            'currency' => 'USD',
+        ]);
+
+        self::assertSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function differentParametersProduceDifferentHash(): void
+    {
+        $hash1 = ParametersHasher::hash('createIntent', [
+            'amount_minor' => 5000,
+            'currency' => 'USD',
+            'provider' => 'test',
+        ]);
+
+        $hash2 = ParametersHasher::hash('createIntent', [
+            'amount_minor' => 6000,
+            'currency' => 'USD',
+            'provider' => 'test',
+        ]);
+
+        self::assertNotSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function differentOperationProducesDifferentHash(): void
+    {
+        $params = [
+            'intentId' => 'pi_test',
+            'provider' => 'test',
+        ];
+
+        $hash1 = ParametersHasher::hash('captureIntent', $params);
+        $hash2 = ParametersHasher::hash('cancelIntent', $params);
+
+        self::assertNotSame($hash1, $hash2);
+    }
+
+    #[Test]
+    public function hashIsSha256Length(): void
+    {
+        $hash = ParametersHasher::hash('test', ['key' => 'value']);
+
+        self::assertSame(64, strlen($hash));
+    }
+
+    #[Test]
+    public function nestedArraysSortedRecursively(): void
+    {
+        $hash1 = ParametersHasher::hash('test', [
+            'outer' => ['b' => 2, 'a' => 1],
+        ]);
+
+        $hash2 = ParametersHasher::hash('test', [
+            'outer' => ['a' => 1, 'b' => 2],
+        ]);
+
+        self::assertSame($hash1, $hash2);
+    }
+}

--- a/tests/Unit/Extension/Payments/Gateway/PaymentGatewayTest.php
+++ b/tests/Unit/Extension/Payments/Gateway/PaymentGatewayTest.php
@@ -14,9 +14,12 @@ use Pulsar\Extension\Payments\Config\IdempotencyConfig;
 use Pulsar\Extension\Payments\Config\PaymentsConfig;
 use Pulsar\Extension\Payments\Config\WebhookConfig;
 use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
 use Pulsar\Extension\Payments\Domain\Currency;
 use Pulsar\Extension\Payments\Domain\Money;
 use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
 use Pulsar\Extension\Payments\Exception\IdempotencyException;
 use Pulsar\Extension\Payments\Exception\PaymentProviderException;
 use Pulsar\Extension\Payments\Gateway\PaymentGateway;
@@ -25,8 +28,10 @@ use Pulsar\Extension\Payments\Provider\NullProvider;
 use Pulsar\Extension\Payments\Provider\SimulatorProvider;
 use Pulsar\Observability\Metrics\LabelSet;
 use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Security\Audit\AuditEntry;
 use Pulsar\Security\Audit\AuditLogger;
 use Pulsar\Security\Audit\AuditSinkInterface;
+use Throwable;
 
 #[CoversClass(PaymentGateway::class)]
 final class PaymentGatewayTest extends TestCase
@@ -221,6 +226,205 @@ final class PaymentGatewayTest extends TestCase
         self::assertSame($intent->id, $retrieved->id);
     }
 
+    #[Test]
+    public function captureIntentIdempotencyReplay(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-cap-replay-1');
+        $firstCharge = $gateway->captureIntent($intent->id, 'idem-cap-replay-2');
+        $secondCharge = $gateway->captureIntent($intent->id, 'idem-cap-replay-2');
+
+        self::assertSame($firstCharge->id, $secondCharge->id);
+        self::assertSame(ChargeStatus::Succeeded, $secondCharge->status);
+    }
+
+    #[Test]
+    public function cancelIntentIdempotencyReplay(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-cancel-replay-1');
+        $firstCancel = $gateway->cancelIntent($intent->id, 'idem-cancel-replay-2');
+        $secondCancel = $gateway->cancelIntent($intent->id, 'idem-cancel-replay-2');
+
+        self::assertSame($firstCancel->id, $secondCancel->id);
+        self::assertSame(PaymentIntentStatus::Cancelled, $secondCancel->status);
+    }
+
+    #[Test]
+    public function refundIdempotencyReplay(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-ref-replay-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-ref-replay-2');
+        $firstRefund = $gateway->refund($charge->id, null, 'idem-ref-replay-3');
+        $secondRefund = $gateway->refund($charge->id, null, 'idem-ref-replay-3');
+
+        self::assertSame($firstRefund->id, $secondRefund->id);
+        self::assertSame(RefundStatus::Succeeded, $secondRefund->status);
+    }
+
+    #[Test]
+    public function captureIntentMismatchThrows(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent1 = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-cap-mis-1');
+        $intent2 = $gateway->createIntent(Money::of(3000, Currency::USD), 'idem-cap-mis-2');
+        $gateway->captureIntent($intent1->id, 'idem-cap-mis-shared');
+
+        $this->expectException(IdempotencyException::class);
+        $gateway->captureIntent($intent2->id, 'idem-cap-mis-shared');
+    }
+
+    #[Test]
+    public function refundMismatchThrows(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(5000, Currency::USD), 'idem-ref-mis-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-ref-mis-2');
+        $gateway->refund($charge->id, null, 'idem-ref-mis-shared');
+
+        $this->expectException(IdempotencyException::class);
+        $gateway->refund($charge->id, Money::of(1000, Currency::USD), 'idem-ref-mis-shared');
+    }
+
+    #[Test]
+    public function captureIntentMetricsIncrement(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-cap-met-1');
+        $gateway->captureIntent($intent->id, 'idem-cap-met-2');
+
+        $counter = $this->metricRegistry->counter('payments_captures_total');
+        self::assertSame(1.0, $counter->value(new LabelSet([
+            'provider' => 'simulator',
+            'currency' => 'USD',
+            'status' => 'succeeded',
+        ])));
+    }
+
+    #[Test]
+    public function refundMetricsIncrement(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-ref-met-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-ref-met-2');
+        $gateway->refund($charge->id, null, 'idem-ref-met-3');
+
+        $counter = $this->metricRegistry->counter('payments_refunds_total');
+        self::assertSame(1.0, $counter->value(new LabelSet([
+            'provider' => 'simulator',
+            'currency' => 'USD',
+            'status' => 'succeeded',
+        ])));
+    }
+
+    #[Test]
+    public function getChargeDelegatesToProvider(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-gc-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-gc-2');
+        $retrieved = $gateway->getCharge($charge->id);
+
+        self::assertSame($charge->id, $retrieved->id);
+    }
+
+    #[Test]
+    public function getRefundDelegatesToProvider(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-gr-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-gr-2');
+        $refund = $gateway->refund($charge->id, null, 'idem-gr-3');
+        $retrieved = $gateway->getRefund($refund->id);
+
+        self::assertSame($refund->id, $retrieved->id);
+    }
+
+    #[Test]
+    public function captureProviderErrorReleasesClaimAndIncrementsMetric(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        // Try to capture a nonexistent intent — provider error propagates
+        try {
+            $gateway->captureIntent('nonexistent', 'idem-cap-err');
+        } catch (Throwable) {
+            // Expected — provider throws on nonexistent intent
+        }
+
+        $errorCounter = $this->metricRegistry->counter('payments_provider_errors_total');
+        self::assertSame(1.0, $errorCounter->value(new LabelSet([
+            'provider' => 'simulator',
+            'operation' => 'captureIntent',
+            'error_type' => 'unknown',
+        ])));
+    }
+
+    #[Test]
+    public function refundProviderErrorReleasesClaimAndIncrementsMetric(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        // 3030 triggers refund failure
+        $intent = $gateway->createIntent(Money::of(3030, Currency::USD), 'idem-ref-err-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-ref-err-2');
+
+        try {
+            $gateway->refund($charge->id, null, 'idem-ref-err-3');
+        } catch (PaymentProviderException) {
+            // Expected
+        }
+
+        $errorCounter = $this->metricRegistry->counter('payments_provider_errors_total');
+        self::assertSame(1.0, $errorCounter->value(new LabelSet([
+            'provider' => 'simulator',
+            'operation' => 'refund',
+            'error_type' => 'refund_failed',
+        ])));
+    }
+
+    #[Test]
+    public function cancelProviderErrorReleasesClaimAndIncrementsMetric(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        // Try to cancel a nonexistent intent — provider error propagates
+        try {
+            $gateway->cancelIntent('nonexistent', 'idem-can-err');
+        } catch (Throwable) {
+            // Expected — provider throws on nonexistent intent
+        }
+
+        $errorCounter = $this->metricRegistry->counter('payments_provider_errors_total');
+        self::assertSame(1.0, $errorCounter->value(new LabelSet([
+            'provider' => 'simulator',
+            'operation' => 'cancelIntent',
+            'error_type' => 'unknown',
+        ])));
+    }
+
     private function createGateway(): PaymentGateway
     {
         $provider = new NullProvider($this->clock);
@@ -228,13 +432,13 @@ final class PaymentGatewayTest extends TestCase
         return $this->createGatewayWith($provider);
     }
 
-    private function createGatewayWith(\Pulsar\Extension\Payments\Contract\PaymentProviderInterface $provider): PaymentGateway
+    private function createGatewayWith(PaymentProviderInterface $provider): PaymentGateway
     {
         $sink = new class implements AuditSinkInterface {
-            /** @var list<\Pulsar\Security\Audit\AuditEntry> */
+            /** @var list<AuditEntry> */
             public array $entries = [];
 
-            public function write(\Pulsar\Security\Audit\AuditEntry $entry): void
+            public function write(AuditEntry $entry): void
             {
                 $this->entries[] = $entry;
             }

--- a/tests/Unit/Extension/Payments/Gateway/PaymentGatewayTest.php
+++ b/tests/Unit/Extension/Payments/Gateway/PaymentGatewayTest.php
@@ -1,0 +1,278 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Gateway;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Config\IdempotencyConfig;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Config\WebhookConfig;
+use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+use Pulsar\Extension\Payments\Exception\IdempotencyException;
+use Pulsar\Extension\Payments\Exception\PaymentProviderException;
+use Pulsar\Extension\Payments\Gateway\PaymentGateway;
+use Pulsar\Extension\Payments\Idempotency\InMemoryIdempotencyStore;
+use Pulsar\Extension\Payments\Provider\NullProvider;
+use Pulsar\Extension\Payments\Provider\SimulatorProvider;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Security\Audit\AuditLogger;
+use Pulsar\Security\Audit\AuditSinkInterface;
+
+#[CoversClass(PaymentGateway::class)]
+final class PaymentGatewayTest extends TestCase
+{
+    private FixedClock $clock;
+    private MetricRegistry $metricRegistry;
+    private InMemoryIdempotencyStore $idempotencyStore;
+
+    protected function setUp(): void
+    {
+        $this->clock = new FixedClock(new DateTimeImmutable('2025-01-01T00:00:00Z'));
+        $this->metricRegistry = new MetricRegistry();
+        $this->idempotencyStore = new InMemoryIdempotencyStore();
+    }
+
+    #[Test]
+    public function createIntentSucceeds(): void
+    {
+        $gateway = $this->createGateway();
+        $amount = Money::of(5000, Currency::USD);
+
+        $intent = $gateway->createIntent($amount, 'idem-key-1');
+
+        self::assertSame(PaymentIntentStatus::Created, $intent->status);
+        self::assertNotEmpty($intent->id);
+    }
+
+    #[Test]
+    public function createIntentIdempotencyReplay(): void
+    {
+        $gateway = $this->createGateway();
+        $amount = Money::of(5000, Currency::USD);
+
+        $first = $gateway->createIntent($amount, 'idem-key-replay');
+        $second = $gateway->createIntent($amount, 'idem-key-replay');
+
+        self::assertSame($first->id, $second->id);
+
+        // Check replay metric
+        $replayCounter = $this->metricRegistry->counter('payments_idempotency_replays_total');
+        self::assertSame(1.0, $replayCounter->value(new LabelSet([
+            'provider' => 'null',
+            'operation' => 'createIntent',
+        ])));
+    }
+
+    #[Test]
+    public function createIntentIdempotencyMismatch(): void
+    {
+        $gateway = $this->createGateway();
+
+        $gateway->createIntent(Money::of(5000, Currency::USD), 'idem-key-mismatch');
+
+        $this->expectException(IdempotencyException::class);
+        $this->expectExceptionMessage('different parameters');
+
+        // Same key, different amount
+        $gateway->createIntent(Money::of(6000, Currency::USD), 'idem-key-mismatch');
+    }
+
+    #[Test]
+    public function invalidIdempotencyKeyEmptyThrows(): void
+    {
+        $gateway = $this->createGateway();
+
+        $this->expectException(IdempotencyException::class);
+        $this->expectExceptionMessage('Invalid idempotency key');
+
+        $gateway->createIntent(Money::of(1000, Currency::USD), '');
+    }
+
+    #[Test]
+    public function invalidIdempotencyKeyWithWhitespaceThrows(): void
+    {
+        $gateway = $this->createGateway();
+
+        $this->expectException(IdempotencyException::class);
+        $this->expectExceptionMessage('invalid characters');
+
+        $gateway->createIntent(Money::of(1000, Currency::USD), 'key with spaces');
+    }
+
+    #[Test]
+    public function invalidIdempotencyKeyTooLongThrows(): void
+    {
+        $gateway = $this->createGateway();
+
+        $this->expectException(IdempotencyException::class);
+
+        $gateway->createIntent(Money::of(1000, Currency::USD), str_repeat('a', 257));
+    }
+
+    #[Test]
+    public function providerErrorReleasesIdempotencyClaim(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        // 9994 triggers timeout
+        try {
+            $gateway->createIntent(Money::of(9994, Currency::USD), 'idem-key-error');
+        } catch (PaymentProviderException) {
+            // Expected
+        }
+
+        // Key should be released — can retry
+        $intent = $gateway->createIntent(Money::of(5000, Currency::USD), 'idem-key-error');
+
+        self::assertSame(PaymentIntentStatus::Created, $intent->status);
+    }
+
+    #[Test]
+    public function metricsIncrementOnSuccess(): void
+    {
+        $gateway = $this->createGateway();
+        $gateway->createIntent(Money::of(1000, Currency::USD), 'idem-metric');
+
+        $counter = $this->metricRegistry->counter('payments_intents_total');
+        self::assertSame(1.0, $counter->value(new LabelSet([
+            'provider' => 'null',
+            'currency' => 'USD',
+            'status' => 'created',
+        ])));
+    }
+
+    #[Test]
+    public function metricsIncrementOnProviderError(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        try {
+            $gateway->createIntent(Money::of(9994, Currency::USD), 'idem-error-metric');
+        } catch (PaymentProviderException) {
+            // Expected
+        }
+
+        $errorCounter = $this->metricRegistry->counter('payments_provider_errors_total');
+        self::assertSame(1.0, $errorCounter->value(new LabelSet([
+            'provider' => 'simulator',
+            'operation' => 'createIntent',
+            'error_type' => 'timeout',
+        ])));
+    }
+
+    #[Test]
+    public function captureIntentSucceeds(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-cap-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-cap-2');
+
+        self::assertSame($intent->id, $charge->intentId);
+    }
+
+    #[Test]
+    public function refundSucceeds(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-ref-1');
+        $charge = $gateway->captureIntent($intent->id, 'idem-ref-2');
+        $refund = $gateway->refund($charge->id, null, 'idem-ref-3');
+
+        self::assertSame($charge->id, $refund->chargeId);
+    }
+
+    #[Test]
+    public function cancelIntentSucceeds(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-cancel-1');
+        $cancelled = $gateway->cancelIntent($intent->id, 'idem-cancel-2');
+
+        self::assertSame(PaymentIntentStatus::Cancelled, $cancelled->status);
+    }
+
+    #[Test]
+    public function getIntentDelegatesToProvider(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $gateway = $this->createGatewayWith($provider);
+
+        $intent = $gateway->createIntent(Money::of(2000, Currency::USD), 'idem-get-1');
+        $retrieved = $gateway->getIntent($intent->id);
+
+        self::assertSame($intent->id, $retrieved->id);
+    }
+
+    private function createGateway(): PaymentGateway
+    {
+        $provider = new NullProvider($this->clock);
+
+        return $this->createGatewayWith($provider);
+    }
+
+    private function createGatewayWith(\Pulsar\Extension\Payments\Contract\PaymentProviderInterface $provider): PaymentGateway
+    {
+        $sink = new class implements AuditSinkInterface {
+            /** @var list<\Pulsar\Security\Audit\AuditEntry> */
+            public array $entries = [];
+
+            public function write(\Pulsar\Security\Audit\AuditEntry $entry): void
+            {
+                $this->entries[] = $entry;
+            }
+        };
+
+        $auditLogger = new AuditLogger($sink, 'test-audit-key-1234');
+
+        return new PaymentGateway(
+            provider: $provider,
+            idempotencyStore: $this->idempotencyStore,
+            auditLogger: $auditLogger,
+            metricRegistry: $this->metricRegistry,
+            logger: new NullLogger(),
+            clock: $this->clock,
+            config: $this->createConfig(),
+        );
+    }
+
+    private function createConfig(): PaymentsConfig
+    {
+        return new PaymentsConfig(
+            provider: 'null',
+            defaultCurrency: 'USD',
+            webhook: new WebhookConfig(
+                secret: 'test-secret',
+                path: '/webhooks/payments',
+                toleranceSeconds: 300,
+                signatureHeader: 'X-Payments-Signature',
+            ),
+            idempotency: new IdempotencyConfig(
+                ttlSeconds: 86400,
+                store: 'memory',
+                maxKeyLength: 256,
+            ),
+            webhookLog: new WebhookLogConfig(
+                ttlSeconds: 259200,
+                store: 'memory',
+            ),
+        );
+    }
+}

--- a/tests/Unit/Extension/Payments/Idempotency/IdempotencyClaimTest.php
+++ b/tests/Unit/Extension/Payments/Idempotency/IdempotencyClaimTest.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Idempotency;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Idempotency\IdempotencyClaim;
+use Pulsar\Extension\Payments\Idempotency\IdempotencyClaimStatus;
+
+#[CoversClass(IdempotencyClaim::class)]
+final class IdempotencyClaimTest extends TestCase
+{
+    #[Test]
+    public function replayHasStatusAndPayload(): void
+    {
+        $claim = IdempotencyClaim::replay('{"data":"cached"}');
+
+        self::assertSame(IdempotencyClaimStatus::Replay, $claim->status);
+        self::assertSame('{"data":"cached"}', $claim->resultPayload);
+    }
+
+    #[Test]
+    public function claimedHasStatusAndNullPayload(): void
+    {
+        $claim = IdempotencyClaim::claimed();
+
+        self::assertSame(IdempotencyClaimStatus::Claimed, $claim->status);
+        self::assertNull($claim->resultPayload);
+    }
+
+    #[Test]
+    public function mismatchHasStatusAndNullPayload(): void
+    {
+        $claim = IdempotencyClaim::mismatch();
+
+        self::assertSame(IdempotencyClaimStatus::Mismatch, $claim->status);
+        self::assertNull($claim->resultPayload);
+    }
+}

--- a/tests/Unit/Extension/Payments/Idempotency/InMemoryIdempotencyStoreTest.php
+++ b/tests/Unit/Extension/Payments/Idempotency/InMemoryIdempotencyStoreTest.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Idempotency;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Exception\IdempotencyException;
+use Pulsar\Extension\Payments\Idempotency\IdempotencyClaimStatus;
+use Pulsar\Extension\Payments\Idempotency\InMemoryIdempotencyStore;
+
+#[CoversClass(InMemoryIdempotencyStore::class)]
+final class InMemoryIdempotencyStoreTest extends TestCase
+{
+    #[Test]
+    public function claimNewKeyReturnsClaimed(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable();
+
+        $claim = $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+
+        self::assertSame(IdempotencyClaimStatus::Claimed, $claim->status);
+        self::assertNull($claim->resultPayload);
+    }
+
+    #[Test]
+    public function claimSameKeyAndHashAfterCommitReturnsReplay(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable();
+
+        $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+        $store->commit('key-1', '{"result":"ok"}');
+
+        $claim = $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+
+        self::assertSame(IdempotencyClaimStatus::Replay, $claim->status);
+        self::assertSame('{"result":"ok"}', $claim->resultPayload);
+    }
+
+    #[Test]
+    public function claimSameKeyDifferentHashReturnsMismatch(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable();
+
+        $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+        $store->commit('key-1', '{"result":"ok"}');
+
+        $claim = $store->claim('key-1', 'hash-different', 'createIntent', $now, 3600);
+
+        self::assertSame(IdempotencyClaimStatus::Mismatch, $claim->status);
+    }
+
+    #[Test]
+    public function claimInFlightKeyThrowsConcurrentClaim(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable();
+
+        $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+
+        $this->expectException(IdempotencyException::class);
+        $this->expectExceptionMessage('currently being processed');
+
+        $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+    }
+
+    #[Test]
+    public function releaseAllowsReclaim(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable();
+
+        $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+        $store->release('key-1');
+
+        $claim = $store->claim('key-1', 'hash-1', 'createIntent', $now, 3600);
+
+        self::assertSame(IdempotencyClaimStatus::Claimed, $claim->status);
+    }
+
+    #[Test]
+    public function expiredRecordTreatedAsNew(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable('@1700000000');
+
+        $store->claim('key-1', 'hash-1', 'createIntent', $now, 60);
+        $store->commit('key-1', '{"result":"old"}');
+
+        $later = new DateTimeImmutable('@1700000100'); // After TTL
+        $claim = $store->claim('key-1', 'hash-2', 'createIntent', $later, 60);
+
+        self::assertSame(IdempotencyClaimStatus::Claimed, $claim->status);
+    }
+
+    #[Test]
+    public function pruneRemovesExpiredRecords(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable('@1700000000');
+
+        $store->claim('key-1', 'hash-1', 'op1', $now, 60);
+        $store->commit('key-1', '{"result":"1"}');
+
+        $store->claim('key-2', 'hash-2', 'op2', $now, 3600);
+        $store->commit('key-2', '{"result":"2"}');
+
+        $later = new DateTimeImmutable('@1700000100');
+        $pruned = $store->prune($later);
+
+        self::assertSame(1, $pruned);
+
+        // key-1 should be gone (TTL 60s, pruned after 100s)
+        $claim1 = $store->claim('key-1', 'hash-1', 'op1', $later, 60);
+        self::assertSame(IdempotencyClaimStatus::Claimed, $claim1->status);
+
+        // key-2 should still exist (TTL 3600s)
+        $claim2 = $store->claim('key-2', 'hash-2', 'op2', $later, 3600);
+        self::assertSame(IdempotencyClaimStatus::Replay, $claim2->status);
+    }
+
+    #[Test]
+    public function commitClearsInFlightFlag(): void
+    {
+        $store = new InMemoryIdempotencyStore();
+        $now = new DateTimeImmutable();
+
+        $store->claim('key-1', 'hash-1', 'op', $now, 3600);
+        $store->commit('key-1', '{"result":"ok"}');
+
+        // Should not throw — in-flight was cleared by commit
+        $claim = $store->claim('key-1', 'hash-1', 'op', $now, 3600);
+        self::assertSame(IdempotencyClaimStatus::Replay, $claim->status);
+    }
+}

--- a/tests/Unit/Extension/Payments/PaymentsExtensionTest.php
+++ b/tests/Unit/Extension/Payments/PaymentsExtensionTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Container\Container;
+use Pulsar\Extension\Payments\Config\IdempotencyConfig;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Config\WebhookConfig;
+use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+use Pulsar\Extension\Payments\PaymentsExtension;
+use Pulsar\Extension\Payments\PaymentsServiceProvider;
+use Pulsar\Routing\Router;
+
+#[CoversClass(PaymentsExtension::class)]
+final class PaymentsExtensionTest extends TestCase
+{
+    #[Test]
+    public function nameReturnsPulsarPayments(): void
+    {
+        $extension = new PaymentsExtension();
+
+        self::assertSame('pulsar/payments', $extension->name());
+    }
+
+    #[Test]
+    public function registerIsNoOp(): void
+    {
+        $extension = new PaymentsExtension();
+        $container = new Container();
+
+        $extension->register($container);
+
+        // register() is intentionally empty — service provider handles bindings
+        // Verify no bindings were added (container has no extra state)
+        self::assertSame([], $container->getBindings());
+    }
+
+    #[Test]
+    public function providersReturnsServiceProviderClass(): void
+    {
+        $extension = new PaymentsExtension();
+
+        $providers = $extension->providers();
+
+        self::assertSame([PaymentsServiceProvider::class], $providers);
+    }
+
+    #[Test]
+    public function bootRegistersWebhookRoute(): void
+    {
+        $extension = new PaymentsExtension();
+        $container = new Container();
+        $router = new Router();
+
+        $config = new PaymentsConfig(
+            provider: 'null',
+            defaultCurrency: 'USD',
+            webhook: new WebhookConfig(
+                secret: 'test-secret',
+                path: '/webhooks/payments',
+                toleranceSeconds: 300,
+                signatureHeader: 'X-Payments-Signature',
+            ),
+            idempotency: new IdempotencyConfig(
+                ttlSeconds: 86400,
+                store: 'memory',
+                maxKeyLength: 256,
+            ),
+            webhookLog: new WebhookLogConfig(
+                ttlSeconds: 259200,
+                store: 'memory',
+            ),
+        );
+
+        $container->instance(PaymentsConfig::class, $config);
+
+        $extension->boot($container, $router);
+
+        $found = false;
+
+        foreach ($router->routes as $route) {
+            if ($route->name === 'payments.webhook') {
+                $found = true;
+                self::assertSame('/webhooks/payments', $route->path);
+
+                break;
+            }
+        }
+
+        self::assertTrue($found, 'Webhook route was not registered');
+    }
+}

--- a/tests/Unit/Extension/Payments/PaymentsServiceProviderTest.php
+++ b/tests/Unit/Extension/Payments/PaymentsServiceProviderTest.php
@@ -1,0 +1,160 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Container\Container;
+use Pulsar\Extension\Payments\Clock\SystemClock;
+use Pulsar\Extension\Payments\Config\IdempotencyConfig;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Config\WebhookConfig;
+use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+use Pulsar\Extension\Payments\Contract\ClockInterface;
+use Pulsar\Extension\Payments\Contract\IdempotencyStoreInterface;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Contract\WebhookEventLogInterface;
+use Pulsar\Extension\Payments\Contract\WebhookVerifierInterface;
+use Pulsar\Extension\Payments\Controller\WebhookController;
+use Pulsar\Extension\Payments\Gateway\PaymentGateway;
+use Pulsar\Extension\Payments\Idempotency\InMemoryIdempotencyStore;
+use Pulsar\Extension\Payments\PaymentsServiceProvider;
+use Pulsar\Extension\Payments\Provider\NullProvider;
+use Pulsar\Extension\Payments\Provider\SimulatorProvider;
+use Pulsar\Extension\Payments\Webhook\HmacWebhookVerifier;
+use Pulsar\Extension\Payments\Webhook\InMemoryWebhookEventLog;
+use Pulsar\Extension\Payments\Webhook\WebhookProcessor;
+
+#[CoversClass(PaymentsServiceProvider::class)]
+final class PaymentsServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function providesReturnsAllServiceIds(): void
+    {
+        $provider = new PaymentsServiceProvider();
+
+        $provides = $provider->provides();
+
+        self::assertContains(ClockInterface::class, $provides);
+        self::assertContains(PaymentsConfig::class, $provides);
+        self::assertContains(PaymentProviderInterface::class, $provides);
+        self::assertContains(IdempotencyStoreInterface::class, $provides);
+        self::assertContains(WebhookEventLogInterface::class, $provides);
+        self::assertContains(WebhookVerifierInterface::class, $provides);
+        self::assertContains(PaymentGateway::class, $provides);
+        self::assertContains(WebhookProcessor::class, $provides);
+        self::assertContains(WebhookController::class, $provides);
+    }
+
+    #[Test]
+    public function registerBindsClockAsSystemClock(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        $clock = $container->get(ClockInterface::class);
+
+        self::assertInstanceOf(SystemClock::class, $clock);
+    }
+
+    #[Test]
+    public function registerBindsPaymentsConfigWithDefaults(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        /** @var PaymentsConfig $config */
+        $config = $container->get(PaymentsConfig::class);
+
+        self::assertSame('null', $config->provider);
+        self::assertSame('USD', $config->defaultCurrency);
+    }
+
+    #[Test]
+    public function registerBindsNullProviderByDefault(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        $paymentProvider = $container->get(PaymentProviderInterface::class);
+
+        self::assertInstanceOf(NullProvider::class, $paymentProvider);
+    }
+
+    #[Test]
+    public function registerBindsSimulatorProviderWhenConfigured(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        // Override the PaymentsConfig to use simulator provider
+        $container->forgetInstance(PaymentsConfig::class);
+        $simulatorConfig = new PaymentsConfig(
+            provider: 'simulator',
+            defaultCurrency: 'EUR',
+            webhook: new WebhookConfig(
+                secret: '',
+                path: '/webhooks/payments',
+                toleranceSeconds: 300,
+                signatureHeader: 'X-Payments-Signature',
+            ),
+            idempotency: new IdempotencyConfig(
+                ttlSeconds: 86400,
+                store: 'memory',
+                maxKeyLength: 256,
+            ),
+            webhookLog: new WebhookLogConfig(
+                ttlSeconds: 259200,
+                store: 'memory',
+            ),
+        );
+        $container->instance(PaymentsConfig::class, $simulatorConfig);
+
+        $paymentProvider = $container->get(PaymentProviderInterface::class);
+
+        self::assertInstanceOf(SimulatorProvider::class, $paymentProvider);
+    }
+
+    #[Test]
+    public function registerBindsInMemoryIdempotencyStoreByDefault(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        $store = $container->get(IdempotencyStoreInterface::class);
+
+        self::assertInstanceOf(InMemoryIdempotencyStore::class, $store);
+    }
+
+    #[Test]
+    public function registerBindsInMemoryWebhookEventLogByDefault(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        $log = $container->get(WebhookEventLogInterface::class);
+
+        self::assertInstanceOf(InMemoryWebhookEventLog::class, $log);
+    }
+
+    #[Test]
+    public function registerBindsHmacWebhookVerifier(): void
+    {
+        $container = new Container();
+        $provider = new PaymentsServiceProvider();
+        $provider->register($container);
+
+        $verifier = $container->get(WebhookVerifierInterface::class);
+
+        self::assertInstanceOf(HmacWebhookVerifier::class, $verifier);
+    }
+}

--- a/tests/Unit/Extension/Payments/Provider/NullProviderTest.php
+++ b/tests/Unit/Extension/Payments/Provider/NullProviderTest.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Provider;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+use Pulsar\Extension\Payments\Provider\NullProvider;
+use Pulsar\Tests\Unit\Extension\Payments\Contract\PaymentProviderContractTestCase;
+
+#[CoversClass(NullProvider::class)]
+final class NullProviderTest extends PaymentProviderContractTestCase
+{
+    private FixedClock $clock;
+
+    protected function setUp(): void
+    {
+        $this->clock = new FixedClock(new DateTimeImmutable('2025-01-01T00:00:00Z'));
+    }
+
+    protected function createProvider(): PaymentProviderInterface
+    {
+        return new NullProvider($this->clock);
+    }
+
+    #[Test]
+    public function nameIsNull(): void
+    {
+        $provider = new NullProvider($this->clock);
+
+        self::assertSame('null', $provider->name());
+    }
+
+    #[Test]
+    public function captureIntentReturnsSucceeded(): void
+    {
+        $provider = new NullProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(1000, Currency::USD), 'key-1');
+
+        $charge = $provider->captureIntent($intent->id, 'key-2');
+
+        self::assertSame(ChargeStatus::Succeeded, $charge->status);
+        self::assertSame($intent->id, $charge->intentId);
+    }
+
+    #[Test]
+    public function refundReturnsSucceeded(): void
+    {
+        $provider = new NullProvider($this->clock);
+        $amount = Money::of(500, Currency::EUR);
+
+        $refund = $provider->refund('ch_test', $amount, 'key-3');
+
+        self::assertSame(RefundStatus::Succeeded, $refund->status);
+        self::assertSame('ch_test', $refund->chargeId);
+    }
+
+    #[Test]
+    public function getIntentThrowsNotFound(): void
+    {
+        $provider = new NullProvider($this->clock);
+
+        $this->expectException(PaymentException::class);
+        $this->expectExceptionMessage('not found');
+
+        $provider->getIntent('nonexistent');
+    }
+
+    #[Test]
+    public function getChargeThrowsNotFound(): void
+    {
+        $provider = new NullProvider($this->clock);
+
+        $this->expectException(PaymentException::class);
+
+        $provider->getCharge('nonexistent');
+    }
+
+    #[Test]
+    public function getRefundThrowsNotFound(): void
+    {
+        $provider = new NullProvider($this->clock);
+
+        $this->expectException(PaymentException::class);
+
+        $provider->getRefund('nonexistent');
+    }
+
+    #[Test]
+    public function deterministicIds(): void
+    {
+        $provider = new NullProvider($this->clock);
+
+        $intent1 = $provider->createIntent(Money::of(100, Currency::USD), 'same-key');
+        $intent2 = $provider->createIntent(Money::of(200, Currency::USD), 'same-key');
+
+        // Same idempotency key produces same ID
+        self::assertSame($intent1->id, $intent2->id);
+    }
+}

--- a/tests/Unit/Extension/Payments/Provider/SimulatorProviderTest.php
+++ b/tests/Unit/Extension/Payments/Provider/SimulatorProviderTest.php
@@ -1,0 +1,231 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Provider;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Contract\PaymentProviderInterface;
+use Pulsar\Extension\Payments\Domain\ChargeStatus;
+use Pulsar\Extension\Payments\Domain\Currency;
+use Pulsar\Extension\Payments\Domain\Money;
+use Pulsar\Extension\Payments\Domain\PaymentIntentStatus;
+use Pulsar\Extension\Payments\Domain\RefundStatus;
+use Pulsar\Extension\Payments\Exception\PaymentException;
+use Pulsar\Extension\Payments\Exception\PaymentProviderException;
+use Pulsar\Extension\Payments\Provider\SimulatorProvider;
+use Pulsar\Tests\Unit\Extension\Payments\Contract\PaymentProviderContractTestCase;
+
+use function strlen;
+
+#[CoversClass(SimulatorProvider::class)]
+final class SimulatorProviderTest extends PaymentProviderContractTestCase
+{
+    private FixedClock $clock;
+
+    protected function setUp(): void
+    {
+        $this->clock = new FixedClock(new DateTimeImmutable('2025-01-01T00:00:00Z'));
+    }
+
+    protected function createProvider(): PaymentProviderInterface
+    {
+        return new SimulatorProvider($this->clock);
+    }
+
+    #[Test]
+    public function nameIsSimulator(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        self::assertSame('simulator', $provider->name());
+    }
+
+    #[Test]
+    public function normalAmountSucceeds(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $intent = $provider->createIntent(Money::of(5000, Currency::USD), 'key-1');
+
+        self::assertSame(PaymentIntentStatus::Created, $intent->status);
+    }
+
+    #[Test]
+    public function amount9999DeclinesInsufficientFunds(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('insufficient_funds');
+
+        $provider->createIntent(Money::of(9999, Currency::USD), 'key-decline');
+    }
+
+    #[Test]
+    public function amount9998DeclinesCardExpired(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('card_expired');
+
+        $provider->createIntent(Money::of(9998, Currency::USD), 'key-expired');
+    }
+
+    #[Test]
+    public function amount9997DeclinesCardDeclined(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('card_declined');
+
+        $provider->createIntent(Money::of(9997, Currency::USD), 'key-declined');
+    }
+
+    #[Test]
+    public function amount9996DeclinesProcessingError(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('processing_error');
+
+        $provider->createIntent(Money::of(9996, Currency::USD), 'key-processing');
+    }
+
+    #[Test]
+    public function amount9995DeclinesFraudSuspected(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('fraud_suspected');
+
+        $provider->createIntent(Money::of(9995, Currency::USD), 'key-fraud');
+    }
+
+    #[Test]
+    public function amount9994ThrowsTimeout(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('timed out');
+
+        $provider->createIntent(Money::of(9994, Currency::USD), 'key-timeout');
+    }
+
+    #[Test]
+    public function amount9993ThrowsNetworkError(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('network error');
+
+        $provider->createIntent(Money::of(9993, Currency::USD), 'key-network');
+    }
+
+    #[Test]
+    public function amount9992ThrowsRateLimited(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('rate limit');
+
+        $provider->createIntent(Money::of(9992, Currency::USD), 'key-rate');
+    }
+
+    #[Test]
+    public function captureAndGetIntent(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(2000, Currency::USD), 'key-capture');
+
+        $charge = $provider->captureIntent($intent->id, 'key-capture-2');
+
+        self::assertSame(ChargeStatus::Succeeded, $charge->status);
+        self::assertSame($intent->id, $charge->intentId);
+
+        $retrieved = $provider->getIntent($intent->id);
+        self::assertSame(PaymentIntentStatus::Captured, $retrieved->status);
+    }
+
+    #[Test]
+    public function cancelAndGetIntent(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(2000, Currency::USD), 'key-cancel');
+
+        $cancelled = $provider->cancelIntent($intent->id, 'key-cancel-2');
+
+        self::assertSame(PaymentIntentStatus::Cancelled, $cancelled->status);
+    }
+
+    #[Test]
+    public function refundSucceeds(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(2000, Currency::USD), 'key-refund');
+        $charge = $provider->captureIntent($intent->id, 'key-refund-2');
+
+        $refund = $provider->refund($charge->id, null, 'key-refund-3');
+
+        self::assertSame(RefundStatus::Succeeded, $refund->status);
+        self::assertSame($charge->id, $refund->chargeId);
+    }
+
+    #[Test]
+    public function amount3030RefundFails(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(3030, Currency::USD), 'key-3030');
+        $charge = $provider->captureIntent($intent->id, 'key-3030-cap');
+
+        $this->expectException(PaymentProviderException::class);
+        $this->expectExceptionMessage('simulated_refund_failure');
+
+        $provider->refund($charge->id, null, 'key-3030-refund');
+    }
+
+    #[Test]
+    public function amount4242FlagsForDispute(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(4242, Currency::USD), 'key-4242');
+        $charge = $provider->captureIntent($intent->id, 'key-4242-cap');
+
+        self::assertTrue($provider->hasDisputeFlag($charge->id));
+    }
+
+    #[Test]
+    public function getIntentThrowsForNonexistent(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+
+        $this->expectException(PaymentException::class);
+        $this->expectExceptionMessage('not found');
+
+        $provider->getIntent('nonexistent');
+    }
+
+    #[Test]
+    public function deterministicIdsIncludeOperationAndResource(): void
+    {
+        $provider = new SimulatorProvider($this->clock);
+        $intent = $provider->createIntent(Money::of(1000, Currency::USD), 'key-determ');
+        $charge = $provider->captureIntent($intent->id, 'key-determ-2');
+
+        // Charge ID should be deterministic
+        self::assertSame(32, strlen($charge->id));
+
+        // Different operation same key produces different ID
+        self::assertNotSame($intent->id, $charge->id);
+    }
+}

--- a/tests/Unit/Extension/Payments/Webhook/HmacWebhookVerifierTest.php
+++ b/tests/Unit/Extension/Payments/Webhook/HmacWebhookVerifierTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Webhook;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+use Pulsar\Extension\Payments\Webhook\HmacWebhookVerifier;
+
+use function sprintf;
+
+#[CoversClass(HmacWebhookVerifier::class)]
+final class HmacWebhookVerifierTest extends TestCase
+{
+    private const string SECRET = 'whsec_test_secret';
+    private FixedClock $clock;
+    private HmacWebhookVerifier $verifier;
+
+    protected function setUp(): void
+    {
+        $this->clock = new FixedClock(new DateTimeImmutable('@1700000000'));
+        $this->verifier = new HmacWebhookVerifier($this->clock);
+    }
+
+    #[Test]
+    public function validSignaturePasses(): void
+    {
+        $payload = '{"id":"evt_1","type":"payment_intent.created"}';
+        $timestamp = 1700000000;
+        $signature = $this->computeSignature($payload, $timestamp, self::SECRET);
+        $header = sprintf('t=%d,v1=%s', $timestamp, $signature);
+
+        // Should not throw
+        $this->verifier->verify($payload, $header, self::SECRET, 300);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function invalidSignatureThrows(): void
+    {
+        $payload = '{"id":"evt_1"}';
+        $timestamp = 1700000000;
+        $header = sprintf('t=%d,v1=%s', $timestamp, 'invalid_hex_signature');
+
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('signature verification failed');
+
+        $this->verifier->verify($payload, $header, self::SECRET, 300);
+    }
+
+    #[Test]
+    public function expiredTimestampThrows(): void
+    {
+        $payload = '{"id":"evt_1"}';
+        $timestamp = 1700000000 - 600; // 10 minutes old
+        $signature = $this->computeSignature($payload, $timestamp, self::SECRET);
+        $header = sprintf('t=%d,v1=%s', $timestamp, $signature);
+
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('too old');
+
+        $this->verifier->verify($payload, $header, self::SECRET, 300);
+    }
+
+    #[Test]
+    public function malformedHeaderEmptyThrows(): void
+    {
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('empty header');
+
+        $this->verifier->verify('body', '', self::SECRET, 300);
+    }
+
+    #[Test]
+    public function malformedHeaderMissingTimestampThrows(): void
+    {
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('missing timestamp');
+
+        $this->verifier->verify('body', 'v1=abc123', self::SECRET, 300);
+    }
+
+    #[Test]
+    public function malformedHeaderNoSignaturesThrows(): void
+    {
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('no v1 signatures');
+
+        $this->verifier->verify('body', 't=1700000000', self::SECRET, 300);
+    }
+
+    #[Test]
+    public function multipleV1OneValidAccepts(): void
+    {
+        $payload = '{"id":"evt_multi"}';
+        $timestamp = 1700000000;
+        $validSig = $this->computeSignature($payload, $timestamp, self::SECRET);
+        $header = sprintf('t=%d,v1=%s,v1=%s', $timestamp, 'old_invalid_sig', $validSig);
+
+        // Should not throw — one valid v1 is enough (secret rotation)
+        $this->verifier->verify($payload, $header, self::SECRET, 300);
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function allV1InvalidRejects(): void
+    {
+        $payload = '{"id":"evt_invalid"}';
+        $timestamp = 1700000000;
+        $header = sprintf('t=%d,v1=%s,v1=%s', $timestamp, 'bad_sig_1', 'bad_sig_2');
+
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('signature verification failed');
+
+        $this->verifier->verify($payload, $header, self::SECRET, 300);
+    }
+
+    #[Test]
+    public function withinTolerancePasses(): void
+    {
+        $payload = '{"id":"evt_tolerance"}';
+        $timestamp = 1700000000 - 299; // Just within 300s tolerance
+        $signature = $this->computeSignature($payload, $timestamp, self::SECRET);
+        $header = sprintf('t=%d,v1=%s', $timestamp, $signature);
+
+        $this->verifier->verify($payload, $header, self::SECRET, 300);
+
+        $this->addToAssertionCount(1);
+    }
+
+    private function computeSignature(string $payload, int $timestamp, string $secret): string
+    {
+        return hash_hmac('sha256', $timestamp . '.' . $payload, $secret);
+    }
+}

--- a/tests/Unit/Extension/Payments/Webhook/InMemoryWebhookEventLogTest.php
+++ b/tests/Unit/Extension/Payments/Webhook/InMemoryWebhookEventLogTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Webhook;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Exception\WebhookException;
+use Pulsar\Extension\Payments\Webhook\InMemoryWebhookEventLog;
+use Pulsar\Extension\Payments\Webhook\WebhookClaimStatus;
+
+#[CoversClass(InMemoryWebhookEventLog::class)]
+final class InMemoryWebhookEventLogTest extends TestCase
+{
+    #[Test]
+    public function claimNewEventReturnsClaimed(): void
+    {
+        $log = new InMemoryWebhookEventLog();
+        $now = new DateTimeImmutable();
+
+        $claim = $log->claim('evt_1', $now, 3600);
+
+        self::assertSame(WebhookClaimStatus::Claimed, $claim->status);
+        self::assertNull($claim->processedAt);
+    }
+
+    #[Test]
+    public function claimProcessedEventReturnsReplay(): void
+    {
+        $log = new InMemoryWebhookEventLog();
+        $now = new DateTimeImmutable();
+
+        $log->claim('evt_1', $now, 3600);
+        $log->commit('evt_1');
+
+        $claim = $log->claim('evt_1', $now, 3600);
+
+        self::assertSame(WebhookClaimStatus::Replay, $claim->status);
+        self::assertNotNull($claim->processedAt);
+    }
+
+    #[Test]
+    public function claimInFlightEventThrowsConcurrentClaim(): void
+    {
+        $log = new InMemoryWebhookEventLog();
+        $now = new DateTimeImmutable();
+
+        $log->claim('evt_1', $now, 3600);
+
+        $this->expectException(WebhookException::class);
+        $this->expectExceptionMessage('currently being processed');
+
+        $log->claim('evt_1', $now, 3600);
+    }
+
+    #[Test]
+    public function releaseAllowsReclaim(): void
+    {
+        $log = new InMemoryWebhookEventLog();
+        $now = new DateTimeImmutable();
+
+        $log->claim('evt_1', $now, 3600);
+        $log->release('evt_1');
+
+        $claim = $log->claim('evt_1', $now, 3600);
+
+        self::assertSame(WebhookClaimStatus::Claimed, $claim->status);
+    }
+
+    #[Test]
+    public function commitThenClaimReturnsReplay(): void
+    {
+        $log = new InMemoryWebhookEventLog();
+        $now = new DateTimeImmutable();
+
+        $log->claim('evt_1', $now, 3600);
+        $log->commit('evt_1');
+
+        $claim = $log->claim('evt_1', $now, 3600);
+
+        self::assertSame(WebhookClaimStatus::Replay, $claim->status);
+    }
+
+    #[Test]
+    public function pruneRemovesExpiredRecords(): void
+    {
+        $log = new InMemoryWebhookEventLog();
+        $now = new DateTimeImmutable('@1700000000');
+
+        $log->claim('evt_1', $now, 60);
+        $log->commit('evt_1');
+
+        $later = new DateTimeImmutable('@1800000000');
+        $pruned = $log->prune($later);
+
+        self::assertSame(1, $pruned);
+
+        // Should be claimable again after prune
+        $claim = $log->claim('evt_1', $later, 3600);
+        self::assertSame(WebhookClaimStatus::Claimed, $claim->status);
+    }
+}

--- a/tests/Unit/Extension/Payments/Webhook/WebhookClaimTest.php
+++ b/tests/Unit/Extension/Payments/Webhook/WebhookClaimTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Webhook;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\Payments\Webhook\WebhookClaim;
+use Pulsar\Extension\Payments\Webhook\WebhookClaimStatus;
+
+#[CoversClass(WebhookClaim::class)]
+final class WebhookClaimTest extends TestCase
+{
+    #[Test]
+    public function replayHasStatusAndProcessedAt(): void
+    {
+        $processedAt = new DateTimeImmutable('2025-01-01T00:00:00Z');
+        $claim = WebhookClaim::replay($processedAt);
+
+        self::assertSame(WebhookClaimStatus::Replay, $claim->status);
+        self::assertSame($processedAt, $claim->processedAt);
+    }
+
+    #[Test]
+    public function claimedHasStatusAndNullProcessedAt(): void
+    {
+        $claim = WebhookClaim::claimed();
+
+        self::assertSame(WebhookClaimStatus::Claimed, $claim->status);
+        self::assertNull($claim->processedAt);
+    }
+}

--- a/tests/Unit/Extension/Payments/Webhook/WebhookProcessorTest.php
+++ b/tests/Unit/Extension/Payments/Webhook/WebhookProcessorTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\Payments\Webhook;
+
+use DateTimeImmutable;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Psr\Log\NullLogger;
+use Pulsar\Extension\Payments\Clock\FixedClock;
+use Pulsar\Extension\Payments\Config\IdempotencyConfig;
+use Pulsar\Extension\Payments\Config\PaymentsConfig;
+use Pulsar\Extension\Payments\Config\WebhookConfig;
+use Pulsar\Extension\Payments\Config\WebhookLogConfig;
+use Pulsar\Extension\Payments\Contract\WebhookHandlerInterface;
+use Pulsar\Extension\Payments\Domain\WebhookEvent;
+use Pulsar\Extension\Payments\Webhook\HmacWebhookVerifier;
+use Pulsar\Extension\Payments\Webhook\InMemoryWebhookEventLog;
+use Pulsar\Extension\Payments\Webhook\WebhookProcessor;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use RuntimeException;
+
+use function sprintf;
+
+#[CoversClass(WebhookProcessor::class)]
+final class WebhookProcessorTest extends TestCase
+{
+    private const string SECRET = 'whsec_test';
+    private FixedClock $clock;
+    private MetricRegistry $metricRegistry;
+    private InMemoryWebhookEventLog $eventLog;
+
+    protected function setUp(): void
+    {
+        $this->clock = new FixedClock(new DateTimeImmutable('@1700000000'));
+        $this->metricRegistry = new MetricRegistry();
+        $this->eventLog = new InMemoryWebhookEventLog();
+    }
+
+    #[Test]
+    public function processValidWebhookSucceeds(): void
+    {
+        $handler = $this->createHandler();
+        $processor = $this->createProcessor($handler);
+
+        $body = $this->createEventBody('evt_1', 'payment_intent.created');
+        $header = $this->createSignatureHeader($body, 1700000000);
+
+        $response = $processor->process($body, $header);
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        self::assertStringContainsString('processed', $response->body);
+        self::assertCount(1, $handler->events);
+    }
+
+    #[Test]
+    public function processInvalidSignatureReturns403(): void
+    {
+        $handler = $this->createHandler();
+        $processor = $this->createProcessor($handler);
+
+        $body = $this->createEventBody('evt_2', 'charge.failed');
+
+        $response = $processor->process($body, 't=1700000000,v1=invalid');
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+        self::assertCount(0, $handler->events);
+    }
+
+    #[Test]
+    public function processReplayReturns200AlreadyProcessed(): void
+    {
+        $handler = $this->createHandler();
+        $processor = $this->createProcessor($handler);
+
+        $body = $this->createEventBody('evt_replay', 'payment_intent.created');
+        $header = $this->createSignatureHeader($body, 1700000000);
+
+        // First request
+        $processor->process($body, $header);
+
+        // Second request — same event ID
+        $response = $processor->process($body, $header);
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        self::assertStringContainsString('already_processed', $response->body);
+        self::assertCount(1, $handler->events); // Handler called only once
+    }
+
+    #[Test]
+    public function processHandlerErrorReturns500AndReleasesEvent(): void
+    {
+        $handler = new class implements WebhookHandlerInterface {
+            public function handle(WebhookEvent $event): void
+            {
+                throw new RuntimeException('Handler exploded');
+            }
+        };
+
+        $processor = $this->createProcessor($handler);
+
+        $body = $this->createEventBody('evt_fail', 'payment_intent.created');
+        $header = $this->createSignatureHeader($body, 1700000000);
+
+        $response = $processor->process($body, $header);
+
+        self::assertSame(ResponseStatus::InternalServerError, $response->status);
+
+        // Event should be released — retry allowed
+        $body2 = $this->createEventBody('evt_fail', 'payment_intent.created');
+        $header2 = $this->createSignatureHeader($body2, 1700000000);
+
+        $handler2 = $this->createHandler();
+        $processor2 = $this->createProcessor($handler2);
+
+        $response2 = $processor2->process($body2, $header2);
+
+        self::assertSame(ResponseStatus::OK, $response2->status);
+    }
+
+    #[Test]
+    public function metricsIncrementOnSuccess(): void
+    {
+        $handler = $this->createHandler();
+        $processor = $this->createProcessor($handler);
+
+        $body = $this->createEventBody('evt_m', 'payment_intent.created');
+        $header = $this->createSignatureHeader($body, 1700000000);
+
+        $processor->process($body, $header);
+
+        $counter = $this->metricRegistry->counter('payments_webhooks_total');
+        self::assertSame(1.0, $counter->value(new LabelSet([
+            'provider' => 'null',
+            'event_type' => 'payment_intent.created',
+            'status' => 'ok',
+        ])));
+    }
+
+    /**
+     * @return object{events: list<WebhookEvent>}&WebhookHandlerInterface
+     */
+    private function createHandler(): WebhookHandlerInterface
+    {
+        return new class implements WebhookHandlerInterface {
+            /** @var list<WebhookEvent> */
+            public array $events = [];
+
+            public function handle(WebhookEvent $event): void
+            {
+                $this->events[] = $event;
+            }
+        };
+    }
+
+    private function createProcessor(WebhookHandlerInterface $handler): WebhookProcessor
+    {
+        return new WebhookProcessor(
+            verifier: new HmacWebhookVerifier($this->clock),
+            eventLog: $this->eventLog,
+            handler: $handler,
+            clock: $this->clock,
+            metricRegistry: $this->metricRegistry,
+            logger: new NullLogger(),
+            config: $this->createConfig(),
+        );
+    }
+
+    private function createConfig(): PaymentsConfig
+    {
+        return new PaymentsConfig(
+            provider: 'null',
+            defaultCurrency: 'USD',
+            webhook: new WebhookConfig(
+                secret: self::SECRET,
+                path: '/webhooks/payments',
+                toleranceSeconds: 300,
+                signatureHeader: 'X-Payments-Signature',
+            ),
+            idempotency: new IdempotencyConfig(
+                ttlSeconds: 86400,
+                store: 'memory',
+                maxKeyLength: 256,
+            ),
+            webhookLog: new WebhookLogConfig(
+                ttlSeconds: 259200,
+                store: 'memory',
+            ),
+        );
+    }
+
+    private function createEventBody(string $id, string $type): string
+    {
+        return json_encode([
+            'id' => $id,
+            'type' => $type,
+            'created_at' => 1700000000,
+            'data' => [],
+        ], JSON_THROW_ON_ERROR);
+    }
+
+    private function createSignatureHeader(string $body, int $timestamp): string
+    {
+        $signature = hash_hmac('sha256', $timestamp . '.' . $body, self::SECRET);
+
+        return sprintf('t=%d,v1=%s', $timestamp, $signature);
+    }
+}

--- a/tests/Unit/FeatureFlag/FlagContextTest.php
+++ b/tests/Unit/FeatureFlag/FlagContextTest.php
@@ -8,6 +8,9 @@ use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Pulsar\FeatureFlag\FlagContext;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
 
 #[CoversClass(FlagContext::class)]
 final class FlagContextTest extends TestCase
@@ -37,5 +40,44 @@ final class FlagContextTest extends TestCase
         self::assertNull($context->userId);
         self::assertNull($context->environment);
         self::assertSame([], $context->attributes);
+    }
+
+    #[Test]
+    public function fromRequestExtractsTenantAndUserId(): void
+    {
+        $request = new Request(
+            method: Method::GET,
+            uri: '/test',
+            path: '/test',
+            queryString: '',
+            headers: new HeaderBag([]),
+            body: '',
+            attributes: ['_tenant_id' => 'acme', '_user_id' => 'user-42'],
+        );
+
+        $context = FlagContext::fromRequest($request);
+
+        self::assertSame('acme', $context->tenantId);
+        self::assertSame('user-42', $context->userId);
+        self::assertNull($context->environment);
+        self::assertSame([], $context->attributes);
+    }
+
+    #[Test]
+    public function fromRequestHandlesMissingAttributes(): void
+    {
+        $request = new Request(
+            method: Method::GET,
+            uri: '/test',
+            path: '/test',
+            queryString: '',
+            headers: new HeaderBag([]),
+            body: '',
+        );
+
+        $context = FlagContext::fromRequest($request);
+
+        self::assertNull($context->tenantId);
+        self::assertNull($context->userId);
     }
 }

--- a/tests/Unit/FeatureFlag/FlagEvaluationLogTest.php
+++ b/tests/Unit/FeatureFlag/FlagEvaluationLogTest.php
@@ -12,6 +12,7 @@ use Pulsar\FeatureFlag\FlagContext;
 use Pulsar\FeatureFlag\FlagEvaluation;
 use Pulsar\FeatureFlag\FlagEvaluationLog;
 use Pulsar\FeatureFlag\FlagEvaluationReason;
+use RuntimeException;
 
 #[CoversClass(FlagEvaluationLog::class)]
 final class FlagEvaluationLogTest extends TestCase
@@ -127,5 +128,68 @@ final class FlagEvaluationLogTest extends TestCase
         ));
 
         self::assertSame(2, $log->count());
+    }
+
+    #[Test]
+    public function addObserverCallsObserverOnRecord(): void
+    {
+        $log = new FlagEvaluationLog();
+        $observed = null;
+
+        $log->addObserver(static function (FlagEvaluation $eval) use (&$observed): void {
+            $observed = $eval;
+        });
+
+        $evaluation = new FlagEvaluation(
+            flagName: 'test-flag',
+            result: true,
+            reason: FlagEvaluationReason::FlagEnabled,
+            context: new FlagContext(),
+            evaluatedAt: new DateTimeImmutable(),
+        );
+
+        $log->record($evaluation);
+
+        self::assertSame($evaluation, $observed);
+    }
+
+    #[Test]
+    public function observerExceptionDoesNotPreventRecording(): void
+    {
+        $log = new FlagEvaluationLog();
+
+        $log->addObserver(static function (): void {
+            throw new RuntimeException('observer failure');
+        });
+
+        $log->record(new FlagEvaluation(
+            flagName: 'flag',
+            result: true,
+            reason: FlagEvaluationReason::FlagEnabled,
+            context: new FlagContext(),
+            evaluatedAt: new DateTimeImmutable(),
+        ));
+
+        self::assertSame(1, $log->count());
+    }
+
+    #[Test]
+    public function resetRequestStateClearsLog(): void
+    {
+        $log = new FlagEvaluationLog();
+
+        $log->record(new FlagEvaluation(
+            flagName: 'flag',
+            result: true,
+            reason: FlagEvaluationReason::FlagEnabled,
+            context: new FlagContext(),
+            evaluatedAt: new DateTimeImmutable(),
+        ));
+
+        self::assertSame(1, $log->count());
+
+        $log->resetRequestState();
+
+        self::assertSame(0, $log->count());
     }
 }

--- a/tests/Unit/Http/RequestTest.php
+++ b/tests/Unit/Http/RequestTest.php
@@ -528,6 +528,102 @@ final class RequestTest extends TestCase
 
         self::assertFalse($request->wantsJson());
     }
+
+    #[Test]
+    public function isSecureReturnsFalseWhenNoHttpsKey(): void
+    {
+        $request = new Request(
+            method: Method::GET,
+            uri: '/',
+            path: '/',
+            queryString: '',
+            headers: new HeaderBag(),
+            body: '',
+            server: [],
+        );
+
+        self::assertFalse($request->isSecure());
+    }
+
+    #[Test]
+    public function jsonReturnsEmptyArrayForNonArrayDecoded(): void
+    {
+        $request = new Request(
+            method: Method::POST,
+            uri: '/',
+            path: '/',
+            queryString: '',
+            headers: new HeaderBag(['Content-Type' => 'application/json']),
+            body: '"just a string"',
+        );
+
+        self::assertSame([], $request->json());
+    }
+
+    #[Test]
+    public function filledReturnsFalseForNullValue(): void
+    {
+        $request = new Request(
+            method: Method::GET,
+            uri: '/',
+            path: '/',
+            queryString: '',
+            headers: new HeaderBag(),
+            body: '',
+            query: ['name' => null],
+        );
+
+        self::assertFalse($request->filled('name'));
+    }
+
+    #[Test]
+    public function fromGlobalsCreatesRequestFromServerData(): void
+    {
+        $server = [
+            'REQUEST_METHOD' => 'POST',
+            'REQUEST_URI' => '/api/users?page=1',
+            'QUERY_STRING' => 'page=1',
+            'SERVER_PROTOCOL' => 'HTTP/2.0',
+            'HTTP_HOST' => 'example.com',
+            'HTTP_CONTENT_TYPE' => 'application/json',
+        ];
+        $get = ['page' => '1'];
+        $post = ['name' => 'Alice'];
+        $cookies = ['session' => 'xyz'];
+
+        $request = Request::fromGlobals(
+            get: $get,
+            post: $post,
+            cookies: $cookies,
+            server: $server,
+        );
+
+        self::assertSame(Method::POST, $request->method);
+        self::assertSame('/api/users?page=1', $request->uri);
+        self::assertSame('/api/users', $request->path);
+        self::assertSame('page=1', $request->queryString);
+        self::assertSame('2.0', $request->protocolVersion);
+        self::assertSame('1', $request->query('page'));
+        self::assertSame('Alice', $request->post('name'));
+        self::assertSame('xyz', $request->cookie('session'));
+    }
+
+    #[Test]
+    public function fromGlobalsDefaultsForMissingServerKeys(): void
+    {
+        $request = Request::fromGlobals(
+            get: [],
+            post: [],
+            cookies: [],
+            server: [],
+        );
+
+        self::assertSame(Method::GET, $request->method);
+        self::assertSame('/', $request->uri);
+        self::assertSame('/', $request->path);
+        self::assertSame('', $request->queryString);
+        self::assertSame('1.1', $request->protocolVersion);
+    }
 }
 
 #[CoversClass(Method::class)]

--- a/tests/Unit/Http/ResponseStatusTest.php
+++ b/tests/Unit/Http/ResponseStatusTest.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Http;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Http\ResponseStatus;
+
+#[CoversClass(ResponseStatus::class)]
+final class ResponseStatusTest extends TestCase
+{
+    #[Test]
+    public function reasonPhraseReturnsCorrectPhraseForAllCases(): void
+    {
+        $expected = [
+            100 => 'Continue',
+            101 => 'Switching Protocols',
+            102 => 'Processing',
+            103 => 'Early Hints',
+            200 => 'OK',
+            201 => 'Created',
+            202 => 'Accepted',
+            203 => 'Non-Authoritative Information',
+            204 => 'No Content',
+            205 => 'Reset Content',
+            206 => 'Partial Content',
+            207 => 'Multi-Status',
+            208 => 'Already Reported',
+            226 => 'IM Used',
+            300 => 'Multiple Choices',
+            301 => 'Moved Permanently',
+            302 => 'Found',
+            303 => 'See Other',
+            304 => 'Not Modified',
+            305 => 'Use Proxy',
+            307 => 'Temporary Redirect',
+            308 => 'Permanent Redirect',
+            400 => 'Bad Request',
+            401 => 'Unauthorized',
+            402 => 'Payment Required',
+            403 => 'Forbidden',
+            404 => 'Not Found',
+            405 => 'Method Not Allowed',
+            406 => 'Not Acceptable',
+            407 => 'Proxy Authentication Required',
+            408 => 'Request Timeout',
+            409 => 'Conflict',
+            410 => 'Gone',
+            411 => 'Length Required',
+            412 => 'Precondition Failed',
+            413 => 'Payload Too Large',
+            414 => 'URI Too Long',
+            415 => 'Unsupported Media Type',
+            416 => 'Range Not Satisfiable',
+            417 => 'Expectation Failed',
+            418 => "I'm a teapot",
+            421 => 'Misdirected Request',
+            422 => 'Unprocessable Entity',
+            423 => 'Locked',
+            424 => 'Failed Dependency',
+            425 => 'Too Early',
+            426 => 'Upgrade Required',
+            428 => 'Precondition Required',
+            429 => 'Too Many Requests',
+            431 => 'Request Header Fields Too Large',
+            451 => 'Unavailable For Legal Reasons',
+            500 => 'Internal Server Error',
+            501 => 'Not Implemented',
+            502 => 'Bad Gateway',
+            503 => 'Service Unavailable',
+            504 => 'Gateway Timeout',
+            505 => 'HTTP Version Not Supported',
+            506 => 'Variant Also Negotiates',
+            507 => 'Insufficient Storage',
+            508 => 'Loop Detected',
+            510 => 'Not Extended',
+            511 => 'Network Authentication Required',
+        ];
+
+        foreach ($expected as $code => $phrase) {
+            $status = ResponseStatus::from($code);
+            self::assertSame($phrase, $status->reasonPhrase(), "Status {$code} should have phrase '{$phrase}'");
+        }
+    }
+
+    #[Test]
+    public function isInformationalReturnsTrueFor1xx(): void
+    {
+        self::assertTrue(ResponseStatus::Continue->isInformational());
+        self::assertTrue(ResponseStatus::SwitchingProtocols->isInformational());
+        self::assertTrue(ResponseStatus::EarlyHints->isInformational());
+    }
+
+    #[Test]
+    public function isInformationalReturnsFalseForNon1xx(): void
+    {
+        self::assertFalse(ResponseStatus::OK->isInformational());
+        self::assertFalse(ResponseStatus::NotFound->isInformational());
+        self::assertFalse(ResponseStatus::InternalServerError->isInformational());
+    }
+
+    #[Test]
+    public function isSuccessfulReturnsTrueFor2xx(): void
+    {
+        self::assertTrue(ResponseStatus::OK->isSuccessful());
+        self::assertTrue(ResponseStatus::Created->isSuccessful());
+        self::assertTrue(ResponseStatus::NoContent->isSuccessful());
+    }
+
+    #[Test]
+    public function isSuccessfulReturnsFalseForNon2xx(): void
+    {
+        self::assertFalse(ResponseStatus::Continue->isSuccessful());
+        self::assertFalse(ResponseStatus::Found->isSuccessful());
+        self::assertFalse(ResponseStatus::BadRequest->isSuccessful());
+    }
+
+    #[Test]
+    public function isRedirectionReturnsTrueFor3xx(): void
+    {
+        self::assertTrue(ResponseStatus::MovedPermanently->isRedirection());
+        self::assertTrue(ResponseStatus::Found->isRedirection());
+        self::assertTrue(ResponseStatus::TemporaryRedirect->isRedirection());
+    }
+
+    #[Test]
+    public function isRedirectionReturnsFalseForNon3xx(): void
+    {
+        self::assertFalse(ResponseStatus::OK->isRedirection());
+        self::assertFalse(ResponseStatus::NotFound->isRedirection());
+    }
+
+    #[Test]
+    public function isClientErrorReturnsTrueFor4xx(): void
+    {
+        self::assertTrue(ResponseStatus::BadRequest->isClientError());
+        self::assertTrue(ResponseStatus::NotFound->isClientError());
+        self::assertTrue(ResponseStatus::TooManyRequests->isClientError());
+    }
+
+    #[Test]
+    public function isClientErrorReturnsFalseForNon4xx(): void
+    {
+        self::assertFalse(ResponseStatus::OK->isClientError());
+        self::assertFalse(ResponseStatus::InternalServerError->isClientError());
+    }
+
+    #[Test]
+    public function isServerErrorReturnsTrueFor5xx(): void
+    {
+        self::assertTrue(ResponseStatus::InternalServerError->isServerError());
+        self::assertTrue(ResponseStatus::BadGateway->isServerError());
+        self::assertTrue(ResponseStatus::ServiceUnavailable->isServerError());
+    }
+
+    #[Test]
+    public function isServerErrorReturnsFalseForNon5xx(): void
+    {
+        self::assertFalse(ResponseStatus::OK->isServerError());
+        self::assertFalse(ResponseStatus::NotFound->isServerError());
+    }
+
+    #[Test]
+    public function isErrorReturnsTrueFor4xxAnd5xx(): void
+    {
+        self::assertTrue(ResponseStatus::BadRequest->isError());
+        self::assertTrue(ResponseStatus::NotFound->isError());
+        self::assertTrue(ResponseStatus::InternalServerError->isError());
+        self::assertTrue(ResponseStatus::ServiceUnavailable->isError());
+    }
+
+    #[Test]
+    public function isErrorReturnsFalseFor1xx2xx3xx(): void
+    {
+        self::assertFalse(ResponseStatus::Continue->isError());
+        self::assertFalse(ResponseStatus::OK->isError());
+        self::assertFalse(ResponseStatus::MovedPermanently->isError());
+    }
+}

--- a/tests/Unit/Observability/Diagnostics/DiagnosticsRendererTest.php
+++ b/tests/Unit/Observability/Diagnostics/DiagnosticsRendererTest.php
@@ -1,0 +1,227 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Diagnostics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Diagnostics\DiagnosticsRenderer;
+use Pulsar\Observability\ErrorTracking\ErrorAggregator;
+use Pulsar\Observability\ErrorTracking\ErrorEvent;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricRegistry;
+use Pulsar\Observability\Tracing\InMemorySpanCollector;
+use Pulsar\Observability\Tracing\Span;
+use Pulsar\Observability\Tracing\SpanId;
+use Pulsar\Observability\Tracing\SpanStatus;
+use Pulsar\Observability\Tracing\TraceContext;
+use Pulsar\Observability\Tracing\TraceId;
+use RuntimeException;
+
+#[CoversClass(DiagnosticsRenderer::class)]
+final class DiagnosticsRendererTest extends TestCase
+{
+    #[Test]
+    public function renderReturnsHtmlWithAllSections(): void
+    {
+        $registry = new MetricRegistry();
+        $renderer = new DiagnosticsRenderer($registry);
+
+        $html = $renderer->render();
+
+        self::assertStringContainsString('Pulsar Diagnostics', $html);
+        self::assertStringContainsString('Metrics', $html);
+        self::assertStringContainsString('Error Groups', $html);
+        self::assertStringContainsString('Recent Traces', $html);
+    }
+
+    #[Test]
+    public function renderShowsEmptyStatesWhenNoData(): void
+    {
+        $registry = new MetricRegistry();
+        $renderer = new DiagnosticsRenderer($registry);
+
+        $html = $renderer->render();
+
+        self::assertStringContainsString('No metrics recorded yet.', $html);
+        self::assertStringContainsString('No errors tracked yet.', $html);
+        self::assertStringContainsString('No traces collected yet.', $html);
+    }
+
+    #[Test]
+    public function renderShowsCounterMetric(): void
+    {
+        $registry = new MetricRegistry();
+        $counter = $registry->counter('http_requests_total', 'Total HTTP requests');
+        $counter->increment();
+
+        $renderer = new DiagnosticsRenderer($registry);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('http_requests_total', $html);
+        self::assertStringContainsString('counter', $html);
+    }
+
+    #[Test]
+    public function renderShowsGaugeMetric(): void
+    {
+        $registry = new MetricRegistry();
+        $gauge = $registry->gauge('memory_usage', 'Current memory');
+        $gauge->set(42.5);
+
+        $renderer = new DiagnosticsRenderer($registry);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('memory_usage', $html);
+        self::assertStringContainsString('gauge', $html);
+    }
+
+    #[Test]
+    public function renderShowsHistogramMetric(): void
+    {
+        $registry = new MetricRegistry();
+        $histogram = $registry->histogram('response_time', 'Response time', [0.1, 0.5, 1.0]);
+        $histogram->observe(0.25);
+
+        $renderer = new DiagnosticsRenderer($registry);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('response_time', $html);
+        self::assertStringContainsString('histogram', $html);
+    }
+
+    #[Test]
+    public function renderShowsErrorGroups(): void
+    {
+        $registry = new MetricRegistry();
+        $aggregator = new ErrorAggregator();
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('Test failure')));
+
+        $renderer = new DiagnosticsRenderer($registry, aggregator: $aggregator);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('RuntimeException', $html);
+        self::assertStringContainsString('Test failure', $html);
+    }
+
+    #[Test]
+    public function renderShowsTraces(): void
+    {
+        $registry = new MetricRegistry();
+        $collector = new InMemorySpanCollector();
+
+        $span = new Span(
+            name: 'test.operation',
+            context: new TraceContext(
+                traceId: new TraceId('abcdef1234567890abcdef1234567890'),
+                spanId: new SpanId('1234567890abcdef'),
+            ),
+        );
+        $span->end();
+        $collector->onEnd($span);
+
+        $renderer = new DiagnosticsRenderer($registry, collector: $collector);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('test.operation', $html);
+        self::assertStringContainsString('abcdef12...', $html);
+    }
+
+    #[Test]
+    public function renderShowsSpanWithErrorStatus(): void
+    {
+        $registry = new MetricRegistry();
+        $collector = new InMemorySpanCollector();
+
+        $span = new Span(
+            name: 'failing.op',
+            context: new TraceContext(
+                traceId: new TraceId('abcdef1234567890abcdef1234567890'),
+                spanId: new SpanId('1234567890abcdef'),
+            ),
+        );
+        $span->status = SpanStatus::Error;
+        $span->end();
+        $collector->onEnd($span);
+
+        $renderer = new DiagnosticsRenderer($registry, collector: $collector);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('badge-error', $html);
+    }
+
+    #[Test]
+    public function renderShowsSpanWithOkStatus(): void
+    {
+        $registry = new MetricRegistry();
+        $collector = new InMemorySpanCollector();
+
+        $span = new Span(
+            name: 'ok.op',
+            context: new TraceContext(
+                traceId: new TraceId('abcdef1234567890abcdef1234567890'),
+                spanId: new SpanId('1234567890abcdef'),
+            ),
+        );
+        $span->status = SpanStatus::Ok;
+        $span->end();
+        $collector->onEnd($span);
+
+        $renderer = new DiagnosticsRenderer($registry, collector: $collector);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('badge-ok', $html);
+    }
+
+    #[Test]
+    public function renderShowsRunningSpanDuration(): void
+    {
+        $registry = new MetricRegistry();
+        $collector = new InMemorySpanCollector();
+
+        $span = new Span(
+            name: 'running.op',
+            context: new TraceContext(
+                traceId: new TraceId('abcdef1234567890abcdef1234567890'),
+                spanId: new SpanId('1234567890abcdef'),
+            ),
+        );
+        // Don't call end() — the span is still running
+        $collector->onEnd($span);
+
+        $renderer = new DiagnosticsRenderer($registry, collector: $collector);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('running', $html);
+    }
+
+    #[Test]
+    public function renderEscapesHtmlSpecialChars(): void
+    {
+        $registry = new MetricRegistry();
+        $aggregator = new ErrorAggregator();
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('<script>alert("xss")</script>')));
+
+        $renderer = new DiagnosticsRenderer($registry, aggregator: $aggregator);
+        $html = $renderer->render();
+
+        self::assertStringNotContainsString('<script>', $html);
+        self::assertStringContainsString('&lt;script&gt;', $html);
+    }
+
+    #[Test]
+    public function renderShowsCounterWithLabelledValues(): void
+    {
+        $registry = new MetricRegistry();
+        $counter = $registry->counter('http_requests_total', 'Total HTTP requests');
+        $counter->increment(new LabelSet(['method' => 'GET']));
+        $counter->increment(new LabelSet(['method' => 'POST']));
+
+        $renderer = new DiagnosticsRenderer($registry);
+        $html = $renderer->render();
+
+        self::assertStringContainsString('http_requests_total', $html);
+    }
+}

--- a/tests/Unit/Observability/ErrorTracking/ErrorAggregatorTest.php
+++ b/tests/Unit/Observability/ErrorTracking/ErrorAggregatorTest.php
@@ -82,4 +82,33 @@ final class ErrorAggregatorTest extends TestCase
         self::assertSame(0, $aggregator->count());
         self::assertSame([], $aggregator->groups());
     }
+
+    #[Test]
+    public function addObserverCallsObserverOnCapture(): void
+    {
+        $aggregator = new ErrorAggregator();
+        $called = false;
+
+        $aggregator->addObserver(static function () use (&$called): void {
+            $called = true;
+        });
+
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('test')));
+
+        self::assertTrue($called);
+    }
+
+    #[Test]
+    public function observerExceptionDoesNotPreventCapture(): void
+    {
+        $aggregator = new ErrorAggregator();
+
+        $aggregator->addObserver(static function (): void {
+            throw new RuntimeException('observer failure');
+        });
+
+        $aggregator->capture(ErrorEvent::fromThrowable(new RuntimeException('test')));
+
+        self::assertSame(1, $aggregator->count());
+    }
 }

--- a/tests/Unit/Observability/ErrorTracking/ErrorGroupTest.php
+++ b/tests/Unit/Observability/ErrorTracking/ErrorGroupTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pulsar\Tests\Unit\Observability\ErrorTracking;
 
+use DateTimeImmutable;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
@@ -63,5 +64,29 @@ final class ErrorGroupTest extends TestCase
 
         self::assertSame(RuntimeException::class, $group->exceptionClass());
         self::assertSame('latest', $group->message());
+    }
+
+    #[Test]
+    public function exceptionClassReturnsNullWhenEmpty(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'));
+
+        self::assertNull($group->exceptionClass());
+    }
+
+    #[Test]
+    public function messageReturnsNullWhenEmpty(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'));
+
+        self::assertNull($group->message());
+    }
+
+    #[Test]
+    public function firstSeenIsSetOnConstruction(): void
+    {
+        $group = new ErrorGroup(new ErrorFingerprint('abc'));
+
+        self::assertInstanceOf(DateTimeImmutable::class, $group->firstSeen());
     }
 }

--- a/tests/Unit/Observability/Log/LogFormatterTest.php
+++ b/tests/Unit/Observability/Log/LogFormatterTest.php
@@ -1,0 +1,304 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Log;
+
+use DateTimeImmutable;
+use DateTimeZone;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Log\LogEntry;
+use Pulsar\Observability\Log\LogFormatter;
+use Pulsar\Observability\Log\LogLevel;
+use RuntimeException;
+use Stringable;
+
+#[CoversClass(LogFormatter::class)]
+final class LogFormatterTest extends TestCase
+{
+    private LogFormatter $formatter;
+
+    protected function setUp(): void
+    {
+        $this->formatter = new LogFormatter();
+    }
+
+    #[Test]
+    public function formatReturnsJsonLineWithNewline(): void
+    {
+        $entry = $this->createEntry(LogLevel::Info, 'hello world');
+
+        $result = $this->formatter->format($entry);
+
+        self::assertStringEndsWith("\n", $result);
+    }
+
+    #[Test]
+    public function formatOutputIsValidJson(): void
+    {
+        $entry = $this->createEntry(LogLevel::Error, 'an error occurred');
+
+        $result = $this->formatter->format($entry);
+
+        $decoded = json_decode(trim($result), true);
+        self::assertIsArray($decoded);
+    }
+
+    #[Test]
+    public function formatIncludesTimestampWithMicroseconds(): void
+    {
+        $timestamp = new DateTimeImmutable('2025-03-15T10:30:45.123456+00:00');
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: 'test',
+            context: [],
+            channel: 'app',
+            timestamp: $timestamp,
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('2025-03-15T10:30:45.123456+00:00', $data['timestamp']);
+    }
+
+    #[Test]
+    public function formatIncludesLevelValue(): void
+    {
+        $entry = $this->createEntry(LogLevel::Warning, 'watch out');
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('warning', $data['level']);
+    }
+
+    #[Test]
+    public function formatIncludesChannel(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Debug,
+            message: 'debug info',
+            context: [],
+            channel: 'security',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('security', $data['channel']);
+    }
+
+    #[Test]
+    public function formatIncludesInterpolatedMessage(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: 'User {username} logged in',
+            context: ['username' => 'alice'],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('User alice logged in', $data['message']);
+    }
+
+    #[Test]
+    public function formatInterpolatesStringableObjects(): void
+    {
+        $stringable = new class implements Stringable {
+            public function __toString(): string
+            {
+                return 'stringable-value';
+            }
+        };
+
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: 'Value is {obj}',
+            context: ['obj' => $stringable],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('Value is stringable-value', $data['message']);
+    }
+
+    #[Test]
+    public function formatSkipsNonStringNonStringableForInterpolation(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: 'Count is {count}',
+            context: ['count' => 42],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('Count is {count}', $data['message']);
+    }
+
+    #[Test]
+    public function formatOmitsContextKeyWhenContextIsEmpty(): void
+    {
+        $entry = $this->createEntry(LogLevel::Info, 'no context');
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertArrayNotHasKey('context', $data);
+    }
+
+    #[Test]
+    public function formatIncludesContextWhenNotEmpty(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: 'test',
+            context: ['key' => 'value'],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertArrayHasKey('context', $data);
+        self::assertSame(['key' => 'value'], $data['context']);
+    }
+
+    #[Test]
+    public function formatSerializesThrowableInContext(): void
+    {
+        $exception = new RuntimeException('Something went wrong', 42);
+
+        $entry = new LogEntry(
+            level: LogLevel::Error,
+            message: 'failure',
+            context: ['exception' => $exception],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertArrayHasKey('context', $data);
+        $context = $data['context'];
+        self::assertIsArray($context);
+        self::assertArrayHasKey('exception', $context);
+        $serialized = $context['exception'];
+        self::assertIsArray($serialized);
+        self::assertSame(RuntimeException::class, $serialized['class']);
+        self::assertSame('Something went wrong', $serialized['message']);
+        self::assertSame(42, $serialized['code']);
+        self::assertArrayHasKey('file', $serialized);
+        self::assertArrayHasKey('line', $serialized);
+        self::assertArrayHasKey('trace', $serialized);
+    }
+
+    #[Test]
+    public function formatPreservesNonThrowableContextValues(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Debug,
+            message: 'mixed context',
+            context: ['string' => 'hello', 'number' => 123, 'array' => [1, 2, 3]],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertArrayHasKey('context', $data);
+        $context = $data['context'];
+        self::assertIsArray($context);
+        self::assertSame('hello', $context['string']);
+        self::assertSame(123, $context['number']);
+        self::assertSame([1, 2, 3], $context['array']);
+    }
+
+    #[Test]
+    public function formatUsesUnescapedSlashesAndUnicode(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: 'path/to/file',
+            context: ['unicode' => "\u{00E9}"],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+
+        self::assertStringContainsString('path/to/file', $result);
+        self::assertStringContainsString("\u{00E9}", $result);
+    }
+
+    #[Test]
+    public function formatHandlesMultiplePlaceholders(): void
+    {
+        $entry = new LogEntry(
+            level: LogLevel::Info,
+            message: '{action} by {user} on {resource}',
+            context: ['action' => 'created', 'user' => 'bob', 'resource' => 'document'],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('now', new DateTimeZone('UTC')),
+        );
+
+        $result = $this->formatter->format($entry);
+        $data = json_decode(trim($result), true);
+
+        self::assertIsArray($data);
+        self::assertSame('created by bob on document', $data['message']);
+    }
+
+    #[Test]
+    public function formatHandlesAllLogLevels(): void
+    {
+        $levels = LogLevel::cases();
+
+        foreach ($levels as $level) {
+            $entry = $this->createEntry($level, 'test');
+            $result = $this->formatter->format($entry);
+            $data = json_decode(trim($result), true);
+
+            self::assertIsArray($data);
+            self::assertSame($level->value, $data['level']);
+        }
+    }
+
+    private function createEntry(LogLevel $level, string $message): LogEntry
+    {
+        return new LogEntry(
+            level: $level,
+            message: $message,
+            context: [],
+            channel: 'app',
+            timestamp: new DateTimeImmutable('2025-01-01T00:00:00.000000+00:00'),
+        );
+    }
+}

--- a/tests/Unit/Observability/Log/LogLevelTest.php
+++ b/tests/Unit/Observability/Log/LogLevelTest.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Log;
+
+use function count;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Log\LogLevel;
+
+#[CoversClass(LogLevel::class)]
+final class LogLevelTest extends TestCase
+{
+    #[Test]
+    public function hasAllEightPsr3Levels(): void
+    {
+        $cases = LogLevel::cases();
+
+        self::assertCount(8, $cases);
+    }
+
+    #[Test]
+    public function emergencyHasSeverityZero(): void
+    {
+        self::assertSame(0, LogLevel::Emergency->severity());
+    }
+
+    #[Test]
+    public function alertHasSeverityOne(): void
+    {
+        self::assertSame(1, LogLevel::Alert->severity());
+    }
+
+    #[Test]
+    public function criticalHasSeverityTwo(): void
+    {
+        self::assertSame(2, LogLevel::Critical->severity());
+    }
+
+    #[Test]
+    public function errorHasSeverityThree(): void
+    {
+        self::assertSame(3, LogLevel::Error->severity());
+    }
+
+    #[Test]
+    public function warningHasSeverityFour(): void
+    {
+        self::assertSame(4, LogLevel::Warning->severity());
+    }
+
+    #[Test]
+    public function noticeHasSeverityFive(): void
+    {
+        self::assertSame(5, LogLevel::Notice->severity());
+    }
+
+    #[Test]
+    public function infoHasSeveritySix(): void
+    {
+        self::assertSame(6, LogLevel::Info->severity());
+    }
+
+    #[Test]
+    public function debugHasSeveritySeven(): void
+    {
+        self::assertSame(7, LogLevel::Debug->severity());
+    }
+
+    #[Test]
+    public function severityDecreasesFromEmergencyToDebug(): void
+    {
+        $ordered = [
+            LogLevel::Emergency,
+            LogLevel::Alert,
+            LogLevel::Critical,
+            LogLevel::Error,
+            LogLevel::Warning,
+            LogLevel::Notice,
+            LogLevel::Info,
+            LogLevel::Debug,
+        ];
+
+        for ($i = 0; $i < count($ordered) - 1; $i++) {
+            self::assertLessThan(
+                $ordered[$i + 1]->severity(),
+                $ordered[$i]->severity(),
+                $ordered[$i]->name . ' should be more severe than ' . $ordered[$i + 1]->name,
+            );
+        }
+    }
+
+    #[Test]
+    public function meetsThresholdWhenMoreSevere(): void
+    {
+        self::assertTrue(LogLevel::Emergency->meetsThreshold(LogLevel::Error));
+        self::assertTrue(LogLevel::Critical->meetsThreshold(LogLevel::Warning));
+    }
+
+    #[Test]
+    public function meetsThresholdWhenEqualSeverity(): void
+    {
+        self::assertTrue(LogLevel::Error->meetsThreshold(LogLevel::Error));
+        self::assertTrue(LogLevel::Debug->meetsThreshold(LogLevel::Debug));
+    }
+
+    #[Test]
+    public function doesNotMeetThresholdWhenLessSevere(): void
+    {
+        self::assertFalse(LogLevel::Debug->meetsThreshold(LogLevel::Error));
+        self::assertFalse(LogLevel::Info->meetsThreshold(LogLevel::Warning));
+        self::assertFalse(LogLevel::Warning->meetsThreshold(LogLevel::Critical));
+    }
+
+    #[Test]
+    public function fromPsrLevelReturnsEnumInstanceAsIs(): void
+    {
+        $level = LogLevel::Error;
+
+        self::assertSame($level, LogLevel::fromPsrLevel($level));
+    }
+
+    #[Test]
+    public function fromPsrLevelParsesValidStrings(): void
+    {
+        self::assertSame(LogLevel::Emergency, LogLevel::fromPsrLevel('emergency'));
+        self::assertSame(LogLevel::Alert, LogLevel::fromPsrLevel('alert'));
+        self::assertSame(LogLevel::Critical, LogLevel::fromPsrLevel('critical'));
+        self::assertSame(LogLevel::Error, LogLevel::fromPsrLevel('error'));
+        self::assertSame(LogLevel::Warning, LogLevel::fromPsrLevel('warning'));
+        self::assertSame(LogLevel::Notice, LogLevel::fromPsrLevel('notice'));
+        self::assertSame(LogLevel::Info, LogLevel::fromPsrLevel('info'));
+        self::assertSame(LogLevel::Debug, LogLevel::fromPsrLevel('debug'));
+    }
+
+    #[Test]
+    public function fromPsrLevelDefaultsToDebugForUnknownString(): void
+    {
+        self::assertSame(LogLevel::Debug, LogLevel::fromPsrLevel('unknown'));
+        self::assertSame(LogLevel::Debug, LogLevel::fromPsrLevel(''));
+        self::assertSame(LogLevel::Debug, LogLevel::fromPsrLevel('EMERGENCY'));
+    }
+
+    #[Test]
+    public function stringBackedValuesMatchPsr3Names(): void
+    {
+        self::assertSame('emergency', LogLevel::Emergency->value);
+        self::assertSame('alert', LogLevel::Alert->value);
+        self::assertSame('critical', LogLevel::Critical->value);
+        self::assertSame('error', LogLevel::Error->value);
+        self::assertSame('warning', LogLevel::Warning->value);
+        self::assertSame('notice', LogLevel::Notice->value);
+        self::assertSame('info', LogLevel::Info->value);
+        self::assertSame('debug', LogLevel::Debug->value);
+    }
+}

--- a/tests/Unit/Observability/Log/LoggerTest.php
+++ b/tests/Unit/Observability/Log/LoggerTest.php
@@ -173,6 +173,64 @@ final class LoggerTest extends TestCase
         self::assertCount(1, $sink->entries);
         self::assertSame(LogLevel::Warning, $sink->entries[0]->level);
     }
+
+    #[Test]
+    public function fromConfigWithExtraSinks(): void
+    {
+        $extraSink = new CollectingSink();
+        $config = new ObservabilityConfig(
+            defaultLoggingChannel: 'app',
+            loggingLevel: 'debug',
+            loggingChannels: [],
+            audit: new \Pulsar\Config\AuditConfig(
+                enabled: false,
+                logPath: 'var/logs/audit.jsonl',
+                events: [],
+            ),
+        );
+
+        $logger = Logger::fromConfigWithExtraSinks($config, [$extraSink]);
+        $logger->info('extra sink test');
+
+        self::assertCount(1, $extraSink->entries);
+    }
+
+    #[Test]
+    public function createSinkReturnsNullForUnknownDriver(): void
+    {
+        $config = new ObservabilityConfig(
+            defaultLoggingChannel: 'custom',
+            loggingLevel: 'debug',
+            loggingChannels: [
+                new LoggingChannelConfig(
+                    name: 'custom',
+                    driver: 'unknown_driver',
+                ),
+            ],
+            audit: new \Pulsar\Config\AuditConfig(
+                enabled: false,
+                logPath: 'var/logs/audit.jsonl',
+                events: [],
+            ),
+        );
+
+        $logger = Logger::fromConfig($config);
+
+        // Logger should be created even with unknown driver — it just has no sinks
+        self::assertInstanceOf(Logger::class, $logger);
+    }
+
+    #[Test]
+    public function logMethodFallsBackToDebugForNonStringLevel(): void
+    {
+        $sink = new CollectingSink();
+        $logger = new Logger([$sink], LogLevel::Debug);
+
+        $logger->log(42, 'non-string level');
+
+        self::assertCount(1, $sink->entries);
+        self::assertSame(LogLevel::Debug, $sink->entries[0]->level);
+    }
 }
 
 /**

--- a/tests/Unit/Observability/Metrics/MetricSnapshotTest.php
+++ b/tests/Unit/Observability/Metrics/MetricSnapshotTest.php
@@ -1,0 +1,212 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Observability\Metrics;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Observability\Metrics\Counter;
+use Pulsar\Observability\Metrics\Gauge;
+use Pulsar\Observability\Metrics\Histogram;
+use Pulsar\Observability\Metrics\LabelSet;
+use Pulsar\Observability\Metrics\MetricSnapshot;
+use Pulsar\Observability\Metrics\MetricType;
+use ReflectionClass;
+
+#[CoversClass(MetricSnapshot::class)]
+final class MetricSnapshotTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsAllProperties(): void
+    {
+        $values = ['method=GET' => 5.0];
+        $snapshot = new MetricSnapshot(
+            name: 'http_requests_total',
+            type: MetricType::Counter,
+            help: 'Total HTTP requests',
+            values: $values,
+        );
+
+        self::assertSame('http_requests_total', $snapshot->name);
+        self::assertSame(MetricType::Counter, $snapshot->type);
+        self::assertSame('Total HTTP requests', $snapshot->help);
+        self::assertSame($values, $snapshot->values);
+        self::assertNull($snapshot->series);
+    }
+
+    #[Test]
+    public function constructorDefaultsToEmptyValuesAndNullSeries(): void
+    {
+        $snapshot = new MetricSnapshot(
+            name: 'test_metric',
+            type: MetricType::Gauge,
+            help: 'A test metric',
+        );
+
+        self::assertSame([], $snapshot->values);
+        self::assertNull($snapshot->series);
+    }
+
+    #[Test]
+    public function constructorAcceptsSeriesData(): void
+    {
+        $series = [
+            '' => [
+                'buckets' => ['0.005' => 0, '0.01' => 1],
+                'sum' => 0.008,
+                'count' => 1,
+            ],
+        ];
+
+        $snapshot = new MetricSnapshot(
+            name: 'request_duration',
+            type: MetricType::Histogram,
+            help: 'Request duration',
+            series: $series,
+        );
+
+        self::assertSame($series, $snapshot->series);
+    }
+
+    #[Test]
+    public function fromCounterCreatesSnapshotWithCounterType(): void
+    {
+        $counter = new Counter('requests_total', 'Total requests');
+        $counter->increment();
+        $counter->increment(value: 4.0);
+
+        $snapshot = MetricSnapshot::fromCounter($counter);
+
+        self::assertSame('requests_total', $snapshot->name);
+        self::assertSame(MetricType::Counter, $snapshot->type);
+        self::assertSame('Total requests', $snapshot->help);
+        self::assertSame($counter->values(), $snapshot->values);
+        self::assertNull($snapshot->series);
+    }
+
+    #[Test]
+    public function fromCounterCapturesLabeledValues(): void
+    {
+        $counter = new Counter('http_requests', 'HTTP request counter');
+        $get = new LabelSet(['method' => 'GET']);
+        $post = new LabelSet(['method' => 'POST']);
+
+        $counter->increment($get);
+        $counter->increment($get);
+        $counter->increment($post);
+
+        $snapshot = MetricSnapshot::fromCounter($counter);
+
+        self::assertSame(2.0, $snapshot->values['method=GET']);
+        self::assertSame(1.0, $snapshot->values['method=POST']);
+    }
+
+    #[Test]
+    public function fromCounterHandlesEmptyCounter(): void
+    {
+        $counter = new Counter('empty_counter', 'No increments');
+
+        $snapshot = MetricSnapshot::fromCounter($counter);
+
+        self::assertSame([], $snapshot->values);
+    }
+
+    #[Test]
+    public function fromGaugeCreatesSnapshotWithGaugeType(): void
+    {
+        $gauge = new Gauge('active_connections', 'Active connections');
+        $gauge->set(42.0);
+
+        $snapshot = MetricSnapshot::fromGauge($gauge);
+
+        self::assertSame('active_connections', $snapshot->name);
+        self::assertSame(MetricType::Gauge, $snapshot->type);
+        self::assertSame('Active connections', $snapshot->help);
+        self::assertSame($gauge->values(), $snapshot->values);
+        self::assertNull($snapshot->series);
+    }
+
+    #[Test]
+    public function fromGaugeCapturesCurrentValue(): void
+    {
+        $gauge = new Gauge('temperature', 'Current temp');
+        $gauge->set(23.5);
+        $gauge->increment();
+        $gauge->decrement(value: 0.5);
+
+        $snapshot = MetricSnapshot::fromGauge($gauge);
+
+        self::assertSame(24.0, $snapshot->values['']);
+    }
+
+    #[Test]
+    public function fromGaugeHandlesEmptyGauge(): void
+    {
+        $gauge = new Gauge('empty_gauge', 'No values set');
+
+        $snapshot = MetricSnapshot::fromGauge($gauge);
+
+        self::assertSame([], $snapshot->values);
+    }
+
+    #[Test]
+    public function fromHistogramCreatesSnapshotWithHistogramType(): void
+    {
+        $histogram = new Histogram('request_duration', 'Request duration in seconds', [0.1, 0.5, 1.0]);
+        $histogram->observe(0.25);
+
+        $snapshot = MetricSnapshot::fromHistogram($histogram);
+
+        self::assertSame('request_duration', $snapshot->name);
+        self::assertSame(MetricType::Histogram, $snapshot->type);
+        self::assertSame('Request duration in seconds', $snapshot->help);
+        self::assertSame([], $snapshot->values);
+        self::assertIsArray($snapshot->series);
+    }
+
+    #[Test]
+    public function fromHistogramCapturesBucketsSumAndCount(): void
+    {
+        $histogram = new Histogram('latency', 'Latency', [0.1, 0.5, 1.0]);
+        $histogram->observe(0.05);
+        $histogram->observe(0.3);
+
+        $snapshot = MetricSnapshot::fromHistogram($histogram);
+
+        self::assertIsArray($snapshot->series);
+        self::assertArrayHasKey('', $snapshot->series);
+
+        $seriesData = $snapshot->series[''];
+        self::assertArrayHasKey('buckets', $seriesData);
+        self::assertArrayHasKey('sum', $seriesData);
+        self::assertArrayHasKey('count', $seriesData);
+        self::assertSame(2, $seriesData['count']);
+        self::assertEqualsWithDelta(0.35, $seriesData['sum'], 0.0001);
+    }
+
+    #[Test]
+    public function fromHistogramHandlesEmptyHistogram(): void
+    {
+        $histogram = new Histogram('empty_histogram', 'No observations', [0.1, 0.5]);
+
+        $snapshot = MetricSnapshot::fromHistogram($histogram);
+
+        self::assertIsArray($snapshot->series);
+        self::assertSame([], $snapshot->series);
+    }
+
+    #[Test]
+    public function snapshotIsReadonly(): void
+    {
+        $snapshot = new MetricSnapshot(
+            name: 'test',
+            type: MetricType::Counter,
+            help: 'test help',
+        );
+
+        $reflection = new ReflectionClass($snapshot);
+        self::assertTrue($reflection->isReadOnly());
+    }
+}

--- a/tests/Unit/Observability/Tracing/SpanIdTest.php
+++ b/tests/Unit/Observability/Tracing/SpanIdTest.php
@@ -41,4 +41,12 @@ final class SpanIdTest extends TestCase
 
         new SpanId('invalid');
     }
+
+    #[Test]
+    public function toStringReturnsValue(): void
+    {
+        $id = new SpanId('00f067aa0ba902b7');
+
+        self::assertSame('00f067aa0ba902b7', $id->toString());
+    }
 }

--- a/tests/Unit/Observability/Tracing/SpanTest.php
+++ b/tests/Unit/Observability/Tracing/SpanTest.php
@@ -97,4 +97,28 @@ final class SpanTest extends TestCase
         self::assertNotNull($seconds);
         self::assertGreaterThanOrEqual(0.0, $seconds);
     }
+
+    #[Test]
+    public function durationSecondsReturnsNullWhenNotEnded(): void
+    {
+        $span = new Span('test', TraceContext::create());
+
+        self::assertNull($span->durationSeconds());
+    }
+
+    #[Test]
+    public function startTimeReturnsPositiveValue(): void
+    {
+        $span = new Span('test', TraceContext::create());
+
+        self::assertGreaterThan(0, $span->startTime());
+    }
+
+    #[Test]
+    public function parentSpanIdIsNullByDefault(): void
+    {
+        $span = new Span('test', TraceContext::create());
+
+        self::assertNull($span->parentSpanId);
+    }
 }

--- a/tests/Unit/Observability/Tracing/TraceIdTest.php
+++ b/tests/Unit/Observability/Tracing/TraceIdTest.php
@@ -41,4 +41,12 @@ final class TraceIdTest extends TestCase
 
         new TraceId('not-valid');
     }
+
+    #[Test]
+    public function toStringReturnsValue(): void
+    {
+        $id = new TraceId('4bf92f3577b34da6a3ce929d0e0e4736');
+
+        self::assertSame('4bf92f3577b34da6a3ce929d0e0e4736', $id->toString());
+    }
 }

--- a/tests/Unit/Routing/RouteGroupTest.php
+++ b/tests/Unit/Routing/RouteGroupTest.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Routing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Http\Method;
+use Pulsar\Routing\Route;
+use Pulsar\Routing\RouteGroup;
+
+#[CoversClass(RouteGroup::class)]
+final class RouteGroupTest extends TestCase
+{
+    #[Test]
+    public function getPrefixReturnsPrefix(): void
+    {
+        $group = new RouteGroup(prefix: '/api');
+
+        self::assertSame('/api', $group->getPrefix());
+    }
+
+    #[Test]
+    public function getMiddlewareReturnsMiddleware(): void
+    {
+        $group = new RouteGroup(middleware: ['auth', 'throttle']);
+
+        self::assertSame(['auth', 'throttle'], $group->getMiddleware());
+    }
+
+    #[Test]
+    public function getAttributesReturnsAttributes(): void
+    {
+        $group = new RouteGroup(attributes: ['version' => 'v1']);
+
+        self::assertSame(['version' => 'v1'], $group->getAttributes());
+    }
+
+    #[Test]
+    public function flattenSingleRoute(): void
+    {
+        $group = new RouteGroup(prefix: '/api');
+        $group->add(new Route(
+            methods: [Method::GET],
+            path: '/users',
+            handler: static fn(): string => 'ok',
+            name: 'api.users',
+        ));
+
+        $routes = $group->flatten();
+
+        self::assertCount(1, $routes);
+        self::assertSame('/api/users', $routes[0]->path);
+        self::assertSame('api.users', $routes[0]->name);
+    }
+
+    #[Test]
+    public function flattenCombinesMiddleware(): void
+    {
+        $group = new RouteGroup(
+            prefix: '/admin',
+            middleware: ['auth'],
+        );
+        $group->add(new Route(
+            methods: [Method::GET],
+            path: '/dashboard',
+            handler: static fn(): string => 'ok',
+            middleware: ['throttle'],
+        ));
+
+        $routes = $group->flatten();
+
+        self::assertSame(['auth', 'throttle'], $routes[0]->middleware);
+    }
+
+    #[Test]
+    public function flattenCombinesAttributes(): void
+    {
+        $group = new RouteGroup(
+            prefix: '/admin',
+            attributes: ['section' => 'admin'],
+        );
+        $group->add(new Route(
+            methods: [Method::GET],
+            path: '/users',
+            handler: static fn(): string => 'ok',
+            attributes: ['permissions' => ['users.list']],
+        ));
+
+        $routes = $group->flatten();
+
+        self::assertSame('admin', $routes[0]->attributes['section']);
+        self::assertSame(['users.list'], $routes[0]->attributes['permissions']);
+    }
+
+    #[Test]
+    public function flattenNestedGroups(): void
+    {
+        $inner = new RouteGroup(prefix: '/v1');
+        $inner->add(new Route(
+            methods: [Method::GET],
+            path: '/items',
+            handler: static fn(): string => 'ok',
+        ));
+
+        $outer = new RouteGroup(prefix: '/api');
+        $outer->group($inner);
+
+        $routes = $outer->flatten();
+
+        self::assertCount(1, $routes);
+        self::assertSame('/api/v1/items', $routes[0]->path);
+    }
+
+    #[Test]
+    public function flattenUsesGroupHostAsDefault(): void
+    {
+        $group = new RouteGroup(prefix: '/api', host: 'api.example.com');
+        $group->add(new Route(
+            methods: [Method::GET],
+            path: '/users',
+            handler: static fn(): string => 'ok',
+        ));
+
+        $routes = $group->flatten();
+
+        self::assertSame('api.example.com', $routes[0]->host);
+    }
+
+    #[Test]
+    public function flattenRouteHostOverridesGroupHost(): void
+    {
+        $group = new RouteGroup(prefix: '/api', host: 'api.example.com');
+        $group->add(new Route(
+            methods: [Method::GET],
+            path: '/special',
+            handler: static fn(): string => 'ok',
+            host: 'special.example.com',
+        ));
+
+        $routes = $group->flatten();
+
+        self::assertSame('special.example.com', $routes[0]->host);
+    }
+
+    #[Test]
+    public function addReturnsSelf(): void
+    {
+        $group = new RouteGroup();
+        $result = $group->add(new Route(
+            methods: [Method::GET],
+            path: '/',
+            handler: static fn(): string => 'ok',
+        ));
+
+        self::assertSame($group, $result);
+    }
+
+    #[Test]
+    public function groupReturnsSelf(): void
+    {
+        $group = new RouteGroup();
+        $result = $group->group(new RouteGroup());
+
+        self::assertSame($group, $result);
+    }
+}

--- a/tests/Unit/Routing/RouterTest.php
+++ b/tests/Unit/Routing/RouterTest.php
@@ -460,4 +460,50 @@ final class MatchedRouteTest extends TestCase
 
         self::assertSame(['auth', 'log'], $matched->getMiddleware());
     }
+
+    #[Test]
+    public function hasParameterReturnsTrueWhenPresent(): void
+    {
+        $route = Route::get('/test/{slug}', fn() => null, 'test');
+        $matched = new MatchedRoute($route, ['slug' => 'hello']);
+
+        self::assertTrue($matched->hasParameter('slug'));
+    }
+
+    #[Test]
+    public function hasParameterReturnsFalseWhenMissing(): void
+    {
+        $route = Route::get('/test', fn() => null, 'test');
+        $matched = new MatchedRoute($route);
+
+        self::assertFalse($matched->hasParameter('slug'));
+    }
+
+    #[Test]
+    public function getHandlerDelegatesToRoute(): void
+    {
+        $handler = static fn() => 'ok';
+        $route = new Route([Method::GET], '/test', $handler);
+        $matched = new MatchedRoute($route);
+
+        self::assertSame($handler, $matched->getHandler());
+    }
+
+    #[Test]
+    public function getNameDelegatesToRoute(): void
+    {
+        $route = Route::get('/test', fn() => null, 'test.route');
+        $matched = new MatchedRoute($route);
+
+        self::assertSame('test.route', $matched->getName());
+    }
+
+    #[Test]
+    public function getNameReturnsNullWhenUnset(): void
+    {
+        $route = new Route([Method::GET], '/test', fn() => null);
+        $matched = new MatchedRoute($route);
+
+        self::assertNull($matched->getName());
+    }
 }

--- a/tests/Unit/Routing/RoutingExceptionTest.php
+++ b/tests/Unit/Routing/RoutingExceptionTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Routing;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Http\Method;
+use Pulsar\Routing\RoutingException;
+
+#[CoversClass(RoutingException::class)]
+final class RoutingExceptionTest extends TestCase
+{
+    #[Test]
+    public function notFoundCreatesExceptionWithPath(): void
+    {
+        $exception = RoutingException::notFound('/users/42');
+
+        self::assertStringContainsString('/users/42', $exception->getMessage());
+        self::assertSame(404, $exception->getCode());
+    }
+
+    #[Test]
+    public function isNotFoundReturnsTrueFor404(): void
+    {
+        $exception = RoutingException::notFound('/test');
+
+        self::assertTrue($exception->isNotFound());
+        self::assertFalse($exception->isMethodNotAllowed());
+    }
+
+    #[Test]
+    public function methodNotAllowedCreatesExceptionWithDetails(): void
+    {
+        $exception = RoutingException::methodNotAllowed(
+            '/users',
+            Method::POST,
+            [Method::GET, Method::HEAD],
+        );
+
+        self::assertStringContainsString('POST', $exception->getMessage());
+        self::assertStringContainsString('/users', $exception->getMessage());
+        self::assertSame(405, $exception->getCode());
+    }
+
+    #[Test]
+    public function isMethodNotAllowedReturnsTrueFor405(): void
+    {
+        $exception = RoutingException::methodNotAllowed(
+            '/test',
+            Method::DELETE,
+            [Method::GET],
+        );
+
+        self::assertTrue($exception->isMethodNotAllowed());
+        self::assertFalse($exception->isNotFound());
+    }
+
+    #[Test]
+    public function getAllowHeaderReturnsFormattedMethods(): void
+    {
+        $exception = RoutingException::methodNotAllowed(
+            '/test',
+            Method::POST,
+            [Method::GET, Method::HEAD, Method::OPTIONS],
+        );
+
+        self::assertSame('GET, HEAD, OPTIONS', $exception->getAllowHeader());
+    }
+
+    #[Test]
+    public function getAllowHeaderReturnsEmptyForNotFound(): void
+    {
+        $exception = RoutingException::notFound('/test');
+
+        self::assertSame('', $exception->getAllowHeader());
+    }
+
+    #[Test]
+    public function allowedMethodsPropertyIsSetByMethodNotAllowed(): void
+    {
+        $exception = RoutingException::methodNotAllowed(
+            '/test',
+            Method::POST,
+            [Method::GET, Method::PUT],
+        );
+
+        self::assertSame([Method::GET, Method::PUT], $exception->allowedMethods);
+    }
+
+    #[Test]
+    public function routerLockedCreatesExceptionWith423(): void
+    {
+        $exception = RoutingException::routerLocked();
+
+        self::assertSame(423, $exception->getCode());
+        self::assertStringContainsString('locked', $exception->getMessage());
+        self::assertStringContainsString('strict', $exception->getMessage());
+    }
+}

--- a/tests/Unit/Studio/Console/Event/Payload/JobPayloadTest.php
+++ b/tests/Unit/Studio/Console/Event/Payload/JobPayloadTest.php
@@ -1,0 +1,263 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Studio\Console\Event\Payload;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Studio\Console\Event\ConsoleEvent;
+use Pulsar\Studio\Console\Event\EventType;
+use Pulsar\Studio\Console\Event\EventVersion;
+use Pulsar\Studio\Console\Event\Payload\JobPayload;
+
+#[CoversClass(JobPayload::class)]
+final class JobPayloadTest extends TestCase
+{
+    #[Test]
+    public function implementsConsoleEventInterface(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'completed',
+        );
+
+        self::assertInstanceOf(ConsoleEvent::class, $payload);
+    }
+
+    #[Test]
+    public function constructorSetsRequiredProperties(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\ProcessPayment',
+            status: 'processing',
+        );
+
+        self::assertSame('App\\Jobs\\ProcessPayment', $payload->jobClass);
+        self::assertSame('processing', $payload->status);
+    }
+
+    #[Test]
+    public function constructorSetsOptionalPropertiesToDefaults(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'queued',
+        );
+
+        self::assertNull($payload->queue);
+        self::assertNull($payload->durationMs);
+        self::assertNull($payload->errorMessage);
+        self::assertSame(1, $payload->attempts);
+        self::assertNull($payload->connection);
+    }
+
+    #[Test]
+    public function constructorSetsAllOptionalProperties(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\GenerateReport',
+            status: 'failed',
+            queue: 'high',
+            durationMs: 1500.75,
+            errorMessage: 'Connection timeout',
+            attempts: 3,
+            connection: 'redis',
+        );
+
+        self::assertSame('App\\Jobs\\GenerateReport', $payload->jobClass);
+        self::assertSame('failed', $payload->status);
+        self::assertSame('high', $payload->queue);
+        self::assertSame(1500.75, $payload->durationMs);
+        self::assertSame('Connection timeout', $payload->errorMessage);
+        self::assertSame(3, $payload->attempts);
+        self::assertSame('redis', $payload->connection);
+    }
+
+    #[Test]
+    public function eventTypeReturnsJobQueuedForQueuedStatus(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'queued',
+        );
+
+        self::assertSame(EventType::JobQueued, $payload->eventType());
+    }
+
+    #[Test]
+    public function eventTypeReturnsJobProcessingForProcessingStatus(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'processing',
+        );
+
+        self::assertSame(EventType::JobProcessing, $payload->eventType());
+    }
+
+    #[Test]
+    public function eventTypeReturnsJobCompletedForCompletedStatus(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'completed',
+        );
+
+        self::assertSame(EventType::JobCompleted, $payload->eventType());
+    }
+
+    #[Test]
+    public function eventTypeReturnsJobFailedForFailedStatus(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'failed',
+        );
+
+        self::assertSame(EventType::JobFailed, $payload->eventType());
+    }
+
+    #[Test]
+    public function eventTypeReturnsJobFailedForUnknownStatus(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'unknown_status',
+        );
+
+        self::assertSame(EventType::JobFailed, $payload->eventType());
+    }
+
+    #[Test]
+    public function schemaVersionReturnsV1(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'queued',
+        );
+
+        self::assertSame(EventVersion::V1, $payload->schemaVersion());
+    }
+
+    #[Test]
+    public function toArrayContainsAllExpectedKeys(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\SendEmail',
+            status: 'completed',
+        );
+
+        $array = $payload->toArray();
+
+        self::assertArrayHasKey('job_class', $array);
+        self::assertArrayHasKey('status', $array);
+        self::assertArrayHasKey('queue', $array);
+        self::assertArrayHasKey('duration_ms', $array);
+        self::assertArrayHasKey('error_message', $array);
+        self::assertArrayHasKey('attempts', $array);
+        self::assertArrayHasKey('connection', $array);
+    }
+
+    #[Test]
+    public function toArrayReturnsCorrectValues(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\ProcessPayment',
+            status: 'failed',
+            queue: 'critical',
+            durationMs: 250.5,
+            errorMessage: 'Insufficient funds',
+            attempts: 2,
+            connection: 'database',
+        );
+
+        $array = $payload->toArray();
+
+        self::assertSame('App\\Jobs\\ProcessPayment', $array['job_class']);
+        self::assertSame('failed', $array['status']);
+        self::assertSame('critical', $array['queue']);
+        self::assertSame(250.5, $array['duration_ms']);
+        self::assertSame('Insufficient funds', $array['error_message']);
+        self::assertSame(2, $array['attempts']);
+        self::assertSame('database', $array['connection']);
+    }
+
+    #[Test]
+    public function toArrayHandlesNullOptionalFields(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\Cleanup',
+            status: 'queued',
+        );
+
+        $array = $payload->toArray();
+
+        self::assertNull($array['queue']);
+        self::assertNull($array['duration_ms']);
+        self::assertNull($array['error_message']);
+        self::assertSame(1, $array['attempts']);
+        self::assertNull($array['connection']);
+    }
+
+    #[Test]
+    public function handlesZeroDuration(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\NoOp',
+            status: 'completed',
+            durationMs: 0.0,
+        );
+
+        self::assertSame(0.0, $payload->durationMs);
+        self::assertSame(0.0, $payload->toArray()['duration_ms']);
+    }
+
+    #[Test]
+    public function handlesZeroAttempts(): void
+    {
+        $payload = new JobPayload(
+            jobClass: 'App\\Jobs\\NoOp',
+            status: 'queued',
+            attempts: 0,
+        );
+
+        self::assertSame(0, $payload->attempts);
+        self::assertSame(0, $payload->toArray()['attempts']);
+    }
+
+    #[Test]
+    public function handlesDifferentQueueNames(): void
+    {
+        $queues = ['default', 'high', 'low', 'critical', 'emails', 'reports'];
+
+        foreach ($queues as $queue) {
+            $payload = new JobPayload(
+                jobClass: 'App\\Jobs\\Test',
+                status: 'queued',
+                queue: $queue,
+            );
+
+            self::assertSame($queue, $payload->queue);
+            self::assertSame($queue, $payload->toArray()['queue']);
+        }
+    }
+
+    #[Test]
+    public function handlesDifferentConnectionNames(): void
+    {
+        $connections = ['redis', 'database', 'sqs', 'beanstalkd', 'sync'];
+
+        foreach ($connections as $connection) {
+            $payload = new JobPayload(
+                jobClass: 'App\\Jobs\\Test',
+                status: 'processing',
+                connection: $connection,
+            );
+
+            self::assertSame($connection, $payload->connection);
+            self::assertSame($connection, $payload->toArray()['connection']);
+        }
+    }
+}

--- a/tests/Unit/Studio/Exception/StudioExceptionTest.php
+++ b/tests/Unit/Studio/Exception/StudioExceptionTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Studio\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Studio\Exception\StudioException;
+use RuntimeException;
+
+#[CoversClass(StudioException::class)]
+final class StudioExceptionTest extends TestCase
+{
+    #[Test]
+    public function extendsRuntimeException(): void
+    {
+        $exception = StudioException::notEnabled();
+
+        self::assertInstanceOf(RuntimeException::class, $exception);
+    }
+
+    #[Test]
+    public function storageNotWritableContainsPath(): void
+    {
+        $exception = StudioException::storageNotWritable('/var/studio/data');
+
+        self::assertSame('Studio storage path is not writable: /var/studio/data', $exception->getMessage());
+    }
+
+    #[Test]
+    public function storeBusyContainsAttempts(): void
+    {
+        $exception = StudioException::storeBusy(5);
+
+        self::assertSame('Studio storage busy after 5 attempts', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function storeBusyChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('Lock timeout');
+        $exception = StudioException::storeBusy(3, $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+        self::assertStringContainsString('3 attempts', $exception->getMessage());
+    }
+
+    #[Test]
+    public function exportRequiresDecryptionKeyHasFixedMessage(): void
+    {
+        $exception = StudioException::exportRequiresDecryptionKey();
+
+        self::assertStringContainsString('PULSAR_MASTER_KEY', $exception->getMessage());
+        self::assertStringContainsString('Cannot export', $exception->getMessage());
+        self::assertStringContainsString('chain verification', $exception->getMessage());
+    }
+
+    #[Test]
+    public function schemaFailedContainsReason(): void
+    {
+        $exception = StudioException::schemaFailed('table creation failed');
+
+        self::assertSame('Studio schema error: table creation failed', $exception->getMessage());
+        self::assertNull($exception->getPrevious());
+    }
+
+    #[Test]
+    public function schemaFailedChainsPreviousException(): void
+    {
+        $previous = new RuntimeException('SQLite error');
+        $exception = StudioException::schemaFailed('migration error', $previous);
+
+        self::assertSame($previous, $exception->getPrevious());
+    }
+
+    #[Test]
+    public function chainBrokenContainsIndexAndReason(): void
+    {
+        $exception = StudioException::chainBroken(42, 'hash mismatch');
+
+        self::assertSame('Evidence chain broken at link 42: hash mismatch', $exception->getMessage());
+    }
+
+    #[Test]
+    public function chainBrokenAtZeroIndex(): void
+    {
+        $exception = StudioException::chainBroken(0, 'missing genesis block');
+
+        self::assertSame('Evidence chain broken at link 0: missing genesis block', $exception->getMessage());
+    }
+
+    #[Test]
+    public function notEnabledHasFixedMessage(): void
+    {
+        $exception = StudioException::notEnabled();
+
+        self::assertSame('Studio is not enabled', $exception->getMessage());
+    }
+
+    #[Test]
+    public function serverStartFailedContainsReason(): void
+    {
+        $exception = StudioException::serverStartFailed('port 8080 already in use');
+
+        self::assertSame('Studio server failed to start: port 8080 already in use', $exception->getMessage());
+    }
+
+    #[Test]
+    public function accessDeniedWithDefaultReason(): void
+    {
+        $exception = StudioException::accessDenied();
+
+        self::assertSame('Studio access denied: unauthorized', $exception->getMessage());
+    }
+
+    #[Test]
+    public function accessDeniedWithCustomReason(): void
+    {
+        $exception = StudioException::accessDenied('IP not whitelisted');
+
+        self::assertSame('Studio access denied: IP not whitelisted', $exception->getMessage());
+    }
+
+    #[Test]
+    public function invalidConfigContainsReason(): void
+    {
+        $exception = StudioException::invalidConfig('port must be an integer');
+
+        self::assertSame('Invalid Studio configuration: port must be an integer', $exception->getMessage());
+    }
+
+    #[Test]
+    public function invalidArchiveContainsReason(): void
+    {
+        $exception = StudioException::invalidArchive('checksum mismatch');
+
+        self::assertSame('Invalid Studio archive: checksum mismatch', $exception->getMessage());
+    }
+}

--- a/tools/php/phpunit.xml
+++ b/tools/php/phpunit.xml
@@ -22,6 +22,7 @@
     <source>
         <include>
             <directory>../../src</directory>
+            <directory>../../extensions/payments/src</directory>
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
## Summary

- **Payments extension** (`extensions/payments/`): vendor-agnostic payment processing with domain model (Money, Currency, PaymentIntent, Charge, Refund, Dispute), contracts, and two test providers (NullProvider, SimulatorProvider)
- **PaymentGateway orchestrator** with atomic claim-based idempotency enforcement, canonical parameter hashing, tamper-evident audit logging via AuditLogger, and MetricRegistry counters
- **Webhook subsystem**: HMAC-SHA256 signature verification with multi-signature rotation support, replay prevention with record-after-success ordering, Fiber-safe in-memory event log
- **158 new tests** across 18 test classes covering domain, contracts, gateway, webhooks, idempotency, parameter hashing, configuration, and exceptions

## Test plan

- [x] All 158 payment extension tests pass (`vendor/bin/phpunit tests/Unit/Extension/Payments/`)
- [x] Full suite passes (3748 tests, 0 failures)
- [x] PHPStan level max: 0 errors
- [x] Psalm level 1: 0 errors
- [x] PHP-CS-Fixer: clean
- [x] Prettier: clean

## Linked Issues
Resolves #73
Resolves #78
