### PR TITLE
feat(security): harden 2FA + add social SSO extension + auth security docs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -43,6 +43,7 @@
       "Pulsar\\Extension\\Payments\\": "extensions/payments/src/",
       "Pulsar\\Extension\\Psr7Bridge\\": "extensions/psr7-bridge/src/",
       "Pulsar\\Extension\\ObservabilityExport\\": "extensions/observability-export/src/",
+      "Pulsar\\Extension\\SocialSso\\": "extensions/social-sso/src/",
       "Pulsar\\Extension\\Studio\\": "extensions/studio/src/"
     }
   },

--- a/config/security.php
+++ b/config/security.php
@@ -80,6 +80,14 @@ return [
             'code_period' => 30,
             'verification_window' => 1,
             'recovery_code_count' => 8,
+            // Bytes of entropy per recovery code (8 = 64-bit, 4 = 32-bit legacy)
+            'recovery_code_bytes' => 8,
+            // Minutes before step-up authentication expires
+            'step_up_timeout_minutes' => 15,
+            // Recovery code algorithm version (2 = 64-bit hashed, 1 = 32-bit plaintext legacy)
+            'recovery_code_algorithm_version' => 2,
+            // Set to true to suppress warnings about in-memory stores in production
+            'allow_in_memory' => false,
         ],
 
         'authorization' => [

--- a/docs/AUTH_SECURITY.md
+++ b/docs/AUTH_SECURITY.md
@@ -1,0 +1,346 @@
+# Authentication Security
+
+Threat model, secure defaults, and deployment guidance for Pulsar's authentication subsystems: two-factor authentication (2FA), social single sign-on (SSO), session management, and step-up re-authentication.
+
+---
+
+## Threat Model
+
+### Authentication Threats
+
+| Threat                       | Attack vector                                                     | Mitigation                                                                                                                          |
+| ---------------------------- | ----------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------- |
+| Credential stuffing          | Automated login attempts using leaked credential lists            | Rate limiting via `TwoFactorRateLimiterInterface` with `ip`, `user_agent_hash`, `device_id` context keys; audit trail for detection |
+| Brute force (TOTP)           | Exhaustive 6-digit code enumeration (10^6 combinations)           | Rate limiter blocks after threshold; replay guard prevents reuse of already-accepted time steps                                     |
+| Session hijacking            | Stolen session cookie via XSS or network sniffing                 | `HttpOnly`, `Secure`, `SameSite=Strict` cookie flags; session regeneration on privilege escalation                                  |
+| Session fixation             | Attacker pre-sets session ID before victim authenticates          | `regenerate()` called after 2FA verification and step-up authentication; `use_strict_mode` rejects uninitialized session IDs        |
+| TOTP replay                  | Re-submitting a previously valid TOTP code within the time window | Replay guard keyed on `(identityId, purpose, timeStep)` rejects duplicate time steps                                                |
+| TOTP clock drift abuse       | Submitting codes from far-future or far-past time steps           | Verification window limits accepted time steps (default: 1 step = +/- 30 seconds)                                                   |
+| Recovery code guessing       | Brute-forcing 64-bit recovery codes                               | 64-bit entropy (2^64 combinations); BLAKE2b HMAC hashing; rate limiter integration                                                  |
+| Recovery code race condition | Two concurrent requests consuming the same recovery code          | Atomic `consume()` in `RecoveryCodeStoreInterface`; exactly one request succeeds, the other receives `AlreadyUsed`                  |
+
+### SSO / OAuth Threats
+
+| Threat                       | Attack vector                                                      | Mitigation                                                                                                                                                                              |
+| ---------------------------- | ------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| State parameter CSRF         | Attacker initiates OAuth flow and tricks victim into completing it | 256-bit random state tokens; one-time consume on verification; TTL expiry (default: 300 seconds)                                                                                        |
+| Nonce replay                 | Reusing an ID token nonce across sessions                          | Session-backed nonce storage; one-time consume via `hash_equals()`; verified only from `IdTokenClaims` (post-signature-verification), never from unverified claims                      |
+| PKCE downgrade               | Forcing plain code challenge method instead of S256                | S256-only enforcement; `plain` method is not supported                                                                                                                                  |
+| Authorization code injection | Substituting a stolen authorization code in the callback           | PKCE verifier bound to state token; code exchange requires matching verifier                                                                                                            |
+| Token leakage                | Secrets exposed in logs, error messages, or debug output           | `#[\SensitiveParameter]` on all `$code`, `$secret`, `$accessToken`, `$refreshToken`, `$idToken` parameters; `__debugInfo()` redaction on `OAuthTokenSet`, `ProviderConfig`, `MasterKey` |
+| Open redirector              | Manipulating redirect URI to exfiltrate authorization codes        | Redirect URIs resolved from `ProviderConfig` only; `CallbackController` never reads redirect URI from request parameters                                                                |
+| ID token signature bypass    | Forged or unsigned ID tokens accepted as valid                     | `alg: "none"` rejected unconditionally; JWKS signature verification required; unsupported algorithms rejected                                                                           |
+| ID token claim manipulation  | Tampered claims (wrong issuer, expired, wrong audience)            | Full OIDC claim validation: `iss`, `aud`, `exp`, `iat`, `nonce`, `azp` (required when multi-audience); clock skew tolerance (default: 120 seconds)                                      |
+
+### 2FA-Specific Threats
+
+| Threat                          | Attack vector                                                | Mitigation                                                                                                                                                                                                    |
+| ------------------------------- | ------------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| TOTP secret exposure            | Secrets readable in storage, logs, or debug output           | Encrypt-at-rest via `TotpSecretStoreInterface` (AEAD with `identityId` as AAD); `#[\SensitiveParameter]` annotations; `__debugInfo()` redaction                                                               |
+| Recovery code plaintext storage | Codes stored unhashed, readable by DB administrators         | BLAKE2b HMAC hashing with derived subkey (id=3, context=`rcvrycod`); only hashes stored                                                                                                                       |
+| Cross-identity replay           | TOTP secret encrypted for identity A decrypted as identity B | AEAD associated data (AAD) includes `identityId`; decryption fails on identity mismatch                                                                                                                       |
+| Step-up inheritance             | User A's step-up session mistakenly applied to user B        | Session key scoped per identity: `_pulsar_step_up[{identityId}]`; different identities cannot inherit step-up status                                                                                          |
+| Secret leakage to observability | Sensitive values exposed in Studio or event collectors       | `AuthEventCollectorInterface` uses allowlist-based metadata: only `action`, `outcome`, `identity_id`, `purpose`, `reason`, `code_index`, `provider`, `remaining_codes` are emitted; unknown keys are stripped |
+
+### Session Threats
+
+| Threat                     | Attack vector                                                   | Mitigation                                                                                                                                              |
+| -------------------------- | --------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Fixation                   | Attacker pre-sets session ID                                    | Session regeneration on login, 2FA verification, and step-up authentication                                                                             |
+| Idle timeout bypass        | Stale sessions remain valid indefinitely                        | Configurable session lifetime; step-up timeout (default: 15 minutes)                                                                                    |
+| Cookie theft               | Session cookie stolen via XSS or man-in-the-middle              | `HttpOnly` (no JavaScript access), `Secure` (HTTPS only), `SameSite=Strict` (no cross-origin sending)                                                   |
+| Cross-site request forgery | Attacker triggers state-changing requests from victim's browser | CSRF middleware with token validation on unsafe methods (`POST`, `PUT`, `PATCH`, `DELETE`); origin/referer validation with configurable trusted origins |
+
+---
+
+## Safe Defaults by Environment
+
+### Production
+
+| Setting                          | Default                            | Rationale                             |
+| -------------------------------- | ---------------------------------- | ------------------------------------- |
+| `cookie_secure`                  | `true`                             | HTTPS-only cookie transmission        |
+| `cookie_samesite`                | `Strict`                           | No cross-origin cookie sending        |
+| `cookie_httponly`                | `true`                             | No JavaScript cookie access           |
+| `regenerate_on_privilege_change` | `true`                             | Session fixation prevention           |
+| `csrf.enabled`                   | `true`                             | CSRF protection on all unsafe methods |
+| `two_factor.allowInMemory`       | `false`                            | In-memory stores emit `WARNING` log   |
+| `require_pkce`                   | `true`                             | PKCE S256 required for all SSO flows  |
+| `require_nonce`                  | `true`                             | Nonce verification required for OIDC  |
+| `allowUnverifiedIdToken`         | `false`                            | ID tokens must be signature-verified  |
+| Replay guard                     | Persistent (SQLite minimum)        | Survives restarts                     |
+| Recovery code store              | Persistent (DB-backed)             | Atomic consume, survives restarts     |
+| TOTP secret store                | Persistent + encrypted (DB-backed) | Encrypt-at-rest with AEAD             |
+
+**Production guardrail:** When in-memory stores (`InMemoryTotpSecretStore`, `InMemoryRecoveryCodeStore`, `InMemoryTotpReplayGuard`) are active and `two_factor.allowInMemory` is `false`, the framework emits a `WARNING` log at boot:
+
+```
+In-memory 2FA store [InMemoryTotpSecretStore] is active — data will not persist across restarts. Bind a persistent implementation.
+```
+
+This is intentionally loud. Set `two_factor.allowInMemory: true` only when you explicitly accept the risk.
+
+### Development
+
+Same defaults as production (security by default). Exceptions:
+
+- `cookie_secure` can be relaxed for `localhost`
+- In-memory stores are acceptable for local development
+- `LocalMockProvider` for SSO testing (no network calls)
+
+### Testing
+
+- `LocalMockProvider` for deterministic SSO flows
+- `InMemoryTotpReplayGuard` for replay guard
+- `InMemoryRecoveryCodeStore` for recovery code store
+- `InMemoryTotpSecretStore` for TOTP secret store
+- No network calls, no external dependencies
+
+---
+
+## Enabling 2FA Safely
+
+### Setup Flow
+
+1. Call `beginSetup()` with the authenticated identity. Returns:
+   - `secret` — raw binary secret (display only once)
+   - `secret_base32` — Base32-encoded for manual entry
+   - `provisioning_uri` — QR code URI (`otpauth://totp/...`)
+   - `recovery_codes` — plaintext codes (display only once, never again)
+   - `recovery_code_set` — `RecoveryCodeSet` with hashed codes for storage
+2. User scans QR code in their authenticator app
+3. User enters a TOTP code to confirm setup
+4. Call `confirmSetup()` with the identity ID, secret, and code
+5. On success, the secret is stored encrypted via `TotpSecretStoreInterface`
+6. On failure, `Confirm2faSetupResult.reason` indicates the cause
+
+### Verification Flow
+
+1. Call `verifyCode()` with identity ID, code, and purpose
+2. The manager loads the secret from `TotpSecretStoreInterface`
+3. The verifier checks the code against the current and adjacent time steps
+4. The replay guard rejects previously-accepted `(identityId, purpose, timeStep)` tuples
+5. `Verify2faResult` contains:
+   - `verified` — boolean success/failure
+   - `reason` — `Valid`, `InvalidCode`, `Replayed`, `Expired`, `NotEnrolled`, `RateLimited`
+   - `purpose` — `Login`, `Setup`, `StepUp`
+   - `acceptedTimeStep` — the accepted time step (null on failure)
+6. On success, the session is regenerated (privilege escalation defense)
+
+### Recovery Code Storage
+
+- Codes are hashed with BLAKE2b HMAC using a derived subkey (master key id=3, context=`rcvrycod`)
+- Only hashes are stored; plaintext codes are shown exactly once during setup
+- Input is canonicalized (uppercase, stripped dashes/spaces) before hashing
+- Code format: `XXXX-XXXX-XXXX-XXXX` (64-bit entropy, 16 hex characters)
+- Legacy format: `XXXX-XXXX` (32-bit entropy, detected by canonical length)
+
+### Recovery Code Rotation
+
+- Call `rotateRecoveryCodes()` with identity ID
+- Generates a new `RecoveryCodeSet`, stores it, invalidates the old set
+- Returns `RecoveryCodeRotationResult` with the new set and plaintext codes
+- Audit event `2fa_recovery_codes_rotated` is emitted
+
+### Rate Limiting
+
+Implement `TwoFactorRateLimiterInterface` and bind it in the container:
+
+```php
+attempt(string $identityId, TwoFactorPurpose $purpose, array $context = []): bool
+reset(string $identityId): void
+```
+
+The `$context` array supports these keys (populate as needed):
+
+| Key               | Description                    |
+| ----------------- | ------------------------------ |
+| `ip`              | Client IP address              |
+| `user_agent_hash` | Hashed user agent string       |
+| `device_id`       | Persistent device fingerprint  |
+| `route`           | Route name for step-up context |
+| `session_id`      | Hashed session ID              |
+
+When `attempt()` returns `false`, the manager returns `VerifyReason::RateLimited` without attempting verification.
+
+---
+
+## Enabling SSO Safely
+
+### PKCE Requirement
+
+All OAuth flows use PKCE with S256. The `plain` method is not supported. PKCE verifiers are bound to state tokens in the session, preventing tab A/B overwrite in concurrent login flows.
+
+### State and Nonce Verification
+
+- **State tokens**: 256-bit random, stored in session with TTL (default: 300 seconds), consumed on verification (one-time use)
+- **Nonces**: 256-bit random, stored in session, verified via `hash_equals()` (constant-time comparison), only checked from `IdTokenClaims` (post-signature-verification)
+
+### ID Token Verification
+
+The `JwksIdTokenVerifier` enforces strict rules:
+
+1. **`alg: "none"` is rejected unconditionally** — unsigned tokens are never accepted
+2. **Unsupported algorithms are rejected** — only RS256 and ES256 are supported
+3. **`kid` handling**: Required when JWKS has multiple keys; single-key JWKS without `kid` uses that key
+4. **`aud` handling**: Must include `clientId`; when multi-valued, `azp` must be present and equal `clientId`
+5. **`jwksUri` must use HTTPS** — validated at config time in `ProviderConfig::fromArray()`
+6. **Clock skew**: Applied to `exp`, `iat`, and `nbf` (default: 120 seconds)
+7. **JWKS caching**: In-memory cache with rotation on unknown `kid`
+
+### Client Secret Management
+
+- `ProviderConfig` annotates `$clientSecret` with `#[\SensitiveParameter]`
+- `__debugInfo()` returns `[REDACTED]` for `clientSecret`
+- Store client secrets in environment variables or a secrets manager, never in version control
+
+### Redirect URI Configuration
+
+Redirect URIs are resolved from `ProviderConfig->redirectUri` or derived from the router's named route (`sso.callback`). The `CallbackController` never reads a redirect URI from request parameters. This prevents open redirector attacks by design.
+
+### Provider Configuration
+
+```php
+ProviderConfig::fromArray('google', [
+    'type' => 'oidc',                    // 'oidc' or 'oauth2'
+    'client_id' => env('GOOGLE_CLIENT_ID'),
+    'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+    'authorization_url' => 'https://accounts.google.com/o/oauth2/v2/auth',
+    'token_url' => 'https://oauth2.googleapis.com/token',
+    'jwks_uri' => 'https://www.googleapis.com/oauth2/v3/certs',
+    'issuer' => 'https://accounts.google.com',
+    'scopes' => ['openid', 'profile', 'email'],
+    'redirect_uri' => '/auth/sso/callback/google',
+]);
+```
+
+When `type` is `oauth2` (no OIDC), an unexpected `id_token` in the response is rejected unless `allow_unverified_id_token: true` is explicitly set. This is documented as insecure and should not be used in regulated environments.
+
+---
+
+## Step-Up Authentication
+
+Step-up re-authentication protects sensitive operations (password changes, payment approvals, admin actions) by requiring a recent 2FA verification.
+
+### How It Works
+
+1. Apply `StepUpMiddleware` to protected routes
+2. The middleware checks the session key `_pulsar_step_up[{identityId}]` for a timestamp
+3. If the timestamp is missing or older than `stepUpTimeoutMinutes` (default: 15), the request is denied with HTTP 403
+4. After successful 2FA verification with `TwoFactorPurpose::StepUp`, call:
+   ```php
+   StepUpMiddleware::markStepUpAuthenticated($session, $identityId);
+   ```
+5. The session key is scoped per identity — user A's step-up does not apply to user B
+
+### Response Format
+
+- JSON requests (`Accept: application/json` or `X-Requested-With: XMLHttpRequest`): JSON error body
+- Browser requests (`Accept: text/html`): HTML error page
+
+---
+
+## Audit Trail
+
+All 2FA operations emit structured audit events via `AuditLogger`:
+
+| Event                           | Category       | Outcome          | Metadata                           |
+| ------------------------------- | -------------- | ---------------- | ---------------------------------- |
+| `2fa_setup_initiated`           | SecurityEvent  | Success          | `identity_id`                      |
+| `2fa_setup_confirmed`           | SecurityEvent  | Success          | `identity_id`                      |
+| `2fa_setup_confirmation_failed` | SecurityEvent  | Failure          | `identity_id`, `reason`            |
+| `2fa_code_verified`             | Authentication | Success          | `identity_id`, `purpose`           |
+| `2fa_code_verification_failed`  | Authentication | Failure / Denied | `identity_id`, `purpose`, `reason` |
+| `2fa_code_replayed`             | SecurityEvent  | Denied           | `identity_id`, `purpose`, `reason` |
+| `2fa_recovery_code_used`        | Authentication | Success          | `identity_id`, `code_index`        |
+| `2fa_recovery_code_replayed`    | SecurityEvent  | Denied           | `identity_id`, `reason`            |
+| `2fa_recovery_code_failed`      | Authentication | Failure          | `identity_id`, `reason`            |
+| `2fa_recovery_codes_rotated`    | SecurityEvent  | Success          | `identity_id`                      |
+
+Metadata never contains TOTP codes, secrets, or recovery code values. The `reason` field uses `VerifyReason` or `ConsumeReason` enum values.
+
+### Interpreting Audit Events
+
+- **Clusters of `2fa_code_verification_failed`** with `reason: invalid_code` for a single identity may indicate brute force
+- **`2fa_code_replayed`** events indicate replay attempts (may be benign if a user double-submits, or malicious)
+- **`2fa_recovery_code_replayed`** with `reason: already_used` indicates a consumed code was resubmitted
+- **`2fa_code_verification_failed`** with `reason: rate_limited` indicates the rate limiter intervened
+- **`2fa_code_verification_failed`** with `reason: not_enrolled` indicates a verification attempt for an identity without 2FA configured
+
+---
+
+## Multi-Node Deployment
+
+In-memory implementations are suitable for development and testing only. For multi-node production deployments:
+
+### Replay Guard
+
+Bind a persistent `TotpReplayGuardInterface` implementation backed by a shared data store (Redis, database). The composite key `(identityId, purpose, timeStep)` must be globally unique across all nodes. TTL = `windowSteps * period + driftPadding` (e.g., `1 * 30 + 30 = 60` seconds).
+
+### Recovery Code Store
+
+Bind a persistent `RecoveryCodeStoreInterface` implementation with atomic `consume()`. Database-level constraints (row-level locks or compare-and-swap) ensure exactly-once consumption even under concurrent requests from different nodes.
+
+### TOTP Secret Store
+
+Bind a persistent `TotpSecretStoreInterface` implementation that encrypts secrets at rest. AEAD with `identityId` as associated data prevents cross-identity ciphertext replay. The framework derives the encryption subkey from `MasterKey` (id=4, context=`totpscrt`).
+
+### Session Store
+
+Use a shared session backend (Redis, database) so that session-based state (step-up timestamps, SSO state tokens, PKCE verifiers, nonces) is accessible from any node.
+
+---
+
+## Configuration Reference
+
+### Two-Factor Authentication (`config/security.php` → `two_factor`)
+
+| Key                            | Type     | Default    | Description                             |
+| ------------------------------ | -------- | ---------- | --------------------------------------- |
+| `enabled`                      | `bool`   | `false`    | Enable 2FA subsystem                    |
+| `issuer`                       | `string` | `'Pulsar'` | TOTP provisioning URI issuer            |
+| `codeDigits`                   | `int`    | `6`        | TOTP code length (6-10)                 |
+| `codePeriod`                   | `int`    | `30`       | TOTP time step in seconds               |
+| `verificationWindow`           | `int`    | `1`        | Number of adjacent time steps to accept |
+| `recoveryCodeCount`            | `int`    | `8`        | Number of recovery codes generated      |
+| `recoveryCodeBytes`            | `int`    | `8`        | Bytes per recovery code (8 = 64-bit)    |
+| `stepUpTimeoutMinutes`         | `int`    | `15`       | Step-up authentication timeout          |
+| `recoveryCodeAlgorithmVersion` | `int`    | `2`        | Recovery code format version            |
+| `allowInMemory`                | `bool`   | `false`    | Suppress in-memory store warnings       |
+
+### Social SSO (`extensions/social-sso/config/social-sso.php`)
+
+| Key               | Type      | Default | Description                         |
+| ----------------- | --------- | ------- | ----------------------------------- |
+| `enabled`         | `bool`    | `false` | Enable SSO extension                |
+| `defaultProvider` | `?string` | `null`  | Default provider name               |
+| `requirePkce`     | `bool`    | `true`  | Require PKCE S256 for all flows     |
+| `requireNonce`    | `bool`    | `true`  | Require nonce verification for OIDC |
+| `stateTtlSeconds` | `int`     | `300`   | State token TTL                     |
+
+### Security Headers (`config/security.php` → `headers`)
+
+Minimum defaults applied when not overridden:
+
+| Header                   | Value                                      |
+| ------------------------ | ------------------------------------------ |
+| `X-Content-Type-Options` | `nosniff`                                  |
+| `X-Frame-Options`        | `DENY`                                     |
+| `Referrer-Policy`        | `strict-origin-when-cross-origin`          |
+| `X-XSS-Protection`       | `0`                                        |
+| `Permissions-Policy`     | `camera=(), microphone=(), geolocation=()` |
+
+---
+
+## Cryptographic Primitives
+
+All cryptographic operations use libsodium per ADR-0006:
+
+| Purpose                | Primitive                           | Key derivation                            |
+| ---------------------- | ----------------------------------- | ----------------------------------------- |
+| TOTP secret encryption | XSalsa20-Poly1305 (AEAD)            | MasterKey subkey id=4, context=`totpscrt` |
+| Recovery code hashing  | BLAKE2b HMAC                        | MasterKey subkey id=3, context=`rcvrycod` |
+| Audit chain integrity  | BLAKE2b HMAC                        | MasterKey via audit context               |
+| Master key derivation  | `sodium_crypto_kdf_derive_from_key` | Single `PULSAR_MASTER_KEY` env var        |
+
+**Exception:** The Social SSO extension uses OpenSSL for JWT signature verification (RS256, ES256) inside a scoped `JwtSignatureDriverInterface` implementation. This is explicitly documented as an extension-scoped dependency; the core framework remains libsodium-only.

--- a/docs/adr/0015-identity-scoped-two-factor-authentication.md
+++ b/docs/adr/0015-identity-scoped-two-factor-authentication.md
@@ -1,0 +1,82 @@
+# ADR-0015: Identity-Scoped Two-Factor Authentication
+
+## Status
+
+Accepted
+
+## Context
+
+The existing 2FA subsystem (`src/Auth/TwoFactor/`) had several security gaps: the `TotpVerifier` hardcoded a 30-second period regardless of generator configuration; the replay guard keyed on `(identityId, code)` instead of `(identityId, purpose, timeStep)`, allowing cross-purpose replay; recovery codes used 32-bit entropy with no atomic consume contract; TOTP secrets were stored in plaintext; and no audit events were emitted for 2FA operations.
+
+The `TwoFactorManagerInterface` lacked an `identityId` parameter on `verifyCode()` and `confirmSetup()`, making it impossible to enforce per-identity replay prevention or secret store lookups.
+
+These gaps are unacceptable for regulated domains (banking, healthcare, legal) where Pulsar is deployed.
+
+## Decision Drivers
+
+1. Replay prevention must be identity-scoped and purpose-scoped
+2. Recovery code consumption must be atomic (race-safe)
+3. TOTP secrets must be encrypted at rest with identity-bound AEAD
+4. All 2FA operations must emit structured audit events
+5. The framework must warn loudly when non-persistent stores are active in production
+
+## Decision
+
+Break `TwoFactorManagerInterface` to require `string $identityId` on `verifyCode()` and `confirmSetup()`. Redesign the replay guard to key on `(identityId, purpose, timeStep)` instead of `(identityId, code)`. Add `TotpSecretStoreInterface` for encrypt-at-rest with `identityId` as AEAD associated data. Add `RecoveryCodeStoreInterface` with atomic `consume()`. Emit audit events for all 10 2FA decision points. Add `TwoFactorRateLimiterInterface` as an optional integration point with extensible context. Add `StepUpMiddleware` scoped per identity. Add `AuthEventCollectorInterface` for Studio observability with allowlist-based metadata redaction.
+
+Wire defaults in `AuthWiring`: in-memory stores for development with a `WARNING` log when active in production (suppressed by `two_factor.allowInMemory: true`).
+
+## Alternatives Considered
+
+### Keep `verifyCode()` without `identityId`
+
+Replay prevention without identity scoping would require the caller to manage identity context externally, creating a footgun where replay guards could be bypassed by omitting the identity. Rejected because the interface must enforce security invariants.
+
+### Store TOTP secrets unhashed (symmetric encryption only)
+
+TOTP secrets cannot be hashed (they must be recoverable for code verification). Symmetric encryption without identity binding (AAD) would allow ciphertext to be replayed under a different identity record if the database is compromised. Rejected in favor of AEAD with `identityId` as associated data.
+
+### Emit audit events via a generic event dispatcher
+
+A generic event system would not guarantee the structured format (actor, action, resource, outcome) required for compliance. The existing `AuditLogger` already provides this format with HMAC chain integrity. Rejected in favor of direct `AuditLogger` integration.
+
+## Consequences
+
+### Positive
+
+- TOTP replay is prevented per identity, per purpose, per time step
+- Recovery code races are eliminated by atomic consume
+- TOTP secrets are encrypted at rest with identity binding
+- All 2FA operations are auditable
+- Production misconfiguration is detected at boot time
+
+### Negative
+
+- Breaking API change: `TwoFactorManagerInterface` gains required `identityId` parameter
+- Callers must update all `verifyCode()` and `confirmSetup()` call sites
+
+### Neutral
+
+- In-memory stores remain the default for development; production requires explicit binding of persistent implementations
+
+## Security Impact
+
+Addresses TOTP replay, recovery code race conditions, TOTP secret exposure at rest, cross-identity AEAD replay, and missing audit trail. See `docs/AUTH_SECURITY.md` for the full threat model.
+
+## Performance Impact
+
+None on the hot path. Replay guard lookups and recovery code store operations are bounded by the 2FA verification flow (not per-request). AEAD encryption/decryption uses libsodium primitives (sub-microsecond).
+
+## Migration / Rollback Plan
+
+**Adoption**: Update all `verifyCode()` and `confirmSetup()` call sites to pass `$identityId`. Bind persistent `TotpSecretStoreInterface`, `RecoveryCodeStoreInterface`, and `TotpReplayGuardInterface` implementations for production. The deprecated `verifyCodeWithSecret()` method provides a migration path for callers that manage secrets externally.
+
+**Rollback**: Revert to pre-rc.8 `TwoFactorManagerInterface` signatures. The in-memory defaults ensure no data loss during rollback (production stores are app-provided).
+
+## Links
+
+- PR #31: feat(security): harden 2FA + add social SSO extension + auth security docs
+- `docs/AUTH_SECURITY.md`: Threat model and deployment guidance
+- ADR-0006: libsodium-only crypto, master key derivation
+- ADR-0008: HMAC-chained tamper-evident audit logging
+- ADR-0014: Kernel service wiring decomposition

--- a/extensions/social-sso/composer.json
+++ b/extensions/social-sso/composer.json
@@ -1,0 +1,15 @@
+{
+  "name": "pulsar/social-sso",
+  "description": "OAuth2/OIDC social SSO extension for Pulsar Framework",
+  "type": "pulsar-extension",
+  "license": "Apache-2.0",
+  "require": {
+    "php": "^8.5",
+    "ext-openssl": "*"
+  },
+  "autoload": {
+    "psr-4": {
+      "Pulsar\\Extension\\SocialSso\\": "src/"
+    }
+  }
+}

--- a/extensions/social-sso/config/social-sso.php
+++ b/extensions/social-sso/config/social-sso.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    /*
+    |--------------------------------------------------------------------------
+    | Social SSO Configuration
+    |--------------------------------------------------------------------------
+    |
+    | enabled: Master toggle for the SSO extension.
+    | default_provider: Default OAuth provider name.
+    | require_pkce: Enforce PKCE (S256-only) for all providers.
+    | require_nonce: Enforce nonce verification for OIDC providers.
+    | state_ttl_seconds: Lifetime of OAuth state tokens.
+    |
+    */
+
+    'enabled' => false,
+    'default_provider' => '',
+    'require_pkce' => true,
+    'require_nonce' => true,
+    'state_ttl_seconds' => 300,
+
+    /*
+    |--------------------------------------------------------------------------
+    | Routes
+    |--------------------------------------------------------------------------
+    */
+
+    'routes' => [
+        'login_path' => '/sso/{provider}/login',
+        'callback_path' => '/sso/{provider}/callback',
+    ],
+
+    /*
+    |--------------------------------------------------------------------------
+    | Providers
+    |--------------------------------------------------------------------------
+    |
+    | Each provider entry defines the OAuth/OIDC configuration.
+    | Supported types: 'oidc' (OpenID Connect), 'oauth2' (pure OAuth 2.0).
+    |
+    | Example:
+    | 'providers' => [
+    |     'google' => [
+    |         'type' => 'oidc',
+    |         'client_id' => env('GOOGLE_CLIENT_ID'),
+    |         'client_secret' => env('GOOGLE_CLIENT_SECRET'),
+    |         'authorization_url' => 'https://accounts.google.com/o/oauth2/v2/auth',
+    |         'token_url' => 'https://oauth2.googleapis.com/token',
+    |         'jwks_uri' => 'https://www.googleapis.com/oauth2/v3/certs',
+    |         'issuer' => 'https://accounts.google.com',
+    |         'scopes' => ['openid', 'email', 'profile'],
+    |         'redirect_uri' => null, // null = auto-resolve from router
+    |     ],
+    | ],
+    |
+    */
+
+    'providers' => [],
+];

--- a/extensions/social-sso/pulsar.json
+++ b/extensions/social-sso/pulsar.json
@@ -1,0 +1,22 @@
+{
+  "name": "pulsar/social-sso",
+  "version": "1.0.0-rc.8",
+  "description": "OAuth2/OIDC social single sign-on extension with PKCE, ID token verification, and identity linking",
+  "extension_class": "Pulsar\\Extension\\SocialSso\\SocialSsoExtension",
+  "pulsar": {
+    "min_version": "1.0.0-rc.7"
+  },
+  "provides": {
+    "services": [
+      "SsoGateway",
+      "OAuthProviderInterface",
+      "OAuthProviderRegistryInterface",
+      "OAuthStateManagerInterface",
+      "NonceVerifierInterface",
+      "IdTokenVerifierInterface",
+      "SocialIdentityLinkerInterface"
+    ],
+    "routes": true,
+    "commands": []
+  }
+}

--- a/extensions/social-sso/src/Config/ProviderConfig.php
+++ b/extensions/social-sso/src/Config/ProviderConfig.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+
+#[Api(since: '1.0.0')]
+final readonly class ProviderConfig
+{
+    /** @param list<string> $scopes */
+    public function __construct(
+        public string $name,
+        public string $type,
+        public string $clientId,
+        #[\SensitiveParameter] public string $clientSecret,
+        public string $authorizationUrl,
+        public string $tokenUrl,
+        public ?string $jwksUri,
+        public ?string $issuer,
+        public array $scopes,
+        public ?string $redirectUri,
+        public bool $allowUnverifiedIdToken = false,
+        public int $maxClockSkewSeconds = 120,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     * @throws SsoException
+     */
+    #[NoDiscard]
+    public static function fromArray(string $name, array $data): self
+    {
+        $jwksUri = isset($data['jwks_uri']) ? (string) $data['jwks_uri'] : null;
+
+        if ($jwksUri !== null && !str_starts_with($jwksUri, 'https://')) {
+            throw SsoException::invalidIdToken('jwksUri must use HTTPS');
+        }
+
+        $scopes = (array) ($data['scopes'] ?? []);
+        /** @var list<string> $scopes */
+
+        return new self(
+            name: $name,
+            type: (string) ($data['type'] ?? 'oidc'),
+            clientId: (string) ($data['client_id'] ?? ''),
+            clientSecret: (string) ($data['client_secret'] ?? ''),
+            authorizationUrl: (string) ($data['authorization_url'] ?? ''),
+            tokenUrl: (string) ($data['token_url'] ?? ''),
+            jwksUri: $jwksUri,
+            issuer: isset($data['issuer']) ? (string) $data['issuer'] : null,
+            scopes: $scopes,
+            redirectUri: isset($data['redirect_uri']) ? (string) $data['redirect_uri'] : null,
+            allowUnverifiedIdToken: (bool) ($data['allow_unverified_id_token'] ?? false),
+            maxClockSkewSeconds: (int) ($data['max_clock_skew_seconds'] ?? 120),
+        );
+    }
+
+    /** @return array<string, string> */
+    public function __debugInfo(): array
+    {
+        return [
+            'name' => $this->name,
+            'type' => $this->type,
+            'clientId' => $this->clientId,
+            'clientSecret' => '[REDACTED]',
+            'authorizationUrl' => $this->authorizationUrl,
+            'tokenUrl' => $this->tokenUrl,
+        ];
+    }
+}

--- a/extensions/social-sso/src/Config/ProviderConfig.php
+++ b/extensions/social-sso/src/Config/ProviderConfig.php
@@ -7,6 +7,7 @@ namespace Pulsar\Extension\SocialSso\Config;
 use NoDiscard;
 use Pulsar\Api\Api;
 use Pulsar\Extension\SocialSso\Exception\SsoException;
+use SensitiveParameter;
 
 #[Api(since: '1.0.0')]
 final readonly class ProviderConfig
@@ -16,7 +17,7 @@ final readonly class ProviderConfig
         public string $name,
         public string $type,
         public string $clientId,
-        #[\SensitiveParameter] public string $clientSecret,
+        #[SensitiveParameter] public string $clientSecret,
         public string $authorizationUrl,
         public string $tokenUrl,
         public ?string $jwksUri,

--- a/extensions/social-sso/src/Config/RoutesConfig.php
+++ b/extensions/social-sso/src/Config/RoutesConfig.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+#[Api(since: '1.0.0')]
+final readonly class RoutesConfig
+{
+    public function __construct(
+        public string $loginPath,
+        public string $callbackPath,
+    ) {}
+
+    /** @param array<string, mixed> $data */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        return new self(
+            loginPath: (string) ($data['login_path'] ?? '/sso/{provider}/login'),
+            callbackPath: (string) ($data['callback_path'] ?? '/sso/{provider}/callback'),
+        );
+    }
+}

--- a/extensions/social-sso/src/Config/SocialSsoConfig.php
+++ b/extensions/social-sso/src/Config/SocialSsoConfig.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Config;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+#[Api(since: '1.0.0')]
+final readonly class SocialSsoConfig
+{
+    /** @param array<string, ProviderConfig> $providers */
+    public function __construct(
+        public bool $enabled,
+        public string $defaultProvider,
+        public bool $requirePkce,
+        public bool $requireNonce,
+        public int $stateTtlSeconds,
+        public RoutesConfig $routes,
+        public array $providers,
+    ) {}
+
+    /** @param array<string, mixed> $data */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        $providersRaw = (array) ($data['providers'] ?? []);
+        $providers = [];
+        foreach ($providersRaw as $name => $providerData) {
+            $providers[(string) $name] = ProviderConfig::fromArray((string) $name, (array) $providerData);
+        }
+
+        $routesData = (array) ($data['routes'] ?? []);
+
+        return new self(
+            enabled: (bool) ($data['enabled'] ?? false),
+            defaultProvider: (string) ($data['default_provider'] ?? ''),
+            requirePkce: (bool) ($data['require_pkce'] ?? true),
+            requireNonce: (bool) ($data['require_nonce'] ?? true),
+            stateTtlSeconds: (int) ($data['state_ttl_seconds'] ?? 300),
+            routes: RoutesConfig::fromArray($routesData),
+            providers: $providers,
+        );
+    }
+}

--- a/extensions/social-sso/src/Contracts/IdTokenVerifierInterface.php
+++ b/extensions/social-sso/src/Contracts/IdTokenVerifierInterface.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Domain\IdTokenVerificationContext;
+
+/**
+ * Verifies OpenID Connect ID tokens.
+ *
+ * Implementations validate the token signature, issuer, audience, expiration,
+ * and other claims according to the OpenID Connect Core specification.
+ */
+#[Api(since: '1.0.0')]
+interface IdTokenVerifierInterface
+{
+    /**
+     * Verify an ID token and extract its claims.
+     *
+     * @throws \Pulsar\Extension\SocialSso\Exception\SsoException on verification failure
+     */
+    public function verify(string $idToken, IdTokenVerificationContext $context): IdTokenClaims;
+}

--- a/extensions/social-sso/src/Contracts/IdTokenVerifierInterface.php
+++ b/extensions/social-sso/src/Contracts/IdTokenVerifierInterface.php
@@ -7,6 +7,7 @@ namespace Pulsar\Extension\SocialSso\Contracts;
 use Pulsar\Api\Api;
 use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
 use Pulsar\Extension\SocialSso\Domain\IdTokenVerificationContext;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
 
 /**
  * Verifies OpenID Connect ID tokens.
@@ -20,7 +21,7 @@ interface IdTokenVerifierInterface
     /**
      * Verify an ID token and extract its claims.
      *
-     * @throws \Pulsar\Extension\SocialSso\Exception\SsoException on verification failure
+     * @throws SsoException on verification failure
      */
     public function verify(string $idToken, IdTokenVerificationContext $context): IdTokenClaims;
 }

--- a/extensions/social-sso/src/Contracts/JwtSignatureDriverInterface.php
+++ b/extensions/social-sso/src/Contracts/JwtSignatureDriverInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Domain\JwkKey;
+
+/**
+ * Pluggable JWT signature verification driver.
+ *
+ * Implementations provide algorithm-specific signature verification (e.g. RS256, ES256).
+ */
+#[Api(since: '1.0.0')]
+interface JwtSignatureDriverInterface
+{
+    /**
+     * Verify a JWT signature against the given key.
+     *
+     * @param string $header   Base64url-decoded JWT header
+     * @param string $payload  Base64url-decoded JWT payload
+     * @param string $signature Base64url-decoded JWT signature
+     */
+    public function verify(string $header, string $payload, string $signature, JwkKey $key): bool;
+
+    /**
+     * Check whether this driver supports the given algorithm.
+     */
+    public function supports(string $algorithm): bool;
+}

--- a/extensions/social-sso/src/Contracts/NonceVerifierInterface.php
+++ b/extensions/social-sso/src/Contracts/NonceVerifierInterface.php
@@ -1,0 +1,27 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+
+/**
+ * Manages nonce generation and verification for OpenID Connect flows.
+ *
+ * Nonces prevent ID token replay attacks by binding tokens to specific authentication requests.
+ */
+#[Api(since: '1.0.0')]
+interface NonceVerifierInterface
+{
+    /**
+     * Generate a new cryptographically random nonce value.
+     */
+    public function generate(): string;
+
+    /**
+     * Verify that the nonce in the verified claims matches an outstanding request.
+     */
+    public function verify(string $nonce, IdTokenClaims $verifiedClaims): bool;
+}

--- a/extensions/social-sso/src/Contracts/OAuthProviderInterface.php
+++ b/extensions/social-sso/src/Contracts/OAuthProviderInterface.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Domain\OAuthRequest;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+
+/**
+ * Provider adapter contract for OAuth-based social authentication.
+ *
+ * Implementations wrap vendor-specific OAuth flows behind this uniform interface.
+ */
+#[Api(since: '1.0.0')]
+interface OAuthProviderInterface
+{
+    /**
+     * Get the provider name (e.g. "github", "google").
+     */
+    public function name(): string;
+
+    /**
+     * Build the authorization URL the user should be redirected to.
+     */
+    public function authorizationUrl(OAuthRequest $request): string;
+
+    /**
+     * Exchange an authorization code for an access/refresh token set.
+     */
+    public function exchangeCode(string $code, string $redirectUri, ?string $codeVerifier = null): OAuthTokenSet;
+
+    /**
+     * Map the token set to a normalized social identity.
+     */
+    public function mapIdentity(OAuthTokenSet $tokenSet): SocialIdentity;
+}

--- a/extensions/social-sso/src/Contracts/OAuthProviderRegistryInterface.php
+++ b/extensions/social-sso/src/Contracts/OAuthProviderRegistryInterface.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pulsar\Extension\SocialSso\Contracts;
 
 use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
 
 /**
  * Registry for OAuth provider implementations.
@@ -22,7 +23,7 @@ interface OAuthProviderRegistryInterface
     /**
      * Retrieve a registered provider by name.
      *
-     * @throws \Pulsar\Extension\SocialSso\Exception\SsoException if the provider is not registered
+     * @throws SsoException if the provider is not registered
      */
     public function get(string $name): OAuthProviderInterface;
 }

--- a/extensions/social-sso/src/Contracts/OAuthProviderRegistryInterface.php
+++ b/extensions/social-sso/src/Contracts/OAuthProviderRegistryInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+
+/**
+ * Registry for OAuth provider implementations.
+ *
+ * Providers are registered by name and retrieved for use during the SSO flow.
+ */
+#[Api(since: '1.0.0')]
+interface OAuthProviderRegistryInterface
+{
+    /**
+     * Register an OAuth provider.
+     */
+    public function register(OAuthProviderInterface $provider): void;
+
+    /**
+     * Retrieve a registered provider by name.
+     *
+     * @throws \Pulsar\Extension\SocialSso\Exception\SsoException if the provider is not registered
+     */
+    public function get(string $name): OAuthProviderInterface;
+}

--- a/extensions/social-sso/src/Contracts/OAuthStateManagerInterface.php
+++ b/extensions/social-sso/src/Contracts/OAuthStateManagerInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+
+/**
+ * Manages cryptographic state tokens for OAuth CSRF protection.
+ *
+ * State tokens are single-use: verification consumes the token to prevent replay attacks.
+ */
+#[Api(since: '1.0.0')]
+interface OAuthStateManagerInterface
+{
+    /**
+     * Generate a new cryptographically random state token.
+     */
+    public function generate(): string;
+
+    /**
+     * Verify and consume a state token (one-time use).
+     *
+     * Returns true if the token was valid and not yet consumed; false otherwise.
+     */
+    public function verify(string $state): bool;
+}

--- a/extensions/social-sso/src/Contracts/SocialIdentityLinkerInterface.php
+++ b/extensions/social-sso/src/Contracts/SocialIdentityLinkerInterface.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Domain\LinkedIdentityResult;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+
+/**
+ * Links a social identity to an application user account.
+ *
+ * Implementations handle account creation, merging, or linking
+ * based on the application's user management strategy.
+ */
+#[Api(since: '1.0.0')]
+interface SocialIdentityLinkerInterface
+{
+    /**
+     * Link a social identity to an application user.
+     */
+    public function link(SocialIdentity $socialIdentity): LinkedIdentityResult;
+}

--- a/extensions/social-sso/src/Contracts/SsoGatewayInterface.php
+++ b/extensions/social-sso/src/Contracts/SsoGatewayInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\SocialSso\Domain\SsoLoginResult;
+
+/**
+ * Top-level gateway for social SSO login flows.
+ *
+ * Orchestrates the full OAuth callback: state verification, code exchange,
+ * identity mapping, and account linking.
+ */
+#[Api(since: '1.0.0')]
+interface SsoGatewayInterface
+{
+    /**
+     * Execute the full social login flow for an OAuth callback.
+     *
+     * @throws \Pulsar\Extension\SocialSso\Exception\SsoException on any SSO failure
+     */
+    public function fullLogin(string $providerName, string $code, string $state): SsoLoginResult;
+}

--- a/extensions/social-sso/src/Contracts/SsoGatewayInterface.php
+++ b/extensions/social-sso/src/Contracts/SsoGatewayInterface.php
@@ -6,6 +6,7 @@ namespace Pulsar\Extension\SocialSso\Contracts;
 
 use Pulsar\Api\Api;
 use Pulsar\Extension\SocialSso\Domain\SsoLoginResult;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
 
 /**
  * Top-level gateway for social SSO login flows.
@@ -19,7 +20,7 @@ interface SsoGatewayInterface
     /**
      * Execute the full social login flow for an OAuth callback.
      *
-     * @throws \Pulsar\Extension\SocialSso\Exception\SsoException on any SSO failure
+     * @throws SsoException on any SSO failure
      */
     public function fullLogin(string $providerName, string $code, string $state): SsoLoginResult;
 }

--- a/extensions/social-sso/src/Domain/IdTokenClaims.php
+++ b/extensions/social-sso/src/Domain/IdTokenClaims.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Verified OIDC ID token claims.
+ *
+ * Contains the standard claims extracted from a verified ID token JWT.
+ * Additional provider-specific claims are available via the $claims array.
+ */
+#[Api(since: '1.0.0')]
+final readonly class IdTokenClaims
+{
+    /**
+     * @param string $sub            Subject identifier (unique user ID at the issuer)
+     * @param string $iss            Issuer identifier URL
+     * @param string|list<string> $aud Audience (client ID or list of client IDs)
+     * @param int $exp               Expiration timestamp (Unix epoch)
+     * @param int $iat               Issued-at timestamp (Unix epoch)
+     * @param ?string $nonce         Nonce echoed from the authorization request
+     * @param ?string $azp           Authorized party (client ID when multiple audiences)
+     * @param array<string, mixed> $claims  Additional claims beyond the standard set
+     */
+    public function __construct(
+        public string $sub,
+        public string $iss,
+        public string|array $aud,
+        public int $exp,
+        public int $iat,
+        public ?string $nonce = null,
+        public ?string $azp = null,
+        public array $claims = [],
+    ) {}
+}

--- a/extensions/social-sso/src/Domain/IdTokenVerificationContext.php
+++ b/extensions/social-sso/src/Domain/IdTokenVerificationContext.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Context parameters for verifying an OIDC ID token.
+ *
+ * Provides the expected audience, issuer, nonce, and acceptable clock
+ * skew when validating ID token claims and signature.
+ */
+#[Api(since: '1.0.0')]
+final readonly class IdTokenVerificationContext
+{
+    /**
+     * @param string $clientId             Expected audience (client ID)
+     * @param string $issuer               Expected issuer URL
+     * @param ?string $nonce               Expected nonce (must match if present in token)
+     * @param int $maxClockSkewSeconds     Maximum tolerable clock skew for exp/iat checks
+     */
+    public function __construct(
+        public string $clientId,
+        public string $issuer,
+        public ?string $nonce = null,
+        public int $maxClockSkewSeconds = 120,
+    ) {}
+}

--- a/extensions/social-sso/src/Domain/JwkKey.php
+++ b/extensions/social-sso/src/Domain/JwkKey.php
@@ -97,7 +97,7 @@ final readonly class JwkKey
 
         $der = self::asn1Sequence($algorithmIdentifier . $pubKeyBitString);
         $pem = "-----BEGIN PUBLIC KEY-----\n"
-            . chunk_split(base64_encode($der), 64, "\n")
+            . chunk_split(base64_encode($der), 64)
             . "-----END PUBLIC KEY-----";
 
         // Validate the generated PEM
@@ -150,7 +150,7 @@ final readonly class JwkKey
         $der = self::asn1Sequence($algorithmIdentifier . $pubKeyBitString);
 
         $pem = "-----BEGIN PUBLIC KEY-----\n"
-            . chunk_split(base64_encode($der), 64, "\n")
+            . chunk_split(base64_encode($der), 64)
             . "-----END PUBLIC KEY-----";
 
         $key = openssl_pkey_get_public($pem);

--- a/extensions/social-sso/src/Domain/JwkKey.php
+++ b/extensions/social-sso/src/Domain/JwkKey.php
@@ -1,0 +1,228 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+use function array_key_exists;
+use function base64_decode;
+use function chr;
+use function openssl_pkey_get_public;
+use function pack;
+use function str_replace;
+use function strlen;
+
+/**
+ * Immutable JWK (JSON Web Key) representation.
+ *
+ * Holds the key type, optional metadata, and raw key parameters.
+ * Supports conversion to PEM format for RSA and EC public keys
+ * via the getPublicKeyPem() method.
+ */
+#[Api(since: '1.0.0')]
+final readonly class JwkKey
+{
+    /**
+     * @param string $kty                  Key type ("RSA", "EC", "oct", etc.)
+     * @param ?string $kid                 Key ID for matching against JWT headers
+     * @param ?string $alg                 Algorithm hint (e.g., "RS256", "ES256")
+     * @param ?string $use                 Key usage ("sig" or "enc")
+     * @param array<string, mixed> $parameters  Raw JWK parameters (n, e, x, y, crv, etc.)
+     */
+    public function __construct(
+        public string $kty,
+        public ?string $kid = null,
+        public ?string $alg = null,
+        public ?string $use = null,
+        public array $parameters = [],
+    ) {}
+
+    /**
+     * Convert the JWK to a PEM-encoded public key string.
+     *
+     * Supports RSA keys (requires "n" and "e" parameters) and EC keys
+     * (requires "crv", "x", and "y" parameters). Returns null for
+     * unsupported key types or missing parameters.
+     */
+    public function getPublicKeyPem(): ?string
+    {
+        return match ($this->kty) {
+            'RSA' => $this->rsaToPem(),
+            'EC' => $this->ecToPem(),
+            default => null,
+        };
+    }
+
+    /**
+     * Build a PEM-encoded RSA public key from JWK "n" and "e" parameters.
+     */
+    private function rsaToPem(): ?string
+    {
+        if (!array_key_exists('n', $this->parameters) || !array_key_exists('e', $this->parameters)) {
+            return null;
+        }
+
+        /** @var string $n */
+        $n = $this->parameters['n'];
+        /** @var string $e */
+        $e = $this->parameters['e'];
+
+        $modulus = self::base64UrlDecode($n);
+        $exponent = self::base64UrlDecode($e);
+
+        if ($modulus === '' || $exponent === '') {
+            return null;
+        }
+
+        // Ensure unsigned integer encoding (prepend 0x00 if high bit set)
+        if (ord($modulus[0]) > 0x7f) {
+            $modulus = "\x00" . $modulus;
+        }
+        if (ord($exponent[0]) > 0x7f) {
+            $exponent = "\x00" . $exponent;
+        }
+
+        $modulusAsn = self::asn1Integer($modulus);
+        $exponentAsn = self::asn1Integer($exponent);
+
+        $pubKeySequence = self::asn1Sequence($modulusAsn . $exponentAsn);
+        $pubKeyBitString = self::asn1BitString($pubKeySequence);
+
+        // RSA OID: 1.2.840.113549.1.1.1
+        $algorithmIdentifier = self::asn1Sequence(
+            "\x06\x09\x2a\x86\x48\x86\xf7\x0d\x01\x01\x01\x05\x00",
+        );
+
+        $der = self::asn1Sequence($algorithmIdentifier . $pubKeyBitString);
+        $pem = "-----BEGIN PUBLIC KEY-----\n"
+            . chunk_split(base64_encode($der), 64, "\n")
+            . "-----END PUBLIC KEY-----";
+
+        // Validate the generated PEM
+        $key = openssl_pkey_get_public($pem);
+
+        return $key !== false ? $pem : null;
+    }
+
+    /**
+     * Build a PEM-encoded EC public key from JWK "crv", "x", and "y" parameters.
+     */
+    private function ecToPem(): ?string
+    {
+        if (
+            !array_key_exists('crv', $this->parameters)
+            || !array_key_exists('x', $this->parameters)
+            || !array_key_exists('y', $this->parameters)
+        ) {
+            return null;
+        }
+
+        /** @var string $crv */
+        $crv = $this->parameters['crv'];
+        /** @var string $x */
+        $x = $this->parameters['x'];
+        /** @var string $y */
+        $y = $this->parameters['y'];
+
+        $xBytes = self::base64UrlDecode($x);
+        $yBytes = self::base64UrlDecode($y);
+
+        if ($xBytes === '' || $yBytes === '') {
+            return null;
+        }
+
+        $curveOid = self::ecCurveOid($crv);
+        if ($curveOid === null) {
+            return null;
+        }
+
+        // Uncompressed EC point: 0x04 || x || y
+        $point = "\x04" . $xBytes . $yBytes;
+
+        // ecPublicKey OID: 1.2.840.10045.2.1
+        $algorithmIdentifier = self::asn1Sequence(
+            "\x06\x07\x2a\x86\x48\xce\x3d\x02\x01" . $curveOid,
+        );
+
+        $pubKeyBitString = self::asn1BitString($point);
+        $der = self::asn1Sequence($algorithmIdentifier . $pubKeyBitString);
+
+        $pem = "-----BEGIN PUBLIC KEY-----\n"
+            . chunk_split(base64_encode($der), 64, "\n")
+            . "-----END PUBLIC KEY-----";
+
+        $key = openssl_pkey_get_public($pem);
+
+        return $key !== false ? $pem : null;
+    }
+
+    /**
+     * Get the ASN.1 DER-encoded OID for a named EC curve.
+     */
+    private static function ecCurveOid(string $crv): ?string
+    {
+        return match ($crv) {
+            'P-256' => "\x06\x08\x2a\x86\x48\xce\x3d\x03\x01\x07",
+            'P-384' => "\x06\x05\x2b\x81\x04\x00\x22",
+            'P-521' => "\x06\x05\x2b\x81\x04\x00\x23",
+            default => null,
+        };
+    }
+
+    /**
+     * Decode a base64url-encoded string.
+     */
+    private static function base64UrlDecode(string $data): string
+    {
+        $decoded = base64_decode(str_replace(['-', '_'], ['+', '/'], $data), true);
+
+        return $decoded !== false ? $decoded : '';
+    }
+
+    /**
+     * Encode a DER ASN.1 INTEGER.
+     */
+    private static function asn1Integer(string $data): string
+    {
+        return "\x02" . self::asn1Length(strlen($data)) . $data;
+    }
+
+    /**
+     * Encode a DER ASN.1 SEQUENCE.
+     */
+    private static function asn1Sequence(string $data): string
+    {
+        return "\x30" . self::asn1Length(strlen($data)) . $data;
+    }
+
+    /**
+     * Encode a DER ASN.1 BIT STRING (with zero unused-bits prefix).
+     */
+    private static function asn1BitString(string $data): string
+    {
+        $content = "\x00" . $data;
+
+        return "\x03" . self::asn1Length(strlen($content)) . $content;
+    }
+
+    /**
+     * Encode a DER ASN.1 length value.
+     */
+    private static function asn1Length(int $length): string
+    {
+        if ($length < 0x80) {
+            return chr($length);
+        }
+
+        $bytes = '';
+        $temp = $length;
+        while ($temp > 0) {
+            $bytes = pack('C', $temp & 0xff) . $bytes;
+            $temp >>= 8;
+        }
+
+        return chr(0x80 | strlen($bytes)) . $bytes;
+    }
+}

--- a/extensions/social-sso/src/Domain/LinkAction.php
+++ b/extensions/social-sso/src/Domain/LinkAction.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Actions that can be taken when linking a social identity to a local account.
+ */
+#[Api(since: '1.0.0')]
+enum LinkAction: string
+{
+    case Linked = 'linked';
+    case Created = 'created';
+    case Unlinked = 'unlinked';
+    case Rejected = 'rejected';
+}

--- a/extensions/social-sso/src/Domain/LinkedIdentityResult.php
+++ b/extensions/social-sso/src/Domain/LinkedIdentityResult.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Result of a social identity linking operation.
+ *
+ * Captures whether the link was established, the resulting
+ * identity ID, and which action was taken.
+ */
+#[Api(since: '1.0.0')]
+final readonly class LinkedIdentityResult
+{
+    /**
+     * @param bool $linked        Whether the identity is now linked to a local account
+     * @param ?string $identityId Local identity record ID (null if rejected)
+     * @param LinkAction $action  The action that was taken during linking
+     */
+    public function __construct(
+        public bool $linked,
+        public ?string $identityId,
+        public LinkAction $action,
+    ) {}
+}

--- a/extensions/social-sso/src/Domain/OAuthRequest.php
+++ b/extensions/social-sso/src/Domain/OAuthRequest.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Immutable OAuth2 authorization request parameters.
+ *
+ * Captures all values needed to build the authorization URL, including
+ * PKCE challenge data and OIDC nonce when applicable.
+ */
+#[Api(since: '1.0.0')]
+final readonly class OAuthRequest
+{
+    /**
+     * @param list<string> $scopes   Requested OAuth scopes
+     * @param string $redirectUri    Callback URI registered with the provider
+     * @param string $state          CSRF state parameter
+     * @param ?string $nonce         OIDC nonce for ID token replay protection
+     * @param ?string $codeChallenge PKCE code challenge (base64url-encoded)
+     * @param string $codeChallengeMethod PKCE challenge method (S256 only)
+     */
+    public function __construct(
+        public string $redirectUri,
+        public array $scopes,
+        public string $state,
+        public ?string $nonce = null,
+        public ?string $codeChallenge = null,
+        public string $codeChallengeMethod = 'S256',
+    ) {}
+}

--- a/extensions/social-sso/src/Domain/OAuthTokenSet.php
+++ b/extensions/social-sso/src/Domain/OAuthTokenSet.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+use SensitiveParameter;
+
+/**
+ * Immutable token set returned by an OAuth2 token endpoint.
+ *
+ * All token material is marked as sensitive to prevent accidental
+ * exposure in stack traces, var_dump output, and error reports.
+ * The __debugInfo() method redacts every token field.
+ *
+ * @phpstan-type UnverifiedClaims array<string, mixed>
+ */
+#[Api(since: '1.0.0')]
+final readonly class OAuthTokenSet
+{
+    /**
+     * @param string $accessToken      Bearer access token
+     * @param ?string $tokenType       Token type (typically "Bearer")
+     * @param ?int $expiresIn          Lifetime in seconds from issuance
+     * @param ?string $refreshToken    Refresh token for token renewal
+     * @param ?string $idToken         OIDC ID token (JWT)
+     * @param ?array<string, mixed> $unverifiedClaims  Raw decoded claims before signature verification
+     */
+    public function __construct(
+        #[SensitiveParameter]
+        public string $accessToken,
+        public ?string $tokenType = null,
+        public ?int $expiresIn = null,
+        #[SensitiveParameter]
+        public ?string $refreshToken = null,
+        #[SensitiveParameter]
+        public ?string $idToken = null,
+        public ?array $unverifiedClaims = null,
+    ) {}
+
+    /**
+     * Redact all token material from debug output.
+     *
+     * @return array<string, mixed>
+     */
+    public function __debugInfo(): array
+    {
+        return [
+            'accessToken' => '[REDACTED]',
+            'tokenType' => $this->tokenType,
+            'expiresIn' => $this->expiresIn,
+            'refreshToken' => $this->refreshToken !== null ? '[REDACTED]' : null,
+            'idToken' => $this->idToken !== null ? '[REDACTED]' : null,
+            'unverifiedClaims' => $this->unverifiedClaims !== null ? '[REDACTED]' : null,
+        ];
+    }
+}

--- a/extensions/social-sso/src/Domain/PkceChallenge.php
+++ b/extensions/social-sso/src/Domain/PkceChallenge.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+use function base64_encode;
+use function hash;
+use function random_bytes;
+use function rtrim;
+use function str_replace;
+
+/**
+ * Immutable PKCE (Proof Key for Code Exchange) challenge pair.
+ *
+ * Generates a cryptographically random code verifier and its
+ * SHA-256 challenge per RFC 7636. Only the S256 method is supported.
+ */
+#[Api(since: '1.0.0')]
+final readonly class PkceChallenge
+{
+    private const string METHOD = 'S256';
+
+    /**
+     * @param string $verifier  Code verifier (base64url-encoded, 43 chars)
+     * @param string $challenge Code challenge (base64url-encoded SHA-256 of verifier)
+     * @param string $method    Challenge method (always "S256")
+     */
+    public function __construct(
+        public string $verifier,
+        public string $challenge,
+        public string $method = self::METHOD,
+    ) {}
+
+    /**
+     * Generate a new PKCE challenge pair.
+     *
+     * Produces a 32-byte random verifier encoded as base64url (43 chars),
+     * then computes the SHA-256 hash of the verifier as the challenge.
+     */
+    #[NoDiscard]
+    public static function generate(): self
+    {
+        $verifier = self::base64UrlEncode(random_bytes(32));
+        $challenge = self::base64UrlEncode(hash('sha256', $verifier, true));
+
+        return new self($verifier, $challenge, self::METHOD);
+    }
+
+    /**
+     * Base64url-encode without padding per RFC 4648 Section 5.
+     */
+    private static function base64UrlEncode(string $data): string
+    {
+        return rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode($data)), '=');
+    }
+}

--- a/extensions/social-sso/src/Domain/SocialIdentity.php
+++ b/extensions/social-sso/src/Domain/SocialIdentity.php
@@ -1,0 +1,34 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Normalized social identity returned by an OAuth provider.
+ *
+ * Maps the provider-specific user info response into a
+ * canonical structure for identity linking and account creation.
+ */
+#[Api(since: '1.0.0')]
+final readonly class SocialIdentity
+{
+    /**
+     * @param string $provider       Provider identifier (e.g., "google", "github")
+     * @param string $providerUserId Provider-scoped unique user identifier
+     * @param ?string $email         User email address (not guaranteed by all providers)
+     * @param ?string $name          Display name
+     * @param ?string $avatarUrl     Profile image URL
+     * @param array<string, mixed> $rawAttributes  Full unprocessed attributes from the provider
+     */
+    public function __construct(
+        public string $provider,
+        public string $providerUserId,
+        public ?string $email = null,
+        public ?string $name = null,
+        public ?string $avatarUrl = null,
+        public array $rawAttributes = [],
+    ) {}
+}

--- a/extensions/social-sso/src/Domain/SsoLoginResult.php
+++ b/extensions/social-sso/src/Domain/SsoLoginResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Aggregate result of a complete SSO login flow.
+ *
+ * Combines the resolved social identity, the identity linking
+ * outcome, and optionally verified ID token claims into a
+ * single result object for downstream processing.
+ */
+#[Api(since: '1.0.0')]
+final readonly class SsoLoginResult
+{
+    /**
+     * @param SocialIdentity $socialIdentity          Normalized identity from the OAuth provider
+     * @param LinkedIdentityResult $linkResult        Result of the identity linking step
+     * @param ?IdTokenClaims $verifiedClaims          Verified OIDC ID token claims (null if not an OIDC flow)
+     */
+    public function __construct(
+        public SocialIdentity $socialIdentity,
+        public LinkedIdentityResult $linkResult,
+        public ?IdTokenClaims $verifiedClaims = null,
+    ) {}
+}

--- a/extensions/social-sso/src/Exception/SsoException.php
+++ b/extensions/social-sso/src/Exception/SsoException.php
@@ -7,7 +7,6 @@ namespace Pulsar\Extension\SocialSso\Exception;
 use NoDiscard;
 use Pulsar\Api\Api;
 use RuntimeException;
-use Throwable;
 
 use function sprintf;
 
@@ -23,9 +22,8 @@ final class SsoException extends RuntimeException
     private function __construct(
         string $message,
         public readonly string $errorType,
-        ?Throwable $previous = null,
     ) {
-        parent::__construct($message, 0, $previous);
+        parent::__construct($message);
     }
 
     #[NoDiscard]

--- a/extensions/social-sso/src/Exception/SsoException.php
+++ b/extensions/social-sso/src/Exception/SsoException.php
@@ -1,0 +1,114 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Exception;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+use RuntimeException;
+use Throwable;
+
+use function sprintf;
+
+/**
+ * Domain-level SSO exceptions.
+ *
+ * Each static factory produces a semantically typed exception with a machine-readable
+ * error type for structured error handling and logging.
+ */
+#[Api(since: '1.0.0')]
+final class SsoException extends RuntimeException
+{
+    private function __construct(
+        string $message,
+        public readonly string $errorType,
+        ?Throwable $previous = null,
+    ) {
+        parent::__construct($message, 0, $previous);
+    }
+
+    #[NoDiscard]
+    public static function invalidState(): self
+    {
+        return new self('OAuth state parameter is invalid or expired', 'invalid_state');
+    }
+
+    #[NoDiscard]
+    public static function invalidNonce(): self
+    {
+        return new self('OpenID Connect nonce verification failed', 'invalid_nonce');
+    }
+
+    #[NoDiscard]
+    public static function invalidIdToken(string $reason): self
+    {
+        return new self(
+            sprintf('ID token verification failed: %s', $reason),
+            'invalid_id_token',
+        );
+    }
+
+    #[NoDiscard]
+    public static function unexpectedIdToken(): self
+    {
+        return new self('Received an ID token when none was expected', 'unexpected_id_token');
+    }
+
+    #[NoDiscard]
+    public static function tokenExchangeFailed(): self
+    {
+        return new self('OAuth token exchange failed', 'token_exchange_failed');
+    }
+
+    #[NoDiscard]
+    public static function providerNotFound(): self
+    {
+        return new self('OAuth provider not found in registry', 'provider_not_found');
+    }
+
+    #[NoDiscard]
+    public static function providerError(): self
+    {
+        return new self('OAuth provider returned an error', 'provider_error');
+    }
+
+    #[NoDiscard]
+    public static function missingAuthorizationCode(): self
+    {
+        return new self('Authorization code is missing from the callback', 'missing_authorization_code');
+    }
+
+    #[NoDiscard]
+    public static function extensionDisabled(): self
+    {
+        return new self('Social SSO extension is disabled', 'extension_disabled');
+    }
+
+    #[NoDiscard]
+    public static function pkceRequired(): self
+    {
+        return new self('PKCE is required but no code verifier was provided', 'pkce_required');
+    }
+
+    #[NoDiscard]
+    public static function jwksFetchFailed(): self
+    {
+        return new self('Failed to fetch JWKS from the provider', 'jwks_fetch_failed');
+    }
+
+    #[NoDiscard]
+    public static function signatureVerificationFailed(): self
+    {
+        return new self('JWT signature verification failed', 'signature_verification_failed');
+    }
+
+    #[NoDiscard]
+    public static function unsupportedAlgorithm(string $alg): self
+    {
+        return new self(
+            sprintf('Unsupported JWT signing algorithm: %s', $alg),
+            'unsupported_algorithm',
+        );
+    }
+}

--- a/extensions/social-sso/src/Features/ExchangeCode/ExchangeCodeHandler.php
+++ b/extensions/social-sso/src/Features/ExchangeCode/ExchangeCodeHandler.php
@@ -1,0 +1,96 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\ExchangeCode;
+
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\IdTokenVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Domain\IdTokenVerificationContext;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+use Pulsar\Extension\SocialSso\Internal\Session\SessionOAuthStateManager;
+
+/**
+ * Exchanges an OAuth authorization code for tokens.
+ *
+ * Verifies the CSRF state token, retrieves the PKCE verifier,
+ * exchanges the code via the provider, and optionally verifies
+ * the OIDC ID token.
+ */
+final readonly class ExchangeCodeHandler
+{
+    public function __construct(
+        private OAuthProviderRegistryInterface $providerRegistry,
+        private OAuthStateManagerInterface $stateManager,
+        private NonceVerifierInterface $nonceVerifier,
+        private IdTokenVerifierInterface $idTokenVerifier,
+        private SocialSsoConfig $config,
+    ) {}
+
+    /**
+     * @throws SsoException
+     */
+    public function handle(ExchangeCodeRequest $request): ExchangeCodeResult
+    {
+        if (!$this->stateManager->verify($request->state)) {
+            throw SsoException::invalidState();
+        }
+
+        $codeVerifier = null;
+        if ($this->stateManager instanceof SessionOAuthStateManager) {
+            $codeVerifier = $this->stateManager->retrievePkceVerifier($request->state);
+        }
+
+        $provider = $this->providerRegistry->get($request->providerName);
+        $providerConfig = $this->config->providers[$request->providerName];
+
+        $redirectUri = $providerConfig->redirectUri ?? '';
+
+        $tokenSet = $provider->exchangeCode($request->code, $redirectUri, $codeVerifier);
+
+        $verifiedClaims = null;
+
+        if ($tokenSet->idToken !== null) {
+            if ($providerConfig->type === 'oauth2' && !$providerConfig->allowUnverifiedIdToken) {
+                throw SsoException::unexpectedIdToken();
+            }
+
+            $verifiedClaims = $this->verifyIdToken(
+                $tokenSet->idToken,
+                $providerConfig->clientId,
+                $providerConfig->issuer ?? '',
+                $providerConfig->maxClockSkewSeconds,
+            );
+
+            if ($this->config->requireNonce && $verifiedClaims->nonce !== null) {
+                if (!$this->nonceVerifier->verify($verifiedClaims->nonce, $verifiedClaims)) {
+                    throw SsoException::invalidNonce();
+                }
+            }
+        }
+
+        return new ExchangeCodeResult(
+            tokenSet: $tokenSet,
+            verifiedClaims: $verifiedClaims,
+        );
+    }
+
+    private function verifyIdToken(
+        string $idToken,
+        string $clientId,
+        string $issuer,
+        int $maxClockSkewSeconds,
+    ): IdTokenClaims {
+        $context = new IdTokenVerificationContext(
+            clientId: $clientId,
+            issuer: $issuer,
+            maxClockSkewSeconds: $maxClockSkewSeconds,
+        );
+
+        return $this->idTokenVerifier->verify($idToken, $context);
+    }
+}

--- a/extensions/social-sso/src/Features/ExchangeCode/ExchangeCodeRequest.php
+++ b/extensions/social-sso/src/Features/ExchangeCode/ExchangeCodeRequest.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\ExchangeCode;
+
+/**
+ * Request DTO for exchanging an OAuth authorization code for tokens.
+ */
+final readonly class ExchangeCodeRequest
+{
+    public function __construct(
+        public string $providerName,
+        public string $code,
+        public string $state,
+    ) {}
+}

--- a/extensions/social-sso/src/Features/ExchangeCode/ExchangeCodeResult.php
+++ b/extensions/social-sso/src/Features/ExchangeCode/ExchangeCodeResult.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\ExchangeCode;
+
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+
+/**
+ * Result DTO for an OAuth authorization code exchange.
+ *
+ * Contains the token set and optionally the verified OIDC ID token claims.
+ */
+final readonly class ExchangeCodeResult
+{
+    public function __construct(
+        public OAuthTokenSet $tokenSet,
+        public ?IdTokenClaims $verifiedClaims = null,
+    ) {}
+}

--- a/extensions/social-sso/src/Features/InitiateLogin/InitiateLoginHandler.php
+++ b/extensions/social-sso/src/Features/InitiateLogin/InitiateLoginHandler.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\InitiateLogin;
+
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Domain\OAuthRequest;
+use Pulsar\Extension\SocialSso\Domain\PkceChallenge;
+use Pulsar\Extension\SocialSso\Internal\Session\SessionOAuthStateManager;
+
+/**
+ * Initiates the OAuth authorization flow for a social login.
+ *
+ * Generates CSRF state, optional PKCE challenge and OIDC nonce,
+ * then builds the authorization URL via the provider adapter.
+ */
+final readonly class InitiateLoginHandler
+{
+    public function __construct(
+        private OAuthProviderRegistryInterface $providerRegistry,
+        private OAuthStateManagerInterface $stateManager,
+        private NonceVerifierInterface $nonceVerifier,
+        private SocialSsoConfig $config,
+    ) {}
+
+    public function handle(InitiateLoginRequest $request): InitiateLoginResult
+    {
+        $provider = $this->providerRegistry->get($request->providerName);
+        $providerConfig = $this->config->providers[$request->providerName];
+
+        $state = $this->stateManager->generate();
+
+        $pkceChallenge = null;
+        if ($this->config->requirePkce) {
+            $pkceChallenge = PkceChallenge::generate();
+
+            if ($this->stateManager instanceof SessionOAuthStateManager) {
+                $this->stateManager->storePkceVerifier($state, $pkceChallenge->verifier);
+            }
+        }
+
+        $nonce = null;
+        if ($this->config->requireNonce && $providerConfig->type === 'oidc') {
+            $nonce = $this->nonceVerifier->generate();
+        }
+
+        $redirectUri = $request->redirectUri ?? $providerConfig->redirectUri ?? '';
+
+        $oauthRequest = new OAuthRequest(
+            redirectUri: $redirectUri,
+            scopes: $providerConfig->scopes,
+            state: $state,
+            nonce: $nonce,
+            codeChallenge: $pkceChallenge?->challenge,
+        );
+
+        $authorizationUrl = $provider->authorizationUrl($oauthRequest);
+
+        return new InitiateLoginResult(
+            authorizationUrl: $authorizationUrl,
+            state: $state,
+            pkceChallenge: $pkceChallenge,
+        );
+    }
+}

--- a/extensions/social-sso/src/Features/InitiateLogin/InitiateLoginRequest.php
+++ b/extensions/social-sso/src/Features/InitiateLogin/InitiateLoginRequest.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\InitiateLogin;
+
+/**
+ * Request DTO for initiating an OAuth social login flow.
+ */
+final readonly class InitiateLoginRequest
+{
+    public function __construct(
+        public string $providerName,
+        public ?string $redirectUri = null,
+    ) {}
+}

--- a/extensions/social-sso/src/Features/InitiateLogin/InitiateLoginResult.php
+++ b/extensions/social-sso/src/Features/InitiateLogin/InitiateLoginResult.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\InitiateLogin;
+
+use Pulsar\Extension\SocialSso\Domain\PkceChallenge;
+
+/**
+ * Result DTO for initiating an OAuth social login flow.
+ *
+ * Contains the authorization URL the user should be redirected to,
+ * the CSRF state token, and the optional PKCE challenge pair.
+ */
+final readonly class InitiateLoginResult
+{
+    public function __construct(
+        public string $authorizationUrl,
+        public string $state,
+        public ?PkceChallenge $pkceChallenge = null,
+    ) {}
+}

--- a/extensions/social-sso/src/Features/MapIdentity/MapIdentityHandler.php
+++ b/extensions/social-sso/src/Features/MapIdentity/MapIdentityHandler.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\MapIdentity;
+
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+
+/**
+ * Maps an OAuth token set to a normalized social identity.
+ *
+ * Delegates to the provider adapter to extract user information
+ * from the token set into a canonical SocialIdentity structure.
+ */
+final readonly class MapIdentityHandler
+{
+    public function __construct(
+        private OAuthProviderRegistryInterface $providerRegistry,
+    ) {}
+
+    public function handle(MapIdentityRequest $request): MapIdentityResult
+    {
+        $provider = $this->providerRegistry->get($request->providerName);
+
+        $socialIdentity = $provider->mapIdentity($request->tokenSet);
+
+        return new MapIdentityResult(
+            socialIdentity: $socialIdentity,
+        );
+    }
+}

--- a/extensions/social-sso/src/Features/MapIdentity/MapIdentityRequest.php
+++ b/extensions/social-sso/src/Features/MapIdentity/MapIdentityRequest.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\MapIdentity;
+
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+
+/**
+ * Request DTO for mapping an OAuth token set to a social identity.
+ */
+final readonly class MapIdentityRequest
+{
+    public function __construct(
+        public OAuthTokenSet $tokenSet,
+        public string $providerName,
+    ) {}
+}

--- a/extensions/social-sso/src/Features/MapIdentity/MapIdentityResult.php
+++ b/extensions/social-sso/src/Features/MapIdentity/MapIdentityResult.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Features\MapIdentity;
+
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+
+/**
+ * Result DTO for mapping an OAuth token set to a social identity.
+ */
+final readonly class MapIdentityResult
+{
+    public function __construct(
+        public SocialIdentity $socialIdentity,
+    ) {}
+}

--- a/extensions/social-sso/src/Gateway/SsoGateway.php
+++ b/extensions/social-sso/src/Gateway/SsoGateway.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Gateway;
+
+use Override;
+use Pulsar\Extension\SocialSso\Contracts\SocialIdentityLinkerInterface;
+use Pulsar\Extension\SocialSso\Contracts\SsoGatewayInterface;
+use Pulsar\Extension\SocialSso\Domain\SsoLoginResult;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+use Pulsar\Extension\SocialSso\Features\ExchangeCode\ExchangeCodeHandler;
+use Pulsar\Extension\SocialSso\Features\ExchangeCode\ExchangeCodeRequest;
+use Pulsar\Extension\SocialSso\Features\MapIdentity\MapIdentityHandler;
+use Pulsar\Extension\SocialSso\Features\MapIdentity\MapIdentityRequest;
+
+/**
+ * Top-level SSO gateway orchestrator.
+ *
+ * Coordinates the full OAuth callback flow: code exchange,
+ * identity mapping, and account linking into a single result.
+ */
+final readonly class SsoGateway implements SsoGatewayInterface
+{
+    public function __construct(
+        private ExchangeCodeHandler $exchangeHandler,
+        private MapIdentityHandler $mapHandler,
+        private SocialIdentityLinkerInterface $linker,
+    ) {}
+
+    /**
+     * @throws SsoException
+     */
+    #[Override]
+    public function fullLogin(string $providerName, string $code, string $state): SsoLoginResult
+    {
+        $exchangeResult = $this->exchangeHandler->handle(
+            new ExchangeCodeRequest(
+                providerName: $providerName,
+                code: $code,
+                state: $state,
+            ),
+        );
+
+        $mapResult = $this->mapHandler->handle(
+            new MapIdentityRequest(
+                tokenSet: $exchangeResult->tokenSet,
+                providerName: $providerName,
+            ),
+        );
+
+        $linkResult = $this->linker->link($mapResult->socialIdentity);
+
+        return new SsoLoginResult(
+            socialIdentity: $mapResult->socialIdentity,
+            linkResult: $linkResult,
+            verifiedClaims: $exchangeResult->verifiedClaims,
+        );
+    }
+}

--- a/extensions/social-sso/src/Internal/Linker/NullSocialIdentityLinker.php
+++ b/extensions/social-sso/src/Internal/Linker/NullSocialIdentityLinker.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Linker;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\SocialIdentityLinkerInterface;
+use Pulsar\Extension\SocialSso\Domain\LinkAction;
+use Pulsar\Extension\SocialSso\Domain\LinkedIdentityResult;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+
+/**
+ * No-op social identity linker.
+ *
+ * Always returns an unlinked result. Applications must replace this with a
+ * concrete linker that integrates with their user management system.
+ */
+#[Internal]
+final readonly class NullSocialIdentityLinker implements SocialIdentityLinkerInterface
+{
+    #[Override]
+    public function link(SocialIdentity $socialIdentity): LinkedIdentityResult
+    {
+        return new LinkedIdentityResult(
+            linked: false,
+            identityId: null,
+            action: LinkAction::Unlinked,
+        );
+    }
+}

--- a/extensions/social-sso/src/Internal/Provider/LocalMockProvider.php
+++ b/extensions/social-sso/src/Internal/Provider/LocalMockProvider.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Provider;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Domain\OAuthRequest;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+
+use function array_key_exists;
+use function http_build_query;
+use function implode;
+
+/**
+ * Local mock OAuth provider for testing and development.
+ *
+ * Returns pre-configured tokens and identities for given authorization codes.
+ * All URLs are synthetic and no real HTTP calls are made.
+ */
+#[Internal]
+final class LocalMockProvider implements OAuthProviderInterface
+{
+    /** @var array<string, OAuthTokenSet> */
+    private array $tokens = [];
+
+    /** @var array<string, SocialIdentity> */
+    private array $identities = [];
+
+    public function __construct(
+        private readonly string $name = 'mock',
+    ) {}
+
+    /**
+     * Pre-configure a token set to be returned when the given authorization code is exchanged.
+     */
+    public function setTokenForCode(string $code, OAuthTokenSet $tokenSet): void
+    {
+        $this->tokens[$code] = $tokenSet;
+    }
+
+    /**
+     * Pre-configure a social identity to be returned when the given authorization code is exchanged.
+     */
+    public function setIdentityForCode(string $code, SocialIdentity $identity): void
+    {
+        $this->identities[$code] = $identity;
+    }
+
+    #[Override]
+    public function name(): string
+    {
+        return $this->name;
+    }
+
+    #[Override]
+    public function authorizationUrl(OAuthRequest $request): string
+    {
+        $params = [
+            'provider' => $this->name,
+            'redirect_uri' => $request->redirectUri,
+            'scope' => implode(' ', $request->scopes),
+            'state' => $request->state,
+            'response_type' => 'code',
+        ];
+
+        if ($request->nonce !== null) {
+            $params['nonce'] = $request->nonce;
+        }
+
+        if ($request->codeChallenge !== null) {
+            $params['code_challenge'] = $request->codeChallenge;
+            $params['code_challenge_method'] = $request->codeChallengeMethod;
+        }
+
+        return 'https://mock.local/authorize?' . http_build_query($params);
+    }
+
+    #[Override]
+    public function exchangeCode(string $code, string $redirectUri, ?string $codeVerifier = null): OAuthTokenSet
+    {
+        if (!array_key_exists($code, $this->tokens)) {
+            throw SsoException::tokenExchangeFailed();
+        }
+
+        return $this->tokens[$code];
+    }
+
+    #[Override]
+    public function mapIdentity(OAuthTokenSet $tokenSet): SocialIdentity
+    {
+        // Look up identity by matching the access token against stored code-based identities
+        foreach ($this->tokens as $code => $storedToken) {
+            if ($storedToken->accessToken === $tokenSet->accessToken && array_key_exists($code, $this->identities)) {
+                return $this->identities[$code];
+            }
+        }
+
+        // Return a default mock identity when no pre-configured mapping exists
+        return new SocialIdentity(
+            provider: $this->name,
+            providerUserId: 'mock-user-' . $tokenSet->accessToken,
+            email: 'mock@example.com',
+            name: 'Mock User',
+        );
+    }
+}

--- a/extensions/social-sso/src/Internal/Provider/OAuthProviderRegistry.php
+++ b/extensions/social-sso/src/Internal/Provider/OAuthProviderRegistry.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Provider;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+
+/**
+ * In-memory OAuth provider registry.
+ *
+ * Stores registered provider implementations keyed by their name and
+ * retrieves them during the SSO flow. Throws on lookup of unregistered providers.
+ */
+#[Internal]
+final class OAuthProviderRegistry implements OAuthProviderRegistryInterface
+{
+    /** @var array<string, OAuthProviderInterface> */
+    private array $providers = [];
+
+    #[Override]
+    public function register(OAuthProviderInterface $provider): void
+    {
+        $this->providers[$provider->name()] = $provider;
+    }
+
+    #[Override]
+    public function get(string $name): OAuthProviderInterface
+    {
+        return $this->providers[$name] ?? throw SsoException::providerNotFound();
+    }
+}

--- a/extensions/social-sso/src/Internal/Session/SessionNonceVerifier.php
+++ b/extensions/social-sso/src/Internal/Session/SessionNonceVerifier.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Session;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Security\Session\SessionInterface;
+
+use function array_key_exists;
+use function bin2hex;
+use function hash_equals;
+use function is_array;
+use function random_bytes;
+
+/**
+ * Session-backed OIDC nonce verifier.
+ *
+ * Generates cryptographically random nonces stored in the user's session and
+ * verifies them against the nonce claim in a verified ID token. Nonces are
+ * single-use to prevent token replay attacks.
+ */
+#[Internal]
+final readonly class SessionNonceVerifier implements NonceVerifierInterface
+{
+    private const string NONCE_KEY = 'sso_nonce';
+
+    public function __construct(
+        private SessionInterface $session,
+    ) {}
+
+    #[Override]
+    public function generate(): string
+    {
+        $nonce = bin2hex(random_bytes(32));
+
+        /** @var array<string, true> $nonces */
+        $nonces = $this->session->get(self::NONCE_KEY, []);
+
+        if (!is_array($nonces)) {
+            $nonces = [];
+        }
+
+        $nonces[$nonce] = true;
+        $this->session->set(self::NONCE_KEY, $nonces);
+
+        return $nonce;
+    }
+
+    #[Override]
+    public function verify(string $nonce, IdTokenClaims $verifiedClaims): bool
+    {
+        // The nonce from the ID token must match the expected nonce
+        if ($verifiedClaims->nonce === null || !hash_equals($nonce, $verifiedClaims->nonce)) {
+            return false;
+        }
+
+        /** @var array<string, true> $nonces */
+        $nonces = $this->session->get(self::NONCE_KEY, []);
+
+        if (!is_array($nonces) || !array_key_exists($nonce, $nonces)) {
+            return false;
+        }
+
+        // One-time consume: remove the nonce
+        unset($nonces[$nonce]);
+        $this->session->set(self::NONCE_KEY, $nonces);
+
+        return true;
+    }
+}

--- a/extensions/social-sso/src/Internal/Session/SessionOAuthStateManager.php
+++ b/extensions/social-sso/src/Internal/Session/SessionOAuthStateManager.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Session;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Security\Session\SessionInterface;
+
+use function array_key_exists;
+use function bin2hex;
+use function is_array;
+use function is_int;
+use function random_bytes;
+use function time;
+
+/**
+ * Session-backed OAuth state manager with TTL enforcement.
+ *
+ * Stores CSRF state tokens and PKCE code verifiers in the user's session.
+ * State tokens are single-use and expire after the configured TTL to prevent
+ * replay attacks and stale authorization flows.
+ */
+#[Internal]
+final readonly class SessionOAuthStateManager implements OAuthStateManagerInterface
+{
+    private const string STATE_KEY = 'sso_state';
+    private const string PKCE_KEY = 'sso_pkce';
+
+    public function __construct(
+        private SessionInterface $session,
+        private int $ttlSeconds = 300,
+    ) {}
+
+    #[Override]
+    public function generate(): string
+    {
+        $state = bin2hex(random_bytes(32));
+
+        /** @var array<string, int> $states */
+        $states = $this->session->get(self::STATE_KEY, []);
+
+        if (!is_array($states)) {
+            $states = [];
+        }
+
+        $states[$state] = time();
+        $this->session->set(self::STATE_KEY, $states);
+
+        return $state;
+    }
+
+    #[Override]
+    public function verify(string $state): bool
+    {
+        /** @var array<string, int> $states */
+        $states = $this->session->get(self::STATE_KEY, []);
+
+        if (!is_array($states) || !array_key_exists($state, $states)) {
+            return false;
+        }
+
+        $createdAt = $states[$state];
+
+        // One-time consume: remove the state regardless of TTL validity
+        unset($states[$state]);
+        $this->session->set(self::STATE_KEY, $states);
+
+        if (!is_int($createdAt)) {
+            return false;
+        }
+
+        return (time() - $createdAt) <= $this->ttlSeconds;
+    }
+
+    /**
+     * Store a PKCE code verifier associated with the given state token.
+     */
+    public function storePkceVerifier(string $state, string $verifier): void
+    {
+        /** @var array<string, string> $pkce */
+        $pkce = $this->session->get(self::PKCE_KEY, []);
+
+        if (!is_array($pkce)) {
+            $pkce = [];
+        }
+
+        $pkce[$state] = $verifier;
+        $this->session->set(self::PKCE_KEY, $pkce);
+    }
+
+    /**
+     * Retrieve and delete the PKCE code verifier for the given state token.
+     *
+     * Returns null if no verifier was stored for this state.
+     */
+    public function retrievePkceVerifier(string $state): ?string
+    {
+        /** @var array<string, string> $pkce */
+        $pkce = $this->session->get(self::PKCE_KEY, []);
+
+        if (!is_array($pkce) || !array_key_exists($state, $pkce)) {
+            return null;
+        }
+
+        $verifier = $pkce[$state];
+
+        unset($pkce[$state]);
+        $this->session->set(self::PKCE_KEY, $pkce);
+
+        return $verifier;
+    }
+}

--- a/extensions/social-sso/src/Internal/Token/JwksFetcher.php
+++ b/extensions/social-sso/src/Internal/Token/JwksFetcher.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Token;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Domain\JwkKey;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+
+use function array_key_exists;
+use function file_get_contents;
+use function is_array;
+use function json_decode;
+use function stream_context_create;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * Fetches and caches JWKS (JSON Web Key Sets) from provider endpoints.
+ *
+ * Maintains an in-memory cache to avoid redundant HTTP requests within the
+ * same request lifecycle. Supports cache-busting for key rotation scenarios:
+ * when a specific kid is not found, the cache is cleared and the JWKS is re-fetched.
+ */
+#[Internal]
+final class JwksFetcher
+{
+    /** @var array<string, list<JwkKey>> */
+    private array $cache = [];
+
+    /**
+     * Fetch all keys from a JWKS endpoint.
+     *
+     * @return list<JwkKey>
+     *
+     * @throws SsoException if the JWKS cannot be fetched or parsed
+     */
+    public function fetchKeys(string $jwksUri): array
+    {
+        if (array_key_exists($jwksUri, $this->cache)) {
+            return $this->cache[$jwksUri];
+        }
+
+        $context = stream_context_create([
+            'http' => [
+                'method' => 'GET',
+                'timeout' => 10,
+                'header' => "Accept: application/json\r\n",
+            ],
+            'ssl' => [
+                'verify_peer' => true,
+                'verify_peer_name' => true,
+            ],
+        ]);
+
+        $response = @file_get_contents($jwksUri, false, $context);
+
+        if ($response === false) {
+            throw SsoException::jwksFetchFailed();
+        }
+
+        /** @var array{keys?: list<array<string, mixed>>} $data */
+        $data = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($data) || !isset($data['keys']) || !is_array($data['keys'])) {
+            throw SsoException::jwksFetchFailed();
+        }
+
+        $keys = [];
+
+        foreach ($data['keys'] as $keyData) {
+            if (!is_array($keyData) || !isset($keyData['kty'])) {
+                continue;
+            }
+
+            /** @var string $kty */
+            $kty = $keyData['kty'];
+
+            $keys[] = new JwkKey(
+                kty: $kty,
+                kid: isset($keyData['kid']) ? (string) $keyData['kid'] : null,
+                alg: isset($keyData['alg']) ? (string) $keyData['alg'] : null,
+                use: isset($keyData['use']) ? (string) $keyData['use'] : null,
+                parameters: $keyData,
+            );
+        }
+
+        $this->cache[$jwksUri] = $keys;
+
+        return $keys;
+    }
+
+    /**
+     * Fetch a specific key by kid from a JWKS endpoint.
+     *
+     * If the kid is not found on the first attempt, the cache for that URI
+     * is cleared and the JWKS is re-fetched to handle key rotation. Returns
+     * null if the key still cannot be found after re-fetching.
+     */
+    public function fetchKey(string $jwksUri, string $kid): ?JwkKey
+    {
+        $keys = $this->fetchKeys($jwksUri);
+
+        foreach ($keys as $key) {
+            if ($key->kid === $kid) {
+                return $key;
+            }
+        }
+
+        // Key not found — clear cache and re-fetch for rotation support
+        unset($this->cache[$jwksUri]);
+
+        $keys = $this->fetchKeys($jwksUri);
+
+        foreach ($keys as $key) {
+            if ($key->kid === $kid) {
+                return $key;
+            }
+        }
+
+        return null;
+    }
+}

--- a/extensions/social-sso/src/Internal/Token/JwksFetcher.php
+++ b/extensions/social-sso/src/Internal/Token/JwksFetcher.php
@@ -8,6 +8,7 @@ use Pulsar\Api\Internal;
 use Pulsar\Extension\SocialSso\Domain\JwkKey;
 use Pulsar\Extension\SocialSso\Exception\SsoException;
 
+use function array_find;
 use function array_key_exists;
 use function file_get_contents;
 use function is_array;
@@ -101,11 +102,10 @@ final class JwksFetcher
     public function fetchKey(string $jwksUri, string $kid): ?JwkKey
     {
         $keys = $this->fetchKeys($jwksUri);
+        $found = array_find($keys, static fn (JwkKey $key): bool => $key->kid === $kid);
 
-        foreach ($keys as $key) {
-            if ($key->kid === $kid) {
-                return $key;
-            }
+        if ($found !== null) {
+            return $found;
         }
 
         // Key not found — clear cache and re-fetch for rotation support
@@ -113,12 +113,6 @@ final class JwksFetcher
 
         $keys = $this->fetchKeys($jwksUri);
 
-        foreach ($keys as $key) {
-            if ($key->kid === $kid) {
-                return $key;
-            }
-        }
-
-        return null;
+        return array_find($keys, static fn (JwkKey $key): bool => $key->kid === $kid);
     }
 }

--- a/extensions/social-sso/src/Internal/Token/JwksIdTokenVerifier.php
+++ b/extensions/social-sso/src/Internal/Token/JwksIdTokenVerifier.php
@@ -1,0 +1,258 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Token;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\IdTokenVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\JwtSignatureDriverInterface;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Domain\IdTokenVerificationContext;
+use Pulsar\Extension\SocialSso\Domain\JwkKey;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+
+use function base64_decode;
+use function count;
+use function explode;
+use function in_array;
+use function is_array;
+use function is_string;
+use function json_decode;
+use function str_repeat;
+use function str_replace;
+use function strlen;
+use function time;
+
+use const JSON_THROW_ON_ERROR;
+
+/**
+ * JWKS-backed OIDC ID token verifier.
+ *
+ * Verifies JWT signatures using keys fetched from the provider's JWKS endpoint,
+ * then validates all standard OIDC claims (issuer, audience, expiration, nonce)
+ * per the OpenID Connect Core specification Section 3.1.3.7.
+ */
+#[Internal]
+final readonly class JwksIdTokenVerifier implements IdTokenVerifierInterface
+{
+    public function __construct(
+        private JwksFetcher $fetcher,
+        private JwtSignatureDriverInterface $signatureDriver,
+    ) {}
+
+    #[Override]
+    public function verify(string $idToken, IdTokenVerificationContext $context): IdTokenClaims
+    {
+        $parts = explode('.', $idToken);
+
+        if (count($parts) !== 3) {
+            throw SsoException::invalidIdToken('token must have exactly three segments');
+        }
+
+        [$headerB64, $payloadB64, $signatureB64] = $parts;
+
+        // Decode header
+        /** @var array{alg?: string, kid?: string, typ?: string} $header */
+        $header = json_decode(self::base64UrlDecode($headerB64), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($header) || !isset($header['alg'])) {
+            throw SsoException::invalidIdToken('missing algorithm in header');
+        }
+
+        /** @var string $alg */
+        $alg = $header['alg'];
+
+        // Reject "none" algorithm
+        if ($alg === 'none') {
+            throw SsoException::unsupportedAlgorithm('none');
+        }
+
+        // Check driver supports the algorithm
+        if (!$this->signatureDriver->supports($alg)) {
+            throw SsoException::unsupportedAlgorithm($alg);
+        }
+
+        // Resolve the signing key
+        $key = $this->resolveSigningKey($context, $header);
+
+        // Verify signature
+        $signature = self::base64UrlDecode($signatureB64);
+
+        if (!$this->signatureDriver->verify($headerB64, $payloadB64, $signature, $key)) {
+            throw SsoException::signatureVerificationFailed();
+        }
+
+        // Decode payload
+        /** @var array<string, mixed> $claims */
+        $claims = json_decode(self::base64UrlDecode($payloadB64), true, 512, JSON_THROW_ON_ERROR);
+
+        if (!is_array($claims)) {
+            throw SsoException::invalidIdToken('payload is not a valid JSON object');
+        }
+
+        // Validate standard claims
+        $this->validateClaims($claims, $context);
+
+        // Build the IdTokenClaims DTO
+        /** @var string $sub */
+        $sub = $claims['sub'];
+        /** @var string $iss */
+        $iss = $claims['iss'];
+        /** @var string|list<string> $aud */
+        $aud = $claims['aud'];
+        /** @var int $exp */
+        $exp = (int) $claims['exp'];
+        /** @var int $iat */
+        $iat = (int) $claims['iat'];
+
+        $nonce = isset($claims['nonce']) && is_string($claims['nonce']) ? $claims['nonce'] : null;
+        $azp = isset($claims['azp']) && is_string($claims['azp']) ? $claims['azp'] : null;
+
+        // Remove standard claims from the extras
+        $standardKeys = ['sub', 'iss', 'aud', 'exp', 'iat', 'nonce', 'azp'];
+        $extraClaims = [];
+
+        foreach ($claims as $claimKey => $claimValue) {
+            if (!in_array($claimKey, $standardKeys, true)) {
+                $extraClaims[$claimKey] = $claimValue;
+            }
+        }
+
+        return new IdTokenClaims(
+            sub: $sub,
+            iss: $iss,
+            aud: $aud,
+            exp: $exp,
+            iat: $iat,
+            nonce: $nonce,
+            azp: $azp,
+            claims: $extraClaims,
+        );
+    }
+
+    /**
+     * Resolve the signing key from JWKS using the token header.
+     *
+     * @param array{alg?: string, kid?: string, typ?: string} $header
+     */
+    private function resolveSigningKey(IdTokenVerificationContext $context, array $header): JwkKey
+    {
+        $jwksUri = $context->issuer . '/.well-known/jwks.json';
+        $kid = $header['kid'] ?? null;
+
+        if ($kid !== null) {
+            $key = $this->fetcher->fetchKey($jwksUri, $kid);
+
+            if ($key === null) {
+                throw SsoException::invalidIdToken('key not found in JWKS for kid: ' . $kid);
+            }
+
+            return $key;
+        }
+
+        // No kid in header — determine key from JWKS
+        $keys = $this->fetcher->fetchKeys($jwksUri);
+
+        if (count($keys) === 0) {
+            throw SsoException::invalidIdToken('JWKS contains no keys');
+        }
+
+        if (count($keys) > 1) {
+            throw SsoException::invalidIdToken('missing kid for multi-key JWKS');
+        }
+
+        return $keys[0];
+    }
+
+    /**
+     * Validate standard OIDC claims against the verification context.
+     *
+     * @param array<string, mixed> $claims
+     */
+    private function validateClaims(array $claims, IdTokenVerificationContext $context): void
+    {
+        // Required claims
+        if (!isset($claims['sub']) || !is_string($claims['sub'])) {
+            throw SsoException::invalidIdToken('missing or invalid "sub" claim');
+        }
+
+        if (!isset($claims['iss']) || !is_string($claims['iss'])) {
+            throw SsoException::invalidIdToken('missing or invalid "iss" claim');
+        }
+
+        if (!isset($claims['aud'])) {
+            throw SsoException::invalidIdToken('missing "aud" claim');
+        }
+
+        if (!isset($claims['exp'])) {
+            throw SsoException::invalidIdToken('missing "exp" claim');
+        }
+
+        if (!isset($claims['iat'])) {
+            throw SsoException::invalidIdToken('missing "iat" claim');
+        }
+
+        // Validate issuer
+        if ($claims['iss'] !== $context->issuer) {
+            throw SsoException::invalidIdToken('issuer mismatch');
+        }
+
+        // Validate audience
+        /** @var string|list<string> $aud */
+        $aud = $claims['aud'];
+        $audList = is_array($aud) ? $aud : [$aud];
+
+        if (!in_array($context->clientId, $audList, true)) {
+            throw SsoException::invalidIdToken('audience mismatch');
+        }
+
+        // If aud contains multiple values, azp must be present and equal to clientId
+        if (count($audList) > 1) {
+            if (!isset($claims['azp']) || $claims['azp'] !== $context->clientId) {
+                throw SsoException::invalidIdToken('azp must equal client_id when multiple audiences are present');
+            }
+        }
+
+        // Validate expiration
+        $now = time();
+        $exp = (int) $claims['exp'];
+        $iat = (int) $claims['iat'];
+
+        if ($exp + $context->maxClockSkewSeconds < $now) {
+            throw SsoException::invalidIdToken('token has expired');
+        }
+
+        if ($iat - $context->maxClockSkewSeconds > $now) {
+            throw SsoException::invalidIdToken('token issued in the future');
+        }
+
+        // Validate nonce if expected
+        if ($context->nonce !== null) {
+            if (!isset($claims['nonce']) || !is_string($claims['nonce']) || $claims['nonce'] !== $context->nonce) {
+                throw SsoException::invalidIdToken('nonce mismatch');
+            }
+        }
+    }
+
+    /**
+     * Decode a base64url-encoded string (no padding, URL-safe alphabet).
+     */
+    private static function base64UrlDecode(string $data): string
+    {
+        $remainder = strlen($data) % 4;
+
+        if ($remainder !== 0) {
+            $data .= str_repeat('=', 4 - $remainder);
+        }
+
+        $decoded = base64_decode(str_replace(['-', '_'], ['+', '/'], $data), true);
+
+        if ($decoded === false) {
+            throw SsoException::invalidIdToken('invalid base64url encoding');
+        }
+
+        return $decoded;
+    }
+}

--- a/extensions/social-sso/src/Internal/Token/JwksIdTokenVerifier.php
+++ b/extensions/social-sso/src/Internal/Token/JwksIdTokenVerifier.php
@@ -13,6 +13,7 @@ use Pulsar\Extension\SocialSso\Domain\IdTokenVerificationContext;
 use Pulsar\Extension\SocialSso\Domain\JwkKey;
 use Pulsar\Extension\SocialSso\Exception\SsoException;
 
+use function array_filter;
 use function base64_decode;
 use function count;
 use function explode;
@@ -25,6 +26,7 @@ use function str_replace;
 use function strlen;
 use function time;
 
+use const ARRAY_FILTER_USE_BOTH;
 use const JSON_THROW_ON_ERROR;
 
 /**
@@ -102,9 +104,7 @@ final readonly class JwksIdTokenVerifier implements IdTokenVerifierInterface
         $iss = $claims['iss'];
         /** @var string|list<string> $aud */
         $aud = $claims['aud'];
-        /** @var int $exp */
         $exp = (int) $claims['exp'];
-        /** @var int $iat */
         $iat = (int) $claims['iat'];
 
         $nonce = isset($claims['nonce']) && is_string($claims['nonce']) ? $claims['nonce'] : null;
@@ -112,13 +112,11 @@ final readonly class JwksIdTokenVerifier implements IdTokenVerifierInterface
 
         // Remove standard claims from the extras
         $standardKeys = ['sub', 'iss', 'aud', 'exp', 'iat', 'nonce', 'azp'];
-        $extraClaims = [];
-
-        foreach ($claims as $claimKey => $claimValue) {
-            if (!in_array($claimKey, $standardKeys, true)) {
-                $extraClaims[$claimKey] = $claimValue;
-            }
-        }
+        $extraClaims = array_filter(
+            $claims,
+            static fn (mixed $v, string $k): bool => !in_array($k, $standardKeys, true),
+            ARRAY_FILTER_USE_BOTH,
+        );
 
         return new IdTokenClaims(
             sub: $sub,

--- a/extensions/social-sso/src/Internal/Token/OpenSslJwtSignatureDriver.php
+++ b/extensions/social-sso/src/Internal/Token/OpenSslJwtSignatureDriver.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso\Internal\Token;
+
+use Override;
+use Pulsar\Api\Internal;
+use Pulsar\Extension\SocialSso\Contracts\JwtSignatureDriverInterface;
+use Pulsar\Extension\SocialSso\Domain\JwkKey;
+
+use function chr;
+use function in_array;
+use function openssl_verify;
+use function ord;
+use function strlen;
+use function substr;
+
+use const OPENSSL_ALGO_SHA256;
+
+/**
+ * OpenSSL-based JWT signature verification driver.
+ *
+ * Supports RS256 (RSA PKCS#1 v1.5 with SHA-256) and ES256 (ECDSA P-256 with SHA-256).
+ * For ES256, converts the raw R+S concatenated signature to DER format before verification.
+ */
+#[Internal]
+final readonly class OpenSslJwtSignatureDriver implements JwtSignatureDriverInterface
+{
+    private const array SUPPORTED_ALGORITHMS = ['RS256', 'ES256'];
+    private const int ES256_COMPONENT_LENGTH = 32;
+
+    #[Override]
+    public function supports(string $algorithm): bool
+    {
+        return in_array($algorithm, self::SUPPORTED_ALGORITHMS, true);
+    }
+
+    #[Override]
+    public function verify(string $header, string $payload, string $signature, JwkKey $key): bool
+    {
+        $pem = $key->getPublicKeyPem();
+
+        if ($pem === null) {
+            return false;
+        }
+
+        $data = $header . '.' . $payload;
+        $alg = $key->alg ?? '';
+
+        return match ($alg) {
+            'RS256' => $this->verifyRs256($data, $signature, $pem),
+            'ES256' => $this->verifyEs256($data, $signature, $pem),
+            default => false,
+        };
+    }
+
+    /**
+     * Verify an RS256 signature using OpenSSL.
+     */
+    private function verifyRs256(string $data, string $signature, string $pem): bool
+    {
+        $result = openssl_verify($data, $signature, $pem, OPENSSL_ALGO_SHA256);
+
+        return $result === 1;
+    }
+
+    /**
+     * Verify an ES256 signature using OpenSSL.
+     *
+     * ECDSA JWT signatures use a raw R+S format (64 bytes for P-256),
+     * which must be converted to DER-encoded ASN.1 for OpenSSL.
+     */
+    private function verifyEs256(string $data, string $signature, string $pem): bool
+    {
+        $componentLength = self::ES256_COMPONENT_LENGTH;
+
+        if (strlen($signature) !== $componentLength * 2) {
+            return false;
+        }
+
+        $r = substr($signature, 0, $componentLength);
+        $s = substr($signature, $componentLength);
+
+        $derSignature = self::ecRawToDer($r, $s);
+
+        $result = openssl_verify($data, $derSignature, $pem, OPENSSL_ALGO_SHA256);
+
+        return $result === 1;
+    }
+
+    /**
+     * Convert raw R and S integers to DER-encoded ASN.1 SEQUENCE of INTEGERs.
+     *
+     * Strips leading zero bytes but prepends 0x00 if the high bit is set
+     * (to ensure unsigned integer encoding in ASN.1).
+     */
+    private static function ecRawToDer(string $r, string $s): string
+    {
+        $r = self::trimLeadingZeros($r);
+        $s = self::trimLeadingZeros($s);
+
+        // Ensure unsigned integer encoding
+        if (ord($r[0]) > 0x7f) {
+            $r = "\x00" . $r;
+        }
+        if (ord($s[0]) > 0x7f) {
+            $s = "\x00" . $s;
+        }
+
+        $rAsn = "\x02" . chr(strlen($r)) . $r;
+        $sAsn = "\x02" . chr(strlen($s)) . $s;
+        $sequence = $rAsn . $sAsn;
+
+        return "\x30" . chr(strlen($sequence)) . $sequence;
+    }
+
+    /**
+     * Strip leading zero bytes from an integer, preserving at least one byte.
+     */
+    private static function trimLeadingZeros(string $data): string
+    {
+        $length = strlen($data);
+
+        for ($i = 0; $i < $length - 1; $i++) {
+            if (ord($data[$i]) !== 0) {
+                break;
+            }
+        }
+
+        return substr($data, $i);
+    }
+}

--- a/extensions/social-sso/src/SocialSsoExtension.php
+++ b/extensions/social-sso/src/SocialSsoExtension.php
@@ -7,7 +7,6 @@ namespace Pulsar\Extension\SocialSso;
 use Pulsar\Container\ContainerInterface;
 use Pulsar\Extensibility\ExtensionInterface;
 use Pulsar\Extensibility\ServiceProviderInterface;
-use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
 use Pulsar\Routing\RouterInterface;
 
 /**
@@ -30,13 +29,6 @@ final class SocialSsoExtension implements ExtensionInterface
 
     public function boot(ContainerInterface $container, RouterInterface $router): void
     {
-        /** @var SocialSsoConfig $config */
-        $config = $container->get(SocialSsoConfig::class);
-
-        if (!$config->enabled) {
-            return;
-        }
-
         // Routes are registered by the service provider or manually by the app
     }
 

--- a/extensions/social-sso/src/SocialSsoExtension.php
+++ b/extensions/social-sso/src/SocialSsoExtension.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso;
+
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ExtensionInterface;
+use Pulsar\Extensibility\ServiceProviderInterface;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Routing\RouterInterface;
+
+/**
+ * Social SSO extension for OAuth-based single sign-on.
+ *
+ * Provides vendor-agnostic social authentication with PKCE, nonce verification,
+ * JWKS-based ID token validation, and pluggable identity linking.
+ */
+final class SocialSsoExtension implements ExtensionInterface
+{
+    public function name(): string
+    {
+        return 'pulsar/social-sso';
+    }
+
+    public function register(ContainerInterface $container): void
+    {
+        // Service provider handles all bindings
+    }
+
+    public function boot(ContainerInterface $container, RouterInterface $router): void
+    {
+        /** @var SocialSsoConfig $config */
+        $config = $container->get(SocialSsoConfig::class);
+
+        if (!$config->enabled) {
+            return;
+        }
+
+        // Routes are registered by the service provider or manually by the app
+    }
+
+    /**
+     * @return list<class-string<ServiceProviderInterface>>
+     */
+    public function providers(): array
+    {
+        return [
+            SocialSsoServiceProvider::class,
+        ];
+    }
+}

--- a/extensions/social-sso/src/SocialSsoServiceProvider.php
+++ b/extensions/social-sso/src/SocialSsoServiceProvider.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\SocialSso;
+
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ServiceProviderInterface;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\IdTokenVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\JwtSignatureDriverInterface;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Contracts\SocialIdentityLinkerInterface;
+use Pulsar\Extension\SocialSso\Contracts\SsoGatewayInterface;
+use Pulsar\Extension\SocialSso\Gateway\SsoGateway;
+use Pulsar\Extension\SocialSso\Internal\Linker\NullSocialIdentityLinker;
+use Pulsar\Extension\SocialSso\Internal\Provider\OAuthProviderRegistry;
+use Pulsar\Extension\SocialSso\Internal\Session\SessionNonceVerifier;
+use Pulsar\Extension\SocialSso\Internal\Session\SessionOAuthStateManager;
+use Pulsar\Extension\SocialSso\Internal\Token\JwksFetcher;
+use Pulsar\Extension\SocialSso\Internal\Token\JwksIdTokenVerifier;
+use Pulsar\Extension\SocialSso\Internal\Token\OpenSslJwtSignatureDriver;
+use Pulsar\Security\Session\SessionInterface;
+
+/**
+ * Service provider for the social SSO extension.
+ *
+ * Binds all SSO services to the container: OAuth provider registry, state management,
+ * nonce verification, JWT/JWKS verification, identity linking, and the SSO gateway.
+ */
+final class SocialSsoServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerInterface $container): void
+    {
+        // Config
+        $container->bind(SocialSsoConfig::class, static function () use ($container): SocialSsoConfig {
+            /** @var array<string, mixed> $configData */
+            $configData = [];
+
+            if ($container->has('config.social_sso')) {
+                /** @var array<string, mixed> $configData */
+                $configData = $container->get('config.social_sso');
+            }
+
+            return SocialSsoConfig::fromArray($configData);
+        });
+
+        // OAuth provider registry
+        $container->bind(OAuthProviderRegistryInterface::class, OAuthProviderRegistry::class);
+
+        // OAuth state manager (session-backed)
+        $container->bind(OAuthStateManagerInterface::class, static function () use ($container): OAuthStateManagerInterface {
+            /** @var SessionInterface $session */
+            $session = $container->get(SessionInterface::class);
+
+            /** @var SocialSsoConfig $config */
+            $config = $container->get(SocialSsoConfig::class);
+
+            return new SessionOAuthStateManager($session, $config->stateTtlSeconds);
+        });
+
+        // Nonce verifier (session-backed)
+        $container->bind(NonceVerifierInterface::class, static function () use ($container): NonceVerifierInterface {
+            /** @var SessionInterface $session */
+            $session = $container->get(SessionInterface::class);
+
+            return new SessionNonceVerifier($session);
+        });
+
+        // JWT signature driver
+        $container->bind(JwtSignatureDriverInterface::class, OpenSslJwtSignatureDriver::class);
+
+        // JWKS fetcher
+        $container->bind(JwksFetcher::class, JwksFetcher::class);
+
+        // ID token verifier (JWKS-based)
+        $container->bind(IdTokenVerifierInterface::class, JwksIdTokenVerifier::class);
+
+        // Social identity linker (null default — apps override with their own implementation)
+        $container->bind(SocialIdentityLinkerInterface::class, NullSocialIdentityLinker::class);
+
+        // SSO gateway
+        $container->bind(SsoGateway::class, SsoGateway::class);
+        $container->bind(SsoGatewayInterface::class, SsoGateway::class);
+    }
+
+    public function provides(): array
+    {
+        return [
+            SocialSsoConfig::class,
+            OAuthProviderRegistryInterface::class,
+            OAuthStateManagerInterface::class,
+            NonceVerifierInterface::class,
+            JwtSignatureDriverInterface::class,
+            JwksFetcher::class,
+            IdTokenVerifierInterface::class,
+            SocialIdentityLinkerInterface::class,
+            SsoGateway::class,
+            SsoGatewayInterface::class,
+        ];
+    }
+}

--- a/src/Auth/Middleware/StepUpMiddleware.php
+++ b/src/Auth/Middleware/StepUpMiddleware.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\Middleware;
+
+use Override;
+use Pulsar\Auth\SecurityContext;
+use Pulsar\Http\Middleware\MiddlewareInterface;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Security\Session\SessionInterface;
+
+/**
+ * Route-level middleware requiring step-up authentication for sensitive operations.
+ *
+ * Checks for a per-identity step-up timestamp in the session. If missing or expired,
+ * returns 403 Forbidden. Identity scoping prevents cross-account step-up inheritance.
+ */
+final readonly class StepUpMiddleware implements MiddlewareInterface
+{
+    private const string SESSION_KEY_PREFIX = '_pulsar_step_up';
+
+    public function __construct(
+        private SessionInterface $session,
+        private int $timeoutMinutes = 15,
+    ) {}
+
+    #[Override]
+    public function process(Request $request, callable $next): Response
+    {
+        /** @var SecurityContext|null $securityContext */
+        $securityContext = $request->attribute('_security_context');
+
+        if ($securityContext === null) {
+            return $this->forbiddenResponse($request);
+        }
+
+        $identity = $securityContext->identity();
+
+        if (!$identity->isAuthenticated()) {
+            return $this->forbiddenResponse($request);
+        }
+
+        $identityId = $identity->id();
+        $sessionKey = self::SESSION_KEY_PREFIX . '[' . $identityId . ']';
+
+        /** @var int|null $stepUpAt */
+        $stepUpAt = $this->session->get($sessionKey);
+
+        if ($stepUpAt === null) {
+            return $this->forbiddenResponse($request);
+        }
+
+        $expiresAt = $stepUpAt + ($this->timeoutMinutes * 60);
+
+        if (time() > $expiresAt) {
+            return $this->forbiddenResponse($request);
+        }
+
+        return $next($request);
+    }
+
+    /**
+     * Mark an identity as step-up authenticated in the session.
+     */
+    public static function markStepUpAuthenticated(SessionInterface $session, string $identityId): void
+    {
+        $sessionKey = self::SESSION_KEY_PREFIX . '[' . $identityId . ']';
+        $session->set($sessionKey, time());
+    }
+
+    private function forbiddenResponse(Request $request): Response
+    {
+        if ($request->wantsJson()) {
+            return Response::json(
+                ['error' => 'Step-up authentication required', 'status' => 403],
+                ResponseStatus::Forbidden,
+            );
+        }
+
+        return new Response(
+            body: 'Step-up authentication required',
+            status: ResponseStatus::Forbidden,
+        );
+    }
+}

--- a/src/Auth/TwoFactor/AuthEventCollectorInterface.php
+++ b/src/Auth/TwoFactor/AuthEventCollectorInterface.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Collects 2FA events for observability (e.g., Studio dashboard).
+ *
+ * Uses an allowlist approach: only known-safe metadata keys are passed
+ * (action, outcome, identity_id, purpose, reason, code_index, provider).
+ * Unknown keys are stripped to prevent accidental secret leakage.
+ */
+#[Api(since: '1.0.0')]
+interface AuthEventCollectorInterface
+{
+    /**
+     * Record a two-factor authentication event.
+     *
+     * @param string $action The event action (e.g., '2fa_code_verified')
+     * @param string $outcome The outcome (e.g., 'success', 'failure', 'denied')
+     * @param string $identityId The identity involved
+     * @param array<string, scalar> $metadata Allowlisted metadata (no secrets)
+     */
+    public function recordTwoFactorEvent(
+        string $action,
+        string $outcome,
+        string $identityId,
+        array $metadata = [],
+    ): void;
+}

--- a/src/Auth/TwoFactor/Confirm2faSetupResult.php
+++ b/src/Auth/TwoFactor/Confirm2faSetupResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Result of a 2FA setup confirmation.
+ */
+#[Api(since: '1.0.0')]
+final readonly class Confirm2faSetupResult
+{
+    public function __construct(
+        public bool $confirmed,
+        public VerifyReason $reason,
+    ) {}
+
+    public static function success(): self
+    {
+        return new self(true, VerifyReason::Valid);
+    }
+
+    public static function failure(VerifyReason $reason): self
+    {
+        return new self(false, $reason);
+    }
+}

--- a/src/Auth/TwoFactor/ConsumeReason.php
+++ b/src/Auth/TwoFactor/ConsumeReason.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Reason codes for recovery code consume operations.
+ */
+#[Api(since: '1.0.0')]
+enum ConsumeReason: string
+{
+    case Consumed = 'consumed';
+    case NotFound = 'not_found';
+    case AlreadyUsed = 'already_used';
+    case NotEnrolled = 'not_enrolled';
+    case RateLimited = 'rate_limited';
+}

--- a/src/Auth/TwoFactor/ConsumeResult.php
+++ b/src/Auth/TwoFactor/ConsumeResult.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Result of a recovery code consume operation.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ConsumeResult
+{
+    public function __construct(
+        public bool $consumed,
+        public int $codeIndex,
+        public ConsumeReason $reason,
+    ) {}
+
+    public static function success(int $codeIndex): self
+    {
+        return new self(true, $codeIndex, ConsumeReason::Consumed);
+    }
+
+    public static function failure(ConsumeReason $reason): self
+    {
+        return new self(false, -1, $reason);
+    }
+}

--- a/src/Auth/TwoFactor/InMemoryRecoveryCodeStore.php
+++ b/src/Auth/TwoFactor/InMemoryRecoveryCodeStore.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use function array_search;
+
+use Pulsar\Api\Internal;
+
+/**
+ * In-memory recovery code store for testing and development.
+ *
+ * Not suitable for production — state is lost on process restart.
+ * Bind a database-backed implementation for persistent storage.
+ */
+#[Internal]
+final class InMemoryRecoveryCodeStore implements RecoveryCodeStoreInterface
+{
+    /** @var array<string, RecoveryCodeSet> */
+    private array $sets = [];
+
+    public function loadSet(string $identityId): ?RecoveryCodeSet
+    {
+        return $this->sets[$identityId] ?? null;
+    }
+
+    public function consume(string $identityId, string $codeHash): ConsumeResult
+    {
+        $set = $this->sets[$identityId] ?? null;
+
+        if ($set === null) {
+            return ConsumeResult::failure(ConsumeReason::NotEnrolled);
+        }
+
+        $index = array_search($codeHash, $set->codeHashes, true);
+
+        if ($index === false) {
+            return ConsumeResult::failure(ConsumeReason::NotFound);
+        }
+
+        /** @var int $index */
+        if ($set->isUsed($index)) {
+            return ConsumeResult::failure(ConsumeReason::AlreadyUsed);
+        }
+
+        $this->sets[$identityId] = $set->withUsedIndex($index);
+
+        return ConsumeResult::success($index);
+    }
+
+    public function store(string $identityId, RecoveryCodeSet $set): void
+    {
+        $this->sets[$identityId] = $set;
+    }
+}

--- a/src/Auth/TwoFactor/InMemoryTotpReplayGuard.php
+++ b/src/Auth/TwoFactor/InMemoryTotpReplayGuard.php
@@ -5,42 +5,46 @@ declare(strict_types=1);
 namespace Pulsar\Auth\TwoFactor;
 
 use function array_filter;
-use function hash;
 
 use Pulsar\Api\Internal;
 
 /**
  * In-memory TOTP replay guard for single-process and testing use.
  *
- * Tracks used codes in process memory. Does not protect against replay
- * attacks across different processes or workers — use SqliteTotpReplayGuard
- * for production multi-worker deployments.
+ * Tracks used time steps in process memory keyed by (identityId, purpose, timeStep).
+ * Does not protect against replay attacks across different processes or workers —
+ * use SqliteTotpReplayGuard for production multi-worker deployments.
  */
 #[Internal]
 final class InMemoryTotpReplayGuard implements TotpReplayGuardInterface
 {
     /**
-     * @var array<string, array<string, int>> identity => [codeHash => timestamp]
+     * @var array<string, int> compositeKey => timestamp
      */
     private array $used = [];
 
-    public function markUsed(string $identityId, string $code, int $timestamp): bool
+    private int $ttl;
+
+    public function __construct(int $ttl = 90)
     {
-        $codeHash = hash('sha256', $code);
+        $this->ttl = $ttl;
+    }
 
-        // Prune expired entries for this identity (older than 90 seconds)
-        if (isset($this->used[$identityId])) {
-            $this->used[$identityId] = array_filter(
-                $this->used[$identityId],
-                static fn(int $ts): bool => $ts > $timestamp - 90,
-            );
-        }
+    public function markUsed(string $identityId, TwoFactorPurpose $purpose, int $timeStep, int $timestamp): bool
+    {
+        $key = $identityId . ':' . $purpose->value . ':' . $timeStep;
 
-        if (isset($this->used[$identityId][$codeHash])) {
+        // Prune expired entries
+        $this->used = array_filter(
+            $this->used,
+            fn(int $ts): bool => $ts > $timestamp - $this->ttl,
+        );
+
+        if (isset($this->used[$key])) {
             return false;
         }
 
-        $this->used[$identityId][$codeHash] = $timestamp;
+        $this->used[$key] = $timestamp;
 
         return true;
     }

--- a/src/Auth/TwoFactor/InMemoryTotpSecretStore.php
+++ b/src/Auth/TwoFactor/InMemoryTotpSecretStore.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Internal;
+use Pulsar\Security\Crypto\EncryptorInterface;
+use SensitiveParameter;
+
+/**
+ * In-memory TOTP secret store for testing and development.
+ *
+ * Encrypts secrets using the provided Encryptor (AEAD, XSalsa20-Poly1305).
+ * Not suitable for production — state is lost on process restart.
+ * Bind a database-backed implementation for persistent storage.
+ */
+#[Internal]
+final class InMemoryTotpSecretStore implements TotpSecretStoreInterface
+{
+    /** @var array<string, string> identityId => encrypted secret */
+    private array $secrets = [];
+
+    public function __construct(
+        private readonly ?EncryptorInterface $encryptor = null,
+    ) {}
+
+    public function store(string $identityId, #[SensitiveParameter] string $secret): void
+    {
+        $this->secrets[$identityId] = $this->encryptor !== null
+            ? $this->encryptor->encrypt($secret)
+            : $secret;
+    }
+
+    public function retrieve(string $identityId): ?string
+    {
+        if (!isset($this->secrets[$identityId])) {
+            return null;
+        }
+
+        return $this->encryptor !== null
+            ? $this->encryptor->decrypt($this->secrets[$identityId])
+            : $this->secrets[$identityId];
+    }
+
+    public function delete(string $identityId): void
+    {
+        unset($this->secrets[$identityId]);
+    }
+}

--- a/src/Auth/TwoFactor/RecoveryCodeGenerator.php
+++ b/src/Auth/TwoFactor/RecoveryCodeGenerator.php
@@ -5,24 +5,32 @@ declare(strict_types=1);
 namespace Pulsar\Auth\TwoFactor;
 
 use function bin2hex;
+use function ord;
 
 use Random\Engine\Secure;
 use Random\RandomException;
 use Random\Randomizer;
 
 use function sprintf;
+use function str_replace;
+use function strlen;
 use function strtoupper;
 use function substr;
 
 /**
- * Generates recovery codes in XXXX-XXXX format.
+ * Generates recovery codes in XXXX-XXXX-XXXX-XXXX format (64-bit entropy).
+ *
+ * Each code is 16 hex characters (8 bytes of randomness) with optional
+ * checksum group for typo detection.
  */
 final readonly class RecoveryCodeGenerator
 {
     private Randomizer $randomizer;
 
-    public function __construct(?Randomizer $randomizer = null)
-    {
+    public function __construct(
+        ?Randomizer $randomizer = null,
+        private int $bytesPerCode = 8,
+    ) {
         $this->randomizer = $randomizer ?? new Randomizer(new Secure());
     }
 
@@ -30,7 +38,7 @@ final readonly class RecoveryCodeGenerator
      * Generate a set of recovery codes.
      *
      * @param int $count Number of codes to generate
-     * @return list<string> Recovery codes in XXXX-XXXX format
+     * @return list<string> Recovery codes in XXXX-XXXX-XXXX-XXXX format
      *
      * @throws RandomException
      */
@@ -39,11 +47,52 @@ final readonly class RecoveryCodeGenerator
         $codes = [];
 
         for ($i = 0; $i < $count; $i++) {
-            $bytes = $this->randomizer->getBytes(4);
+            $bytes = $this->randomizer->getBytes($this->bytesPerCode);
             $hex = strtoupper(bin2hex($bytes));
-            $codes[] = sprintf('%s-%s', substr($hex, 0, 4), substr($hex, 4, 4));
+
+            $codes[] = match ($this->bytesPerCode) {
+                4 => sprintf('%s-%s', substr($hex, 0, 4), substr($hex, 4, 4)),
+                default => sprintf(
+                    '%s-%s-%s-%s',
+                    substr($hex, 0, 4),
+                    substr($hex, 4, 4),
+                    substr($hex, 8, 4),
+                    substr($hex, 12, 4),
+                ),
+            };
         }
 
         return $codes;
+    }
+
+    /**
+     * Compute a 2-hex-char checksum for a recovery code.
+     *
+     * XORs all bytes of the canonical (no dashes) hex representation to produce
+     * a single byte used for typo detection.
+     */
+    public static function checksum(string $code): string
+    {
+        $canonical = self::canonicalize($code);
+        $bytes = hex2bin($canonical);
+
+        if ($bytes === false) {
+            return '00';
+        }
+
+        $xor = 0;
+        for ($i = 0; $i < strlen($bytes); $i++) {
+            $xor ^= ord($bytes[$i]);
+        }
+
+        return strtoupper(sprintf('%02X', $xor));
+    }
+
+    /**
+     * Canonicalize a recovery code: uppercase, strip dashes and spaces.
+     */
+    public static function canonicalize(string $code): string
+    {
+        return strtoupper(str_replace(['-', ' '], '', $code));
     }
 }

--- a/src/Auth/TwoFactor/RecoveryCodeHasher.php
+++ b/src/Auth/TwoFactor/RecoveryCodeHasher.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use function hash_equals;
+
+use Pulsar\Api\Internal;
+use Pulsar\Security\Crypto\Hmac;
+use SensitiveParameter;
+use SodiumException;
+
+use function str_replace;
+use function strtoupper;
+
+/**
+ * Hashes recovery codes using HMAC-BLAKE2b with a derived key.
+ *
+ * Canonicalizes input (uppercase, strip dashes/spaces) before hashing
+ * for consistent matching regardless of user input formatting.
+ */
+#[Internal]
+final readonly class RecoveryCodeHasher
+{
+    public function __construct(
+        #[SensitiveParameter]
+        private string $key,
+    ) {}
+
+    /**
+     * Hash a single recovery code.
+     *
+     * @throws SodiumException
+     */
+    public function hash(#[SensitiveParameter] string $code): string
+    {
+        return Hmac::computeHex(self::canonicalize($code), $this->key);
+    }
+
+    /**
+     * Hash a list of recovery codes.
+     *
+     * @param list<string> $codes
+     * @return list<string>
+     *
+     * @throws SodiumException
+     */
+    public function hashAll(array $codes): array
+    {
+        $hashes = [];
+
+        foreach ($codes as $code) {
+            $hashes[] = $this->hash($code);
+        }
+
+        return $hashes;
+    }
+
+    /**
+     * Verify a code against a list of hashed codes.
+     *
+     * @param list<string> $hashedCodes
+     * @return int Index of matching hash, or -1 if no match
+     *
+     * @throws SodiumException
+     */
+    public function verify(#[SensitiveParameter] string $code, array $hashedCodes): int
+    {
+        $hash = $this->hash($code);
+
+        foreach ($hashedCodes as $index => $hashedCode) {
+            if (hash_equals($hashedCode, $hash)) {
+                return $index;
+            }
+        }
+
+        return -1;
+    }
+
+    /**
+     * Canonicalize a recovery code: uppercase, strip dashes and spaces.
+     */
+    public static function canonicalize(string $code): string
+    {
+        return strtoupper(str_replace(['-', ' '], '', $code));
+    }
+}

--- a/src/Auth/TwoFactor/RecoveryCodeRotationResult.php
+++ b/src/Auth/TwoFactor/RecoveryCodeRotationResult.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Result of a recovery code rotation operation.
+ */
+#[Api(since: '1.0.0')]
+final readonly class RecoveryCodeRotationResult
+{
+    /**
+     * @param RecoveryCodeSet $set The new hashed recovery code set
+     * @param list<string> $plaintextCodes The new plaintext codes (show once, then discard)
+     */
+    public function __construct(
+        public RecoveryCodeSet $set,
+        public array $plaintextCodes,
+    ) {}
+}

--- a/src/Auth/TwoFactor/RecoveryCodeSet.php
+++ b/src/Auth/TwoFactor/RecoveryCodeSet.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use function count;
+use function in_array;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Immutable value object representing a set of hashed recovery codes.
+ */
+#[Api(since: '1.0.0')]
+final readonly class RecoveryCodeSet
+{
+    /**
+     * @param string $setId Unique identifier for this code set (128-bit hex)
+     * @param list<string> $codeHashes HMAC-BLAKE2b hashes of each code
+     * @param list<int> $usedIndices Indices of consumed codes
+     * @param int $algorithmVersion 1 = 32-bit legacy, 2 = 64-bit
+     * @param int $createdAt Unix timestamp of creation
+     */
+    public function __construct(
+        public string $setId,
+        public array $codeHashes,
+        public array $usedIndices,
+        public int $algorithmVersion,
+        public int $createdAt,
+    ) {}
+
+    public function isUsed(int $index): bool
+    {
+        return in_array($index, $this->usedIndices, true);
+    }
+
+    #[NoDiscard]
+    public function withUsedIndex(int $index): self
+    {
+        if ($this->isUsed($index)) {
+            return $this;
+        }
+
+        return new self(
+            $this->setId,
+            $this->codeHashes,
+            [...$this->usedIndices, $index],
+            $this->algorithmVersion,
+            $this->createdAt,
+        );
+    }
+
+    public function remainingCount(): int
+    {
+        return count($this->codeHashes) - count($this->usedIndices);
+    }
+}

--- a/src/Auth/TwoFactor/RecoveryCodeStoreInterface.php
+++ b/src/Auth/TwoFactor/RecoveryCodeStoreInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Persistence contract for recovery code sets.
+ *
+ * Implementations provide atomic consume to prevent race conditions
+ * where two concurrent requests could both consume the same code.
+ */
+#[Api(since: '1.0.0')]
+interface RecoveryCodeStoreInterface
+{
+    /**
+     * Load the recovery code set for an identity.
+     *
+     * @return RecoveryCodeSet|null null when the identity has no recovery codes
+     */
+    public function loadSet(string $identityId): ?RecoveryCodeSet;
+
+    /**
+     * Atomically consume a recovery code by its hash.
+     *
+     * Must be atomic — if two concurrent requests try to consume the same code,
+     * exactly one succeeds and the other returns AlreadyUsed.
+     *
+     * @param string $identityId Identity owning the code set
+     * @param string $codeHash HMAC hash of the code to consume
+     */
+    public function consume(string $identityId, string $codeHash): ConsumeResult;
+
+    /**
+     * Store a recovery code set for an identity.
+     *
+     * Overwrites any existing set.
+     */
+    public function store(string $identityId, RecoveryCodeSet $set): void;
+}

--- a/src/Auth/TwoFactor/SqliteTotpReplayGuard.php
+++ b/src/Auth/TwoFactor/SqliteTotpReplayGuard.php
@@ -4,8 +4,6 @@ declare(strict_types=1);
 
 namespace Pulsar\Auth\TwoFactor;
 
-use function hash;
-
 use PDO;
 use PDOException;
 use Pulsar\Api\Internal;
@@ -16,9 +14,9 @@ use function random_int;
 /**
  * TOTP replay guard backed by SQLite.
  *
- * Stores used TOTP codes in a shared SQLite database, providing
- * cross-process replay protection. Uses WAL mode for concurrent access
- * from multiple PHP-FPM workers.
+ * Stores used TOTP time steps in a shared SQLite database keyed by
+ * (identity_id, purpose, time_step), providing cross-process replay
+ * protection. Uses WAL mode for concurrent access from multiple PHP-FPM workers.
  */
 #[Internal]
 final readonly class SqliteTotpReplayGuard implements TotpReplayGuardInterface
@@ -29,28 +27,30 @@ final readonly class SqliteTotpReplayGuard implements TotpReplayGuardInterface
     {
         $this->db = SqliteWalFactory::create($storagePath, <<<'SQL'
             CREATE TABLE IF NOT EXISTS totp_used (
-                identity_code TEXT PRIMARY KEY,
-                used_at INTEGER NOT NULL
+                identity_id TEXT NOT NULL,
+                purpose TEXT NOT NULL,
+                time_step INTEGER NOT NULL,
+                used_at INTEGER NOT NULL,
+                PRIMARY KEY (identity_id, purpose, time_step)
             )
             SQL);
     }
 
-    public function markUsed(string $identityId, string $code, int $timestamp): bool
+    public function markUsed(string $identityId, TwoFactorPurpose $purpose, int $timeStep, int $timestamp): bool
     {
-        $key = $identityId . ':' . hash('sha256', $code);
-
         // Probabilistic pruning — entries older than 90 seconds
         if (random_int(1, 20) === 1) {
             $this->prune($timestamp - 90);
         }
 
         try {
-            $this->db->prepare('INSERT INTO totp_used (identity_code, used_at) VALUES (?, ?)')
-                ->execute([$key, $timestamp]);
+            $this->db->prepare(
+                'INSERT INTO totp_used (identity_id, purpose, time_step, used_at) VALUES (?, ?, ?, ?)',
+            )->execute([$identityId, $purpose->value, $timeStep, $timestamp]);
 
             return true;
         } catch (PDOException) {
-            // UNIQUE constraint violation — code already used
+            // PRIMARY KEY constraint violation — time step already used
             return false;
         }
     }

--- a/src/Auth/TwoFactor/TotpGenerator.php
+++ b/src/Auth/TwoFactor/TotpGenerator.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pulsar\Auth\TwoFactor;
 
+use function assert;
 use function hash_hmac;
 use function intdiv;
 use function ord;
@@ -33,7 +34,34 @@ final readonly class TotpGenerator
         private string $algorithm = 'sha1',
         ?Randomizer $randomizer = null,
     ) {
+        assert($period > 0, 'TOTP period must be positive');
+        assert($codeDigits >= 6 && $codeDigits <= 10, 'TOTP digits must be between 6 and 10');
+
         $this->randomizer = $randomizer ?? new Randomizer(new Secure());
+    }
+
+    /**
+     * Get the TOTP period in seconds.
+     *
+     * @return positive-int
+     */
+    public function period(): int
+    {
+        assert($this->period > 0);
+
+        return $this->period;
+    }
+
+    /**
+     * Get the number of digits in generated codes.
+     *
+     * @return int<6, 10>
+     */
+    public function digits(): int
+    {
+        assert($this->codeDigits >= 6 && $this->codeDigits <= 10);
+
+        return $this->codeDigits;
     }
 
     /**

--- a/src/Auth/TwoFactor/TotpReplayGuardInterface.php
+++ b/src/Auth/TwoFactor/TotpReplayGuardInterface.php
@@ -9,21 +9,25 @@ use Pulsar\Api\Api;
 /**
  * Prevents TOTP code replay attacks.
  *
- * Implementations track which codes have been used for each identity
- * within the current time window to prevent the same code from being
- * accepted more than once.
+ * Implementations track which time steps have been used for each identity
+ * and purpose to prevent the same code from being accepted more than once.
+ *
+ * The key scope is (identityId, purpose, timeStep) — not (identityId, code).
+ * This prevents replay across different purposes and correctly ties the
+ * guard to the accepted time step rather than the code string.
  */
 #[Api(since: '1.0.0')]
 interface TotpReplayGuardInterface
 {
     /**
-     * Mark a TOTP code as used and return whether it was previously unused.
+     * Mark a time step as used and return whether it was previously unused.
      *
      * @param string $identityId Identity that submitted the code
-     * @param string $code The TOTP code
-     * @param int $timestamp Unix timestamp of the verification
+     * @param TwoFactorPurpose $purpose The verification purpose
+     * @param int $timeStep The accepted TOTP time step (counter value, not timestamp)
+     * @param int $timestamp Unix timestamp of the verification (for TTL pruning)
      *
-     * @return bool true if the code was not previously used (now marked), false if already used
+     * @return bool true if the time step was not previously used (now marked), false if already used
      */
-    public function markUsed(string $identityId, string $code, int $timestamp): bool;
+    public function markUsed(string $identityId, TwoFactorPurpose $purpose, int $timeStep, int $timestamp): bool;
 }

--- a/src/Auth/TwoFactor/TotpSecretStoreInterface.php
+++ b/src/Auth/TwoFactor/TotpSecretStoreInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+use SensitiveParameter;
+
+/**
+ * Persistence contract for TOTP shared secrets.
+ *
+ * Implementations must encrypt secrets at rest. The framework provides
+ * InMemoryTotpSecretStore for testing; production deployments bind a
+ * database-backed implementation.
+ */
+#[Api(since: '1.0.0')]
+interface TotpSecretStoreInterface
+{
+    /**
+     * Store an encrypted TOTP secret for an identity.
+     *
+     * @param string $identityId The identity owning this secret
+     * @param string $secret The raw binary TOTP secret to encrypt and store
+     */
+    public function store(string $identityId, #[SensitiveParameter] string $secret): void;
+
+    /**
+     * Retrieve and decrypt a TOTP secret for an identity.
+     *
+     * @param string $identityId The identity owning this secret
+     * @return string|null Decrypted raw secret, or null if not found
+     */
+    public function retrieve(string $identityId): ?string;
+
+    /**
+     * Delete a stored TOTP secret.
+     *
+     * @param string $identityId The identity owning this secret
+     */
+    public function delete(string $identityId): void;
+}

--- a/src/Auth/TwoFactor/TotpVerifier.php
+++ b/src/Auth/TwoFactor/TotpVerifier.php
@@ -5,9 +5,14 @@ declare(strict_types=1);
 namespace Pulsar\Auth\TwoFactor;
 
 use function hash_equals;
+use function intdiv;
+
+use SensitiveParameter;
 
 /**
  * Verifies TOTP codes with a configurable time window to account for clock drift.
+ *
+ * Returns the accepted time step on success for replay guard keying and diagnostics.
  */
 final readonly class TotpVerifier
 {
@@ -20,37 +25,48 @@ final readonly class TotpVerifier
      * Verify a TOTP code against the given secret.
      *
      * Checks the code against the current time step and ±window adjacent steps.
-     * When a replay guard and identity ID are provided, ensures the same code
-     * cannot be accepted twice within the time window.
+     * When a replay guard, identity ID, and purpose are provided, ensures the same
+     * time step cannot be accepted twice within the window.
+     *
+     * Returns the accepted time step on match (for replay guard keying), or null on failure.
      *
      * @param string $secret Raw binary secret
      * @param string $code User-provided code
      * @param int|null $timestamp Unix timestamp (defaults to current time)
      * @param TotpReplayGuardInterface|null $replayGuard Replay protection (recommended for production)
      * @param string|null $identityId Identity submitting the code (required with replay guard)
+     * @param TwoFactorPurpose $purpose The verification purpose
      */
     public function verify(
+        #[SensitiveParameter]
         string $secret,
+        #[SensitiveParameter]
         string $code,
         ?int $timestamp = null,
         ?TotpReplayGuardInterface $replayGuard = null,
         ?string $identityId = null,
-    ): bool {
+        TwoFactorPurpose $purpose = TwoFactorPurpose::Login,
+    ): ?int {
         $timestamp ??= time();
+        $period = $this->generator->period();
 
         for ($i = -$this->window; $i <= $this->window; $i++) {
-            $checkTime = $timestamp + ($i * 30);
+            $checkTime = $timestamp + ($i * $period);
             $expected = $this->generator->computeCode($secret, $checkTime);
 
             if (hash_equals($expected, $code)) {
+                $timeStep = intdiv($checkTime, $period);
+
                 if ($replayGuard !== null && $identityId !== null) {
-                    return $replayGuard->markUsed($identityId, $code, $timestamp);
+                    if (!$replayGuard->markUsed($identityId, $purpose, $timeStep, $timestamp)) {
+                        return null;
+                    }
                 }
 
-                return true;
+                return $timeStep;
             }
         }
 
-        return false;
+        return null;
     }
 }

--- a/src/Auth/TwoFactor/TwoFactorManager.php
+++ b/src/Auth/TwoFactor/TwoFactorManager.php
@@ -4,15 +4,37 @@ declare(strict_types=1);
 
 namespace Pulsar\Auth\TwoFactor;
 
+use function assert;
+use function bin2hex;
+
 use Override;
+use Pulsar\Audit\AuditLoggerInterface;
 use Pulsar\Auth\Identity\IdentityInterface;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditOutcome;
+use Pulsar\Security\Session\SessionInterface;
 use Random\RandomException;
+
+use function random_bytes;
+
+use SensitiveParameter;
 
 /**
  * Orchestrates TOTP and recovery code operations for two-factor authentication.
+ *
+ * Integrates replay guard, secret store, recovery code store, audit logging,
+ * session regeneration, rate limiting, and observability event collection.
  */
 final readonly class TwoFactorManager implements TwoFactorManagerInterface
 {
+    /**
+     * Metadata keys allowed in audit and collector events (allowlist).
+     */
+    private const array ALLOWED_METADATA_KEYS = [
+        'action', 'outcome', 'identity_id', 'purpose', 'reason',
+        'code_index', 'provider', 'remaining_codes',
+    ];
+
     public function __construct(
         private TotpGenerator $generator,
         private TotpVerifier $verifier,
@@ -20,6 +42,14 @@ final readonly class TwoFactorManager implements TwoFactorManagerInterface
         private RecoveryCodeVerifier $recoveryCodeVerifier,
         private string $issuer = 'Pulsar',
         private int $recoveryCodeCount = 8,
+        private ?TotpReplayGuardInterface $replayGuard = null,
+        private ?TotpSecretStoreInterface $secretStore = null,
+        private ?RecoveryCodeHasher $recoveryCodeHasher = null,
+        private ?RecoveryCodeStoreInterface $recoveryCodeStore = null,
+        private ?AuditLoggerInterface $auditLogger = null,
+        private ?SessionInterface $session = null,
+        private ?TwoFactorRateLimiterInterface $rateLimiter = null,
+        private ?AuthEventCollectorInterface $eventCollector = null,
     ) {}
 
     /**
@@ -33,6 +63,13 @@ final readonly class TwoFactorManager implements TwoFactorManagerInterface
         $uri = $this->generator->provisioningUri($secret, $identity->displayName(), $this->issuer);
         $recoveryCodes = $this->recoveryCodeGenerator->generate($this->recoveryCodeCount);
 
+        $this->emitAudit(
+            AuditEvent::SecurityEvent,
+            AuditOutcome::Success,
+            $identity->id(),
+            '2fa_setup_initiated',
+        );
+
         return [
             'secret' => $secret,
             'secret_base32' => $base32,
@@ -42,20 +79,276 @@ final readonly class TwoFactorManager implements TwoFactorManagerInterface
     }
 
     #[Override]
-    public function confirmSetup(string $secret, string $code): bool
-    {
-        return $this->verifier->verify($secret, $code);
+    public function confirmSetup(
+        string $identityId,
+        #[SensitiveParameter]
+        string $secret,
+        #[SensitiveParameter]
+        string $code,
+    ): Confirm2faSetupResult {
+        assert($identityId !== '', 'identityId must not be empty');
+
+        $timeStep = $this->verifier->verify(
+            $secret,
+            $code,
+            purpose: TwoFactorPurpose::Setup,
+        );
+
+        if ($timeStep === null) {
+            $this->emitAudit(
+                AuditEvent::SecurityEvent,
+                AuditOutcome::Failure,
+                $identityId,
+                '2fa_setup_confirmation_failed',
+                ['reason' => 'invalid_code'],
+            );
+
+            return Confirm2faSetupResult::failure(VerifyReason::InvalidCode);
+        }
+
+        // Store the encrypted secret on successful confirmation
+        $this->secretStore?->store($identityId, $secret);
+
+        $this->emitAudit(
+            AuditEvent::SecurityEvent,
+            AuditOutcome::Success,
+            $identityId,
+            '2fa_setup_confirmed',
+        );
+
+        return Confirm2faSetupResult::success();
     }
 
     #[Override]
-    public function verifyCode(string $secret, string $code): bool
-    {
-        return $this->verifier->verify($secret, $code);
+    public function verifyCode(
+        string $identityId,
+        #[SensitiveParameter]
+        string $code,
+        TwoFactorPurpose $purpose = TwoFactorPurpose::Login,
+    ): Verify2faResult {
+        assert($identityId !== '', 'identityId must not be empty');
+
+        if ($this->rateLimiter !== null && !$this->rateLimiter->attempt($identityId, $purpose)) {
+            $this->emitAudit(
+                AuditEvent::Authentication,
+                AuditOutcome::Denied,
+                $identityId,
+                '2fa_code_verification_failed',
+                ['purpose' => $purpose->value, 'reason' => 'rate_limited'],
+            );
+
+            return Verify2faResult::failure(VerifyReason::RateLimited, $purpose);
+        }
+
+        if ($this->secretStore === null) {
+            return Verify2faResult::failure(VerifyReason::NotEnrolled, $purpose);
+        }
+
+        $secret = $this->secretStore->retrieve($identityId);
+
+        if ($secret === null) {
+            return Verify2faResult::failure(VerifyReason::NotEnrolled, $purpose);
+        }
+
+        return $this->doVerify($identityId, $secret, $code, $purpose);
     }
 
     #[Override]
-    public function verifyRecoveryCode(string $code, array $validCodes): int
+    public function verifyCodeWithSecret(
+        string $identityId,
+        #[SensitiveParameter]
+        string $secret,
+        #[SensitiveParameter]
+        string $code,
+        TwoFactorPurpose $purpose = TwoFactorPurpose::Login,
+    ): Verify2faResult {
+        assert($identityId !== '', 'identityId must not be empty');
+
+        if ($this->rateLimiter !== null && !$this->rateLimiter->attempt($identityId, $purpose)) {
+            $this->emitAudit(
+                AuditEvent::Authentication,
+                AuditOutcome::Denied,
+                $identityId,
+                '2fa_code_verification_failed',
+                ['purpose' => $purpose->value, 'reason' => 'rate_limited'],
+            );
+
+            return Verify2faResult::failure(VerifyReason::RateLimited, $purpose);
+        }
+
+        return $this->doVerify($identityId, $secret, $code, $purpose);
+    }
+
+    #[Override]
+    public function verifyRecoveryCode(
+        string $identityId,
+        #[SensitiveParameter]
+        string $code,
+        array $validCodes = [],
+    ): int {
+        // Store-backed mode: use hasher + store for atomic consume
+        if ($this->recoveryCodeHasher !== null && $this->recoveryCodeStore !== null) {
+            $hash = $this->recoveryCodeHasher->hash($code);
+            $result = $this->recoveryCodeStore->consume($identityId, $hash);
+
+            if ($result->consumed) {
+                $this->emitAudit(
+                    AuditEvent::Authentication,
+                    AuditOutcome::Success,
+                    $identityId,
+                    '2fa_recovery_code_used',
+                    ['code_index' => (string) $result->codeIndex],
+                );
+
+                // Regenerate session on recovery code use (privilege escalation defense)
+                $this->session?->regenerate();
+
+                return $result->codeIndex;
+            }
+
+            $action = $result->reason === ConsumeReason::AlreadyUsed
+                ? '2fa_recovery_code_replayed'
+                : '2fa_recovery_code_failed';
+            $outcome = $result->reason === ConsumeReason::AlreadyUsed
+                ? AuditOutcome::Denied
+                : AuditOutcome::Failure;
+
+            $this->emitAudit(
+                AuditEvent::Authentication,
+                $outcome,
+                $identityId,
+                $action,
+                ['reason' => $result->reason->value],
+            );
+
+            return -1;
+        }
+
+        // Legacy mode: plaintext comparison
+        $index = $this->recoveryCodeVerifier->verify($code, $validCodes);
+
+        if ($index >= 0) {
+            $this->emitAudit(
+                AuditEvent::Authentication,
+                AuditOutcome::Success,
+                $identityId,
+                '2fa_recovery_code_used',
+                ['code_index' => (string) $index],
+            );
+        } else {
+            $this->emitAudit(
+                AuditEvent::Authentication,
+                AuditOutcome::Failure,
+                $identityId,
+                '2fa_recovery_code_failed',
+            );
+        }
+
+        return $index;
+    }
+
+    /**
+     * Rotate recovery codes: generate new set, store, invalidate old set.
+     *
+     * @throws RandomException
+     */
+    public function rotateRecoveryCodes(string $identityId): RecoveryCodeRotationResult
     {
-        return $this->recoveryCodeVerifier->verify($code, $validCodes);
+        assert($identityId !== '', 'identityId must not be empty');
+
+        $plaintextCodes = $this->recoveryCodeGenerator->generate($this->recoveryCodeCount);
+        $codeHashes = $this->recoveryCodeHasher !== null
+            ? $this->recoveryCodeHasher->hashAll($plaintextCodes)
+            : [];
+
+        $set = new RecoveryCodeSet(
+            setId: bin2hex(random_bytes(16)),
+            codeHashes: $codeHashes,
+            usedIndices: [],
+            algorithmVersion: 2,
+            createdAt: time(),
+        );
+
+        $this->recoveryCodeStore?->store($identityId, $set);
+
+        $this->emitAudit(
+            AuditEvent::SecurityEvent,
+            AuditOutcome::Success,
+            $identityId,
+            '2fa_recovery_codes_rotated',
+        );
+
+        return new RecoveryCodeRotationResult($set, $plaintextCodes);
+    }
+
+    private function doVerify(
+        string $identityId,
+        string $secret,
+        string $code,
+        TwoFactorPurpose $purpose,
+    ): Verify2faResult {
+        $timeStep = $this->verifier->verify(
+            $secret,
+            $code,
+            replayGuard: $this->replayGuard,
+            identityId: $identityId,
+            purpose: $purpose,
+        );
+
+        if ($timeStep === null) {
+            $this->emitAudit(
+                AuditEvent::Authentication,
+                AuditOutcome::Failure,
+                $identityId,
+                '2fa_code_verification_failed',
+                ['purpose' => $purpose->value, 'reason' => 'invalid_code'],
+            );
+
+            return Verify2faResult::failure(VerifyReason::InvalidCode, $purpose);
+        }
+
+        // Session regeneration on successful 2FA (privilege escalation defense)
+        $this->session?->regenerate();
+
+        $this->emitAudit(
+            AuditEvent::Authentication,
+            AuditOutcome::Success,
+            $identityId,
+            '2fa_code_verified',
+            ['purpose' => $purpose->value],
+        );
+
+        return Verify2faResult::success($purpose, $timeStep);
+    }
+
+    /**
+     * Emit an audit event and collector event with allowlisted metadata.
+     *
+     * @param array<string, string> $metadata
+     */
+    private function emitAudit(
+        AuditEvent $event,
+        AuditOutcome $outcome,
+        string $identityId,
+        string $action,
+        array $metadata = [],
+    ): void {
+        // Enforce metadata allowlist
+        $sanitized = array_intersect_key($metadata, array_flip(self::ALLOWED_METADATA_KEYS));
+
+        $this->auditLogger?->log(
+            $event,
+            $outcome,
+            $identityId,
+            $action,
+            metadata: $sanitized,
+        );
+
+        $this->eventCollector?->recordTwoFactorEvent(
+            $action,
+            $outcome->value,
+            $identityId,
+            $sanitized,
+        );
     }
 }

--- a/src/Auth/TwoFactor/TwoFactorManagerInterface.php
+++ b/src/Auth/TwoFactor/TwoFactorManagerInterface.php
@@ -6,9 +6,13 @@ namespace Pulsar\Auth\TwoFactor;
 
 use Pulsar\Api\Api;
 use Pulsar\Auth\Identity\IdentityInterface;
+use SensitiveParameter;
 
 /**
  * Contract for two-factor authentication management.
+ *
+ * BREAKING in 1.0.0-rc.8: verifyCode() and confirmSetup() now require
+ * a string $identityId parameter for replay prevention scoping.
  */
 #[Api(since: '1.0.0')]
 interface TwoFactorManagerInterface
@@ -22,19 +26,75 @@ interface TwoFactorManagerInterface
 
     /**
      * Confirm 2FA setup by verifying the initial TOTP code.
+     *
+     * @param non-empty-string $identityId Identity of the user completing setup
+     * @param string $secret Raw binary TOTP secret
+     * @param string $code User-provided TOTP code
      */
-    public function confirmSetup(string $secret, string $code): bool;
+    public function confirmSetup(
+        string $identityId,
+        #[SensitiveParameter]
+        string $secret,
+        #[SensitiveParameter]
+        string $code,
+    ): Confirm2faSetupResult;
 
     /**
-     * Verify a TOTP code during login.
+     * Verify a TOTP code during login or step-up.
+     *
+     * Loads the secret from TotpSecretStoreInterface. If no store is configured
+     * or no secret is found, returns Verify2faResult with VerifyReason::NotEnrolled.
+     *
+     * @param non-empty-string $identityId Identity of the user verifying
+     * @param string $code User-provided TOTP code
+     * @param TwoFactorPurpose $purpose The verification purpose
      */
-    public function verifyCode(string $secret, string $code): bool;
+    public function verifyCode(
+        string $identityId,
+        #[SensitiveParameter]
+        string $code,
+        TwoFactorPurpose $purpose = TwoFactorPurpose::Login,
+    ): Verify2faResult;
+
+    /**
+     * Verify a TOTP code with an explicit secret.
+     *
+     * @deprecated Use verifyCode() with TotpSecretStoreInterface instead.
+     *             This method will be removed in 2.0.
+     *
+     * @param non-empty-string $identityId Identity of the user verifying
+     * @param string $secret Raw binary TOTP secret
+     * @param string $code User-provided TOTP code
+     * @param TwoFactorPurpose $purpose The verification purpose
+     */
+    public function verifyCodeWithSecret(
+        string $identityId,
+        #[SensitiveParameter]
+        string $secret,
+        #[SensitiveParameter]
+        string $code,
+        TwoFactorPurpose $purpose = TwoFactorPurpose::Login,
+    ): Verify2faResult;
 
     /**
      * Verify a recovery code during login.
      *
-     * @param list<string> $validCodes
+     * @param non-empty-string $identityId Identity of the user
+     * @param string $code User-provided recovery code
+     * @param list<string> $validCodes Available recovery codes (for legacy non-store mode)
      * @return int Index of matched code, or -1 if no match
      */
-    public function verifyRecoveryCode(string $code, array $validCodes): int;
+    public function verifyRecoveryCode(
+        string $identityId,
+        #[SensitiveParameter]
+        string $code,
+        array $validCodes = [],
+    ): int;
+
+    /**
+     * Rotate recovery codes: generate a new set, store it, invalidate the old set.
+     *
+     * @param non-empty-string $identityId Identity of the user
+     */
+    public function rotateRecoveryCodes(string $identityId): RecoveryCodeRotationResult;
 }

--- a/src/Auth/TwoFactor/TwoFactorPurpose.php
+++ b/src/Auth/TwoFactor/TwoFactorPurpose.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Purpose of a two-factor authentication verification.
+ */
+#[Api(since: '1.0.0')]
+enum TwoFactorPurpose: string
+{
+    case Login = 'login';
+    case Setup = 'setup';
+    case StepUp = 'step_up';
+}

--- a/src/Auth/TwoFactor/TwoFactorRateLimiterInterface.php
+++ b/src/Auth/TwoFactor/TwoFactorRateLimiterInterface.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Optional rate limiting for 2FA verification attempts.
+ *
+ * Not wired by default — apps provide their own implementation
+ * scoped to their specific rate limiting needs (identity + IP + timeframe, etc.).
+ *
+ * Documented context keys (apps decide which to populate):
+ * - 'ip': Client IP address
+ * - 'user_agent_hash': Hashed user agent string
+ * - 'device_id': Persistent device fingerprint
+ * - 'route': Route name for step-up context
+ * - 'session_id': Hashed session ID
+ */
+#[Api(since: '1.0.0')]
+interface TwoFactorRateLimiterInterface
+{
+    /**
+     * Check if a verification attempt is allowed.
+     *
+     * @param string $identityId Identity attempting verification
+     * @param TwoFactorPurpose $purpose The verification purpose
+     * @param array<string, string> $context Additional context for scoping
+     *
+     * @return bool true if allowed, false if rate limited
+     */
+    public function attempt(string $identityId, TwoFactorPurpose $purpose, array $context = []): bool;
+
+    /**
+     * Reset rate limit counters for an identity.
+     */
+    public function reset(string $identityId): void;
+}

--- a/src/Auth/TwoFactor/Verify2faResult.php
+++ b/src/Auth/TwoFactor/Verify2faResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Result of a TOTP code verification.
+ */
+#[Api(since: '1.0.0')]
+final readonly class Verify2faResult
+{
+    public function __construct(
+        public bool $verified,
+        public VerifyReason $reason,
+        public TwoFactorPurpose $purpose,
+        public ?int $acceptedTimeStep = null,
+    ) {}
+
+    public static function success(TwoFactorPurpose $purpose, int $acceptedTimeStep): self
+    {
+        return new self(true, VerifyReason::Valid, $purpose, $acceptedTimeStep);
+    }
+
+    public static function failure(VerifyReason $reason, TwoFactorPurpose $purpose): self
+    {
+        return new self(false, $reason, $purpose);
+    }
+}

--- a/src/Auth/TwoFactor/VerifyReason.php
+++ b/src/Auth/TwoFactor/VerifyReason.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Auth\TwoFactor;
+
+use Pulsar\Api\Api;
+
+/**
+ * Reason codes for TOTP verification outcomes.
+ */
+#[Api(since: '1.0.0')]
+enum VerifyReason: string
+{
+    case Valid = 'valid';
+    case InvalidCode = 'invalid_code';
+    case Replayed = 'replayed';
+    case Expired = 'expired';
+    case NotEnrolled = 'not_enrolled';
+    case RateLimited = 'rate_limited';
+}

--- a/src/Config/TwoFactorConfig.php
+++ b/src/Config/TwoFactorConfig.php
@@ -23,6 +23,10 @@ readonly class TwoFactorConfig
         public int $codePeriod = 30,
         public int $verificationWindow = 1,
         public int $recoveryCodeCount = 8,
+        public int $recoveryCodeBytes = 8,
+        public int $stepUpTimeoutMinutes = 15,
+        public int $recoveryCodeAlgorithmVersion = 2,
+        public bool $allowInMemory = false,
     ) {}
 
     /**
@@ -44,6 +48,13 @@ readonly class TwoFactorConfig
         $verificationWindow = is_int($rawVerificationWindow) ? $rawVerificationWindow : (int) (is_numeric($rawVerificationWindow) ? $rawVerificationWindow : 1);
         $rawRecoveryCodeCount = $data['recovery_code_count'] ?? 8;
         $recoveryCodeCount = is_int($rawRecoveryCodeCount) ? $rawRecoveryCodeCount : (int) (is_numeric($rawRecoveryCodeCount) ? $rawRecoveryCodeCount : 8);
+        $rawRecoveryCodeBytes = $data['recovery_code_bytes'] ?? 8;
+        $recoveryCodeBytes = is_int($rawRecoveryCodeBytes) ? $rawRecoveryCodeBytes : (int) (is_numeric($rawRecoveryCodeBytes) ? $rawRecoveryCodeBytes : 8);
+        $rawStepUpTimeoutMinutes = $data['step_up_timeout_minutes'] ?? 15;
+        $stepUpTimeoutMinutes = is_int($rawStepUpTimeoutMinutes) ? $rawStepUpTimeoutMinutes : (int) (is_numeric($rawStepUpTimeoutMinutes) ? $rawStepUpTimeoutMinutes : 15);
+        $rawRecoveryCodeAlgorithmVersion = $data['recovery_code_algorithm_version'] ?? 2;
+        $recoveryCodeAlgorithmVersion = is_int($rawRecoveryCodeAlgorithmVersion) ? $rawRecoveryCodeAlgorithmVersion : (int) (is_numeric($rawRecoveryCodeAlgorithmVersion) ? $rawRecoveryCodeAlgorithmVersion : 2);
+        $allowInMemory = (bool) ($data['allow_in_memory'] ?? false);
 
         return new self(
             enabled: $enabled,
@@ -52,6 +63,10 @@ readonly class TwoFactorConfig
             codePeriod: $codePeriod,
             verificationWindow: $verificationWindow,
             recoveryCodeCount: $recoveryCodeCount,
+            recoveryCodeBytes: $recoveryCodeBytes,
+            stepUpTimeoutMinutes: $stepUpTimeoutMinutes,
+            recoveryCodeAlgorithmVersion: $recoveryCodeAlgorithmVersion,
+            allowInMemory: $allowInMemory,
         );
     }
 }

--- a/src/Core/Wiring/AuthWiring.php
+++ b/src/Core/Wiring/AuthWiring.php
@@ -163,7 +163,6 @@ final readonly class AuthWiring implements ServiceWiringInterface
             }
 
             // Secret store
-            $secretStore = null;
             if ($container->has(TotpSecretStoreInterface::class)) {
                 /** @var TotpSecretStoreInterface $secretStore */
                 $secretStore = $container->get(TotpSecretStoreInterface::class);
@@ -181,7 +180,6 @@ final readonly class AuthWiring implements ServiceWiringInterface
 
             // Recovery code hasher + store
             $recoveryCodeHasher = null;
-            $recoveryCodeStore = null;
             if ($container->has(MasterKey::class)) {
                 /** @var MasterKey $masterKey */
                 $masterKey = $container->get(MasterKey::class);
@@ -250,7 +248,7 @@ final readonly class AuthWiring implements ServiceWiringInterface
 
                 foreach ($inMemoryStores as $store) {
                     $logger->warning(
-                        "In-memory 2FA store [{$store}] is active — data will not persist across restarts. Bind a persistent implementation.",
+                        "In-memory 2FA store [$store] is active — data will not persist across restarts. Bind a persistent implementation.",
                     );
                 }
             }

--- a/src/Core/Wiring/AuthWiring.php
+++ b/src/Core/Wiring/AuthWiring.php
@@ -4,7 +4,9 @@ declare(strict_types=1);
 
 namespace Pulsar\Core\Wiring;
 
+use Psr\Log\LoggerInterface;
 use Pulsar\Api\Internal;
+use Pulsar\Audit\AuditLoggerInterface;
 use Pulsar\Auth\AuthManager;
 use Pulsar\Auth\AuthManagerInterface;
 use Pulsar\Auth\Authorization\Gate;
@@ -17,15 +19,25 @@ use Pulsar\Auth\Guard\TokenGuard;
 use Pulsar\Auth\Guard\TokenResolverInterface;
 use Pulsar\Auth\Middleware\AuthenticationMiddleware;
 use Pulsar\Auth\Middleware\AuthorizationMiddleware;
+use Pulsar\Auth\Middleware\StepUpMiddleware;
 use Pulsar\Auth\Middleware\TwoFactorMiddleware;
 use Pulsar\Auth\Password\PasswordHasher;
 use Pulsar\Auth\Password\PasswordHasherInterface;
+use Pulsar\Auth\TwoFactor\AuthEventCollectorInterface;
+use Pulsar\Auth\TwoFactor\InMemoryRecoveryCodeStore;
+use Pulsar\Auth\TwoFactor\InMemoryTotpReplayGuard;
+use Pulsar\Auth\TwoFactor\InMemoryTotpSecretStore;
 use Pulsar\Auth\TwoFactor\RecoveryCodeGenerator;
+use Pulsar\Auth\TwoFactor\RecoveryCodeHasher;
+use Pulsar\Auth\TwoFactor\RecoveryCodeStoreInterface;
 use Pulsar\Auth\TwoFactor\RecoveryCodeVerifier;
 use Pulsar\Auth\TwoFactor\TotpGenerator;
+use Pulsar\Auth\TwoFactor\TotpReplayGuardInterface;
+use Pulsar\Auth\TwoFactor\TotpSecretStoreInterface;
 use Pulsar\Auth\TwoFactor\TotpVerifier;
 use Pulsar\Auth\TwoFactor\TwoFactorManager;
 use Pulsar\Auth\TwoFactor\TwoFactorManagerInterface;
+use Pulsar\Auth\TwoFactor\TwoFactorRateLimiterInterface;
 use Pulsar\Config\ConfigManager;
 use Pulsar\Config\SecurityConfig;
 use Pulsar\Container\ContainerInterface;
@@ -34,6 +46,8 @@ use Pulsar\Http\Middleware\MiddlewarePipeline;
 use Pulsar\Http\Middleware\MiddlewareRegistry;
 use Pulsar\Routing\Router;
 use Pulsar\Security\Audit\AuditLogger;
+use Pulsar\Security\Crypto\Encryptor;
+use Pulsar\Security\Crypto\MasterKey;
 use Pulsar\Security\Session\SessionInterface;
 use Random\Randomizer;
 
@@ -65,6 +79,7 @@ final readonly class AuthWiring implements ServiceWiringInterface
         $authManager = new AuthManager($authConfig->defaultGuard);
 
         // Session guard
+        $session = null;
         if ($container->has(SessionInterface::class)) {
             /** @var SessionInterface $session */
             $session = $container->get(SessionInterface::class);
@@ -101,6 +116,25 @@ final readonly class AuthWiring implements ServiceWiringInterface
         $container->instance(Gate::class, $gate);
         $container->instance(GateInterface::class, $gate);
 
+        // Audit logger (resolve early — used by 2FA and middleware)
+        // Resolve interface for 2FA manager; concrete class for auth middleware
+        $auditLoggerInterface = $container->has(AuditLoggerInterface::class)
+            ? $container->get(AuditLoggerInterface::class)
+            : null;
+        /** @var AuditLoggerInterface|null $auditLoggerInterface */
+        $auditLogger = $container->has(AuditLogger::class)
+            ? $container->get(AuditLogger::class)
+            : null;
+        /** @var AuditLogger|null $auditLogger */
+        $auditLoggerForTwoFactor = $auditLoggerInterface ?? $auditLogger;
+        /** @var AuditLoggerInterface|null $auditLoggerForTwoFactor */
+
+        // Logger for production guardrails
+        $logger = $container->has(LoggerInterface::class)
+            ? $container->get(LoggerInterface::class)
+            : null;
+        /** @var LoggerInterface|null $logger */
+
         // 2FA services
         if ($authConfig->twoFactor->enabled) {
             /** @var Randomizer $randomizer */
@@ -112,8 +146,70 @@ final readonly class AuthWiring implements ServiceWiringInterface
                 randomizer: $randomizer,
             );
             $totpVerifier = new TotpVerifier($totpGenerator, $authConfig->twoFactor->verificationWindow);
-            $recoveryCodeGenerator = new RecoveryCodeGenerator($randomizer);
+            $recoveryCodeGenerator = new RecoveryCodeGenerator(
+                $randomizer,
+                bytesPerCode: $authConfig->twoFactor->recoveryCodeBytes,
+            );
             $recoveryCodeVerifier = new RecoveryCodeVerifier();
+
+            // Replay guard — use app-provided or fall back to in-memory
+            if ($container->has(TotpReplayGuardInterface::class)) {
+                /** @var TotpReplayGuardInterface $replayGuard */
+                $replayGuard = $container->get(TotpReplayGuardInterface::class);
+            } else {
+                $replayGuard = new InMemoryTotpReplayGuard();
+                $container->instance(InMemoryTotpReplayGuard::class, $replayGuard);
+                $container->instance(TotpReplayGuardInterface::class, $replayGuard);
+            }
+
+            // Secret store
+            $secretStore = null;
+            if ($container->has(TotpSecretStoreInterface::class)) {
+                /** @var TotpSecretStoreInterface $secretStore */
+                $secretStore = $container->get(TotpSecretStoreInterface::class);
+            } else {
+                $encryptor = null;
+                if ($container->has(MasterKey::class)) {
+                    /** @var MasterKey $masterKey */
+                    $masterKey = $container->get(MasterKey::class);
+                    $encryptor = Encryptor::fromDerivedKey($masterKey, 4, 'totpscrt');
+                }
+                $secretStore = new InMemoryTotpSecretStore($encryptor);
+                $container->instance(InMemoryTotpSecretStore::class, $secretStore);
+                $container->instance(TotpSecretStoreInterface::class, $secretStore);
+            }
+
+            // Recovery code hasher + store
+            $recoveryCodeHasher = null;
+            $recoveryCodeStore = null;
+            if ($container->has(MasterKey::class)) {
+                /** @var MasterKey $masterKey */
+                $masterKey = $container->get(MasterKey::class);
+                $subKey = $masterKey->deriveSubKey(3, 'rcvrycod');
+                $recoveryCodeHasher = new RecoveryCodeHasher($subKey);
+                $container->instance(RecoveryCodeHasher::class, $recoveryCodeHasher);
+            }
+
+            if ($container->has(RecoveryCodeStoreInterface::class)) {
+                /** @var RecoveryCodeStoreInterface $recoveryCodeStore */
+                $recoveryCodeStore = $container->get(RecoveryCodeStoreInterface::class);
+            } else {
+                $recoveryCodeStore = new InMemoryRecoveryCodeStore();
+                $container->instance(InMemoryRecoveryCodeStore::class, $recoveryCodeStore);
+                $container->instance(RecoveryCodeStoreInterface::class, $recoveryCodeStore);
+            }
+
+            // Rate limiter (only if app provides one)
+            $rateLimiter = $container->has(TwoFactorRateLimiterInterface::class)
+                ? $container->get(TwoFactorRateLimiterInterface::class)
+                : null;
+            /** @var TwoFactorRateLimiterInterface|null $rateLimiter */
+
+            // Event collector (only if bound — e.g., by Studio)
+            $eventCollector = $container->has(AuthEventCollectorInterface::class)
+                ? $container->get(AuthEventCollectorInterface::class)
+                : null;
+            /** @var AuthEventCollectorInterface|null $eventCollector */
 
             $twoFactorManager = new TwoFactorManager(
                 generator: $totpGenerator,
@@ -122,6 +218,14 @@ final readonly class AuthWiring implements ServiceWiringInterface
                 recoveryCodeVerifier: $recoveryCodeVerifier,
                 issuer: $authConfig->twoFactor->issuer,
                 recoveryCodeCount: $authConfig->twoFactor->recoveryCodeCount,
+                replayGuard: $replayGuard,
+                secretStore: $secretStore,
+                recoveryCodeHasher: $recoveryCodeHasher,
+                recoveryCodeStore: $recoveryCodeStore,
+                auditLogger: $auditLoggerForTwoFactor,
+                session: $session,
+                rateLimiter: $rateLimiter,
+                eventCollector: $eventCollector,
             );
 
             $container->instance(TotpGenerator::class, $totpGenerator);
@@ -130,27 +234,52 @@ final readonly class AuthWiring implements ServiceWiringInterface
             $container->instance(RecoveryCodeVerifier::class, $recoveryCodeVerifier);
             $container->instance(TwoFactorManager::class, $twoFactorManager);
             $container->instance(TwoFactorManagerInterface::class, $twoFactorManager);
+
+            // Production guardrail: warn when in-memory stores are active
+            if ($logger !== null && !$authConfig->twoFactor->allowInMemory) {
+                $inMemoryStores = [];
+                if ($secretStore instanceof InMemoryTotpSecretStore) {
+                    $inMemoryStores[] = 'InMemoryTotpSecretStore';
+                }
+                if ($recoveryCodeStore instanceof InMemoryRecoveryCodeStore) {
+                    $inMemoryStores[] = 'InMemoryRecoveryCodeStore';
+                }
+                if ($replayGuard instanceof InMemoryTotpReplayGuard) {
+                    $inMemoryStores[] = 'InMemoryTotpReplayGuard';
+                }
+
+                foreach ($inMemoryStores as $store) {
+                    $logger->warning(
+                        "In-memory 2FA store [{$store}] is active — data will not persist across restarts. Bind a persistent implementation.",
+                    );
+                }
+            }
         }
 
         // Middleware
         $authenticationMiddleware = new AuthenticationMiddleware($authManager);
         $container->instance(AuthenticationMiddleware::class, $authenticationMiddleware);
 
-        $auditLogger = $container->has(AuditLogger::class)
-            ? $container->get(AuditLogger::class)
-            : null;
-
         $authContextHolder = $container->has(RequestContextHolder::class)
             ? $container->get(RequestContextHolder::class)
             : null;
 
-        /** @var AuditLogger|null $auditLogger */
         /** @var RequestContextHolder|null $authContextHolder */
         $authorizationMiddleware = new AuthorizationMiddleware($gate, $auditLogger, $authContextHolder);
         $container->instance(AuthorizationMiddleware::class, $authorizationMiddleware);
 
         $twoFactorMiddleware = new TwoFactorMiddleware();
         $container->instance(TwoFactorMiddleware::class, $twoFactorMiddleware);
+
+        // Step-up middleware (requires session)
+        if ($session !== null) {
+            $stepUpMiddleware = new StepUpMiddleware(
+                $session,
+                $authConfig->twoFactor->stepUpTimeoutMinutes,
+            );
+            $container->instance(StepUpMiddleware::class, $stepUpMiddleware);
+            $middlewareRegistry->alias('step-up', $stepUpMiddleware);
+        }
 
         // Register middleware aliases
         $middlewareRegistry->alias('auth', $authorizationMiddleware);

--- a/src/Security/Crypto/Hmac.php
+++ b/src/Security/Crypto/Hmac.php
@@ -8,6 +8,7 @@ use function hash_equals;
 
 use InvalidArgumentException;
 use NoDiscard;
+use Pulsar\Api\Api;
 
 use function sodium_bin2hex;
 use function sodium_crypto_generichash;
@@ -22,6 +23,7 @@ use function strlen;
  *
  * Provides keyed hashing for integrity verification and tamper detection.
  */
+#[Api(since: '1.0.0')]
 final class Hmac
 {
     /**

--- a/tests/Integration/Auth/TwoFactorFlowTest.php
+++ b/tests/Integration/Auth/TwoFactorFlowTest.php
@@ -72,14 +72,17 @@ final class TwoFactorFlowTest extends TestCase
         // Step 2: Confirm setup with a valid TOTP code
         $timestamp = time();
         $code = $this->generator->computeCode($setup['secret'], $timestamp);
-        self::assertTrue($this->manager->confirmSetup($setup['secret'], $code));
+        $confirmResult = $this->manager->confirmSetup('user-1', $setup['secret'], $code);
+        self::assertTrue($confirmResult->confirmed);
 
-        // Step 3: Verify code during login
+        // Step 3: Verify code during login (using deprecated verifyCodeWithSecret)
         $loginCode = $this->generator->computeCode($setup['secret'], $timestamp);
-        self::assertTrue($this->manager->verifyCode($setup['secret'], $loginCode));
+        $verifyResult = $this->manager->verifyCodeWithSecret('user-1', $setup['secret'], $loginCode);
+        self::assertTrue($verifyResult->verified);
 
         // Step 4: Use recovery code as fallback
         $recoveryIndex = $this->manager->verifyRecoveryCode(
+            'user-1',
             $setup['recovery_codes'][0],
             $setup['recovery_codes'],
         );
@@ -87,6 +90,7 @@ final class TwoFactorFlowTest extends TestCase
 
         // Wrong recovery code fails
         $failedIndex = $this->manager->verifyRecoveryCode(
+            'user-1',
             'ZZZZ-ZZZZ',
             $setup['recovery_codes'],
         );

--- a/tests/Unit/Auth/Middleware/StepUpMiddlewareTest.php
+++ b/tests/Unit/Auth/Middleware/StepUpMiddlewareTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Auth\Middleware;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\MockObject\Stub;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Auth\AuthManagerInterface;
+use Pulsar\Auth\Identity\Identity;
+use Pulsar\Auth\Identity\IdentityInterface;
+use Pulsar\Auth\Middleware\StepUpMiddleware;
+use Pulsar\Auth\SecurityContext;
+use Pulsar\Http\HeaderBag;
+use Pulsar\Http\Method;
+use Pulsar\Http\Request;
+use Pulsar\Http\Response;
+use Pulsar\Http\ResponseStatus;
+use Pulsar\Security\Session\SessionInterface;
+
+#[CoversClass(StepUpMiddleware::class)]
+final class StepUpMiddlewareTest extends TestCase
+{
+    /** @var SessionInterface&Stub */
+    private SessionInterface $session;
+
+    protected function setUp(): void
+    {
+        $this->session = $this->createStub(SessionInterface::class);
+    }
+
+    #[Test]
+    public function missingStepUpTimestampReturns403(): void
+    {
+        $middleware = new StepUpMiddleware($this->session, timeoutMinutes: 15);
+
+        $identity = new Identity('user-1', 'Test User', ['user']);
+        $request = $this->createRequestWithIdentity($identity);
+
+        $this->session->method('get')->willReturn(null);
+
+        $response = $middleware->process($request, fn() => new Response(body: 'OK'));
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+    }
+
+    #[Test]
+    public function expiredStepUpReturns403(): void
+    {
+        $middleware = new StepUpMiddleware($this->session, timeoutMinutes: 15);
+
+        $identity = new Identity('user-1', 'Test User', ['user']);
+        $request = $this->createRequestWithIdentity($identity);
+
+        // Set step-up 20 minutes ago (expired for 15-minute timeout)
+        $this->session->method('get')->willReturn(time() - (20 * 60));
+
+        $response = $middleware->process($request, fn() => new Response(body: 'OK'));
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+    }
+
+    #[Test]
+    public function freshStepUpPassesThrough(): void
+    {
+        $middleware = new StepUpMiddleware($this->session, timeoutMinutes: 15);
+
+        $identity = new Identity('user-1', 'Test User', ['user']);
+        $request = $this->createRequestWithIdentity($identity);
+
+        // Set step-up 5 minutes ago (fresh for 15-minute timeout)
+        $this->session->method('get')->willReturn(time() - (5 * 60));
+
+        $response = $middleware->process($request, fn() => new Response(body: 'OK'));
+
+        self::assertSame(ResponseStatus::OK, $response->status);
+        self::assertSame('OK', $response->body);
+    }
+
+    #[Test]
+    public function markStepUpAuthenticatedSetsSessionValue(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->expects(self::once())
+            ->method('set')
+            ->with('_pulsar_step_up[user-1]', self::isInt());
+
+        StepUpMiddleware::markStepUpAuthenticated($session, 'user-1');
+    }
+
+    #[Test]
+    public function differentIdentitiesDontInheritStepUp(): void
+    {
+        $middleware = new StepUpMiddleware($this->session, timeoutMinutes: 15);
+
+        $identity = new Identity('user-2', 'Other User', ['user']);
+        $request = $this->createRequestWithIdentity($identity);
+
+        // Session has step-up for user-1 but not user-2
+        $this->session->method('get')
+            ->willReturnCallback(fn(string $key) => match ($key) {
+                '_pulsar_step_up[user-1]' => time(),
+                default => null,
+            });
+
+        $response = $middleware->process($request, fn() => new Response(body: 'OK'));
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+    }
+
+    #[Test]
+    public function jsonRequestGetsJsonResponse(): void
+    {
+        $middleware = new StepUpMiddleware($this->session, timeoutMinutes: 15);
+
+        $identity = new Identity('user-1', 'Test User', ['user']);
+        $request = $this->createRequestWithIdentity($identity, headers: ['Accept' => 'application/json']);
+
+        $this->session->method('get')->willReturn(null);
+
+        $response = $middleware->process($request, fn() => new Response(body: 'OK'));
+
+        self::assertSame(ResponseStatus::Forbidden, $response->status);
+        self::assertStringContainsString('Step-up authentication required', $response->body);
+    }
+
+    /**
+     * @param array<string, string> $headers
+     */
+    private function createRequestWithIdentity(
+        IdentityInterface $identity,
+        array $headers = [],
+    ): Request {
+        $authManager = $this->createStub(AuthManagerInterface::class);
+
+        $request = new Request(
+            method: Method::GET,
+            uri: '/test',
+            path: '/test',
+            queryString: '',
+            headers: new HeaderBag($headers),
+            body: '',
+            attributes: [],
+        );
+
+        $authManager->method('authenticate')->willReturn($identity);
+        $securityContext = new SecurityContext($authManager, $request);
+
+        return new Request(
+            method: Method::GET,
+            uri: '/test',
+            path: '/test',
+            queryString: '',
+            headers: new HeaderBag($headers),
+            body: '',
+            attributes: ['_security_context' => $securityContext],
+        );
+    }
+}

--- a/tests/Unit/Auth/TwoFactor/RecoveryCodeGeneratorTest.php
+++ b/tests/Unit/Auth/TwoFactor/RecoveryCodeGeneratorTest.php
@@ -39,6 +39,22 @@ final class RecoveryCodeGeneratorTest extends TestCase
         $codes = $this->generator->generate(8);
 
         foreach ($codes as $code) {
+            // 64-bit format: XXXX-XXXX-XXXX-XXXX (16 hex chars)
+            self::assertMatchesRegularExpression(
+                '/^[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}-[0-9A-F]{4}$/',
+                $code,
+            );
+        }
+    }
+
+    #[Test]
+    public function legacyGeneratorProduces32BitFormat(): void
+    {
+        $legacyGenerator = new RecoveryCodeGenerator(bytesPerCode: 4);
+        $codes = $legacyGenerator->generate(4);
+
+        foreach ($codes as $code) {
+            // 32-bit format: XXXX-XXXX (8 hex chars)
             self::assertMatchesRegularExpression('/^[0-9A-F]{4}-[0-9A-F]{4}$/', $code);
         }
     }
@@ -49,5 +65,23 @@ final class RecoveryCodeGeneratorTest extends TestCase
         $codes = $this->generator->generate(16);
 
         self::assertSame(count($codes), count(array_unique($codes)));
+    }
+
+    #[Test]
+    public function checksumProducesConsistentResult(): void
+    {
+        $code = 'ABCD-1234-EF56-7890';
+        $checksum1 = RecoveryCodeGenerator::checksum($code);
+        $checksum2 = RecoveryCodeGenerator::checksum($code);
+
+        self::assertSame($checksum1, $checksum2);
+        self::assertMatchesRegularExpression('/^[0-9A-F]{2}$/', $checksum1);
+    }
+
+    #[Test]
+    public function canonicalizeStripsDelimitersAndUppercases(): void
+    {
+        self::assertSame('ABCD1234EF567890', RecoveryCodeGenerator::canonicalize('abcd-1234-ef56-7890'));
+        self::assertSame('ABCD1234EF567890', RecoveryCodeGenerator::canonicalize('ABCD 1234 EF56 7890'));
     }
 }

--- a/tests/Unit/Auth/TwoFactor/RecoveryCodeHasherTest.php
+++ b/tests/Unit/Auth/TwoFactor/RecoveryCodeHasherTest.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Auth\TwoFactor;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Auth\TwoFactor\RecoveryCodeHasher;
+
+use function strlen;
+
+#[CoversClass(RecoveryCodeHasher::class)]
+final class RecoveryCodeHasherTest extends TestCase
+{
+    private RecoveryCodeHasher $hasher;
+
+    protected function setUp(): void
+    {
+        // Use a fixed 32-byte key for deterministic testing
+        $this->hasher = new RecoveryCodeHasher(str_repeat('k', 32));
+    }
+
+    #[Test]
+    public function hashProducesDeterministicOutput(): void
+    {
+        $hash1 = $this->hasher->hash('ABCD-1234-EF56-7890');
+        $hash2 = $this->hasher->hash('ABCD-1234-EF56-7890');
+
+        self::assertSame($hash1, $hash2);
+        self::assertSame(64, strlen($hash1)); // 32 bytes = 64 hex chars
+    }
+
+    #[Test]
+    public function hashAllReturnsCorrectCount(): void
+    {
+        $codes = ['ABCD-1234-EF56-7890', 'DEAD-BEEF-CAFE-BABE'];
+        $hashes = $this->hasher->hashAll($codes);
+
+        self::assertCount(2, $hashes);
+        self::assertSame($this->hasher->hash($codes[0]), $hashes[0]);
+        self::assertSame($this->hasher->hash($codes[1]), $hashes[1]);
+    }
+
+    #[Test]
+    public function verifyMatchesCorrectCode(): void
+    {
+        $codes = ['ABCD-1234-EF56-7890', 'DEAD-BEEF-CAFE-BABE'];
+        $hashes = $this->hasher->hashAll($codes);
+
+        self::assertSame(0, $this->hasher->verify('ABCD-1234-EF56-7890', $hashes));
+        self::assertSame(1, $this->hasher->verify('DEAD-BEEF-CAFE-BABE', $hashes));
+    }
+
+    #[Test]
+    public function verifyReturnsNegativeOneForMiss(): void
+    {
+        $hashes = $this->hasher->hashAll(['ABCD-1234-EF56-7890']);
+
+        self::assertSame(-1, $this->hasher->verify('FFFF-FFFF-FFFF-FFFF', $hashes));
+    }
+
+    #[Test]
+    public function verifyIsCaseInsensitive(): void
+    {
+        $hashes = $this->hasher->hashAll(['ABCD-1234-EF56-7890']);
+
+        self::assertSame(0, $this->hasher->verify('abcd-1234-ef56-7890', $hashes));
+    }
+
+    #[Test]
+    public function canonicalizationStripsDelimiters(): void
+    {
+        $hash1 = $this->hasher->hash('ABCD-1234-EF56-7890');
+        $hash2 = $this->hasher->hash('ABCD 1234 EF56 7890');
+        $hash3 = $this->hasher->hash('ABCD1234EF567890');
+
+        self::assertSame($hash1, $hash2);
+        self::assertSame($hash1, $hash3);
+    }
+
+    #[Test]
+    public function canonicalizeStaticMethod(): void
+    {
+        self::assertSame('ABCD1234EF567890', RecoveryCodeHasher::canonicalize('abcd-1234-ef56-7890'));
+        self::assertSame('ABCD1234EF567890', RecoveryCodeHasher::canonicalize('ABCD 1234 EF56 7890'));
+    }
+}

--- a/tests/Unit/Auth/TwoFactor/RecoveryCodeStoreTest.php
+++ b/tests/Unit/Auth/TwoFactor/RecoveryCodeStoreTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Auth\TwoFactor;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Auth\TwoFactor\ConsumeReason;
+use Pulsar\Auth\TwoFactor\ConsumeResult;
+use Pulsar\Auth\TwoFactor\InMemoryRecoveryCodeStore;
+use Pulsar\Auth\TwoFactor\RecoveryCodeSet;
+
+#[CoversClass(InMemoryRecoveryCodeStore::class)]
+#[CoversClass(RecoveryCodeSet::class)]
+#[CoversClass(ConsumeResult::class)]
+final class RecoveryCodeStoreTest extends TestCase
+{
+    private InMemoryRecoveryCodeStore $store;
+
+    protected function setUp(): void
+    {
+        $this->store = new InMemoryRecoveryCodeStore();
+    }
+
+    #[Test]
+    public function loadSetReturnsNullWhenNotStored(): void
+    {
+        self::assertNull($this->store->loadSet('user-1'));
+    }
+
+    #[Test]
+    public function storeAndLoadSetRoundTrip(): void
+    {
+        $set = new RecoveryCodeSet(
+            setId: 'abc123',
+            codeHashes: ['hash1', 'hash2', 'hash3'],
+            usedIndices: [],
+            algorithmVersion: 2,
+            createdAt: 1000000,
+        );
+
+        $this->store->store('user-1', $set);
+        $loaded = $this->store->loadSet('user-1');
+
+        self::assertNotNull($loaded);
+        self::assertSame('abc123', $loaded->setId);
+        self::assertCount(3, $loaded->codeHashes);
+        self::assertSame([], $loaded->usedIndices);
+    }
+
+    #[Test]
+    public function consumeSucceedsForValidCode(): void
+    {
+        $set = new RecoveryCodeSet(
+            setId: 'abc123',
+            codeHashes: ['hash1', 'hash2', 'hash3'],
+            usedIndices: [],
+            algorithmVersion: 2,
+            createdAt: 1000000,
+        );
+
+        $this->store->store('user-1', $set);
+
+        $result = $this->store->consume('user-1', 'hash2');
+
+        self::assertTrue($result->consumed);
+        self::assertSame(1, $result->codeIndex);
+        self::assertSame(ConsumeReason::Consumed, $result->reason);
+    }
+
+    #[Test]
+    public function consumeRejectsAlreadyUsedCode(): void
+    {
+        $set = new RecoveryCodeSet(
+            setId: 'abc123',
+            codeHashes: ['hash1', 'hash2'],
+            usedIndices: [],
+            algorithmVersion: 2,
+            createdAt: 1000000,
+        );
+
+        $this->store->store('user-1', $set);
+
+        $first = $this->store->consume('user-1', 'hash1');
+        self::assertTrue($first->consumed);
+
+        $second = $this->store->consume('user-1', 'hash1');
+        self::assertFalse($second->consumed);
+        self::assertSame(ConsumeReason::AlreadyUsed, $second->reason);
+    }
+
+    #[Test]
+    public function consumeRejectsUnknownCodeHash(): void
+    {
+        $set = new RecoveryCodeSet(
+            setId: 'abc123',
+            codeHashes: ['hash1'],
+            usedIndices: [],
+            algorithmVersion: 2,
+            createdAt: 1000000,
+        );
+
+        $this->store->store('user-1', $set);
+
+        $result = $this->store->consume('user-1', 'unknown');
+
+        self::assertFalse($result->consumed);
+        self::assertSame(ConsumeReason::NotFound, $result->reason);
+    }
+
+    #[Test]
+    public function consumeReturnsNotEnrolledWhenNoSet(): void
+    {
+        $result = $this->store->consume('user-1', 'hash1');
+
+        self::assertFalse($result->consumed);
+        self::assertSame(ConsumeReason::NotEnrolled, $result->reason);
+    }
+
+    #[Test]
+    public function recoveryCodeSetRemainingCount(): void
+    {
+        $set = new RecoveryCodeSet(
+            setId: 'abc123',
+            codeHashes: ['h1', 'h2', 'h3'],
+            usedIndices: [0],
+            algorithmVersion: 2,
+            createdAt: 1000000,
+        );
+
+        self::assertSame(2, $set->remainingCount());
+        self::assertTrue($set->isUsed(0));
+        self::assertFalse($set->isUsed(1));
+
+        $updated = $set->withUsedIndex(1);
+        self::assertSame(1, $updated->remainingCount());
+    }
+}

--- a/tests/Unit/Auth/TwoFactor/TotpGeneratorTest.php
+++ b/tests/Unit/Auth/TwoFactor/TotpGeneratorTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Pulsar\Tests\Unit\Auth\TwoFactor;
 
 use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Pulsar\Auth\TwoFactor\TotpGenerator;
@@ -99,5 +100,73 @@ final class TotpGeneratorTest extends TestCase
         // timestamp 90 => time step = intdiv(90, 30) = 3, which differs from step 1
         // This is overwhelmingly likely to be different
         self::assertMatchesRegularExpression('/^\d{6}$/', $codeDifferentTime);
+    }
+
+    /**
+     * RFC 6238 Appendix B SHA-1 test vectors (8-digit mode).
+     *
+     * @return array<string, array{int, string}>
+     */
+    public static function rfc6238Sha1EightDigitProvider(): array
+    {
+        return [
+            'T=59'          => [59,          '94287082'],
+            'T=1111111109'  => [1111111109,  '07081804'],
+            'T=1111111111'  => [1111111111,  '14050471'],
+            'T=1234567890'  => [1234567890,  '89005924'],
+            'T=2000000000'  => [2000000000,  '69279037'],
+            'T=20000000000' => [20000000000, '65353130'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rfc6238Sha1EightDigitProvider')]
+    public function rfc6238AppendixBEightDigitVectors(int $timestamp, string $expected): void
+    {
+        $generator8 = new TotpGenerator(codeDigits: 8);
+        $secret = '12345678901234567890';
+
+        $code = $generator8->computeCode($secret, $timestamp);
+
+        self::assertSame($expected, $code, "RFC 6238 SHA-1 8-digit vector failed at T={$timestamp}");
+    }
+
+    /**
+     * RFC 6238 Appendix B SHA-1 test vectors — 6-digit variants (last 6 digits of 8-digit values).
+     *
+     * @return array<string, array{int, string}>
+     */
+    public static function rfc6238Sha1SixDigitProvider(): array
+    {
+        return [
+            'T=59'          => [59,          '287082'],
+            'T=1111111109'  => [1111111109,  '081804'],
+            'T=1111111111'  => [1111111111,  '050471'],
+            'T=1234567890'  => [1234567890,  '005924'],
+            'T=2000000000'  => [2000000000,  '279037'],
+            'T=20000000000' => [20000000000, '353130'],
+        ];
+    }
+
+    #[Test]
+    #[DataProvider('rfc6238Sha1SixDigitProvider')]
+    public function rfc6238AppendixBSixDigitVectors(int $timestamp, string $expected): void
+    {
+        $secret = '12345678901234567890';
+
+        $code = $this->generator->computeCode($secret, $timestamp);
+
+        self::assertSame($expected, $code, "RFC 6238 SHA-1 6-digit vector failed at T={$timestamp}");
+    }
+
+    #[Test]
+    public function periodAndDigitsAccessors(): void
+    {
+        self::assertSame(30, $this->generator->period());
+        self::assertSame(6, $this->generator->digits());
+
+        $custom = new TotpGenerator(codeDigits: 8, period: 60);
+        self::assertSame(60, $custom->period());
+        self::assertSame(8, $custom->digits());
     }
 }

--- a/tests/Unit/Auth/TwoFactor/TotpReplayGuardTest.php
+++ b/tests/Unit/Auth/TwoFactor/TotpReplayGuardTest.php
@@ -17,6 +17,7 @@ use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
 use Pulsar\Auth\TwoFactor\InMemoryTotpReplayGuard;
 use Pulsar\Auth\TwoFactor\SqliteTotpReplayGuard;
+use Pulsar\Auth\TwoFactor\TwoFactorPurpose;
 
 use function random_bytes;
 use function rmdir;
@@ -53,7 +54,7 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
     }
 
     #[Test]
@@ -61,17 +62,17 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
-        self::assertFalse($guard->markUsed('user-1', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertFalse($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
     }
 
     #[Test]
-    public function inMemoryAllowsDifferentCodes(): void
+    public function inMemoryAllowsDifferentTimeSteps(): void
     {
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
-        self::assertTrue($guard->markUsed('user-1', '654321', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33334, 1000));
     }
 
     #[Test]
@@ -79,8 +80,17 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
-        self::assertTrue($guard->markUsed('user-2', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertTrue($guard->markUsed('user-2', TwoFactorPurpose::Login, 33333, 1000));
+    }
+
+    #[Test]
+    public function inMemoryAllowsDifferentPurposes(): void
+    {
+        $guard = new InMemoryTotpReplayGuard();
+
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::StepUp, 33333, 1000));
     }
 
     #[Test]
@@ -88,9 +98,9 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
         // 91 seconds later — expired
-        self::assertTrue($guard->markUsed('user-1', '123456', 1091));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1091));
     }
 
     #[Test]
@@ -98,7 +108,7 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = $this->createSqliteGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
     }
 
     #[Test]
@@ -106,17 +116,17 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = $this->createSqliteGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
-        self::assertFalse($guard->markUsed('user-1', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertFalse($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
     }
 
     #[Test]
-    public function sqliteAllowsDifferentCodes(): void
+    public function sqliteAllowsDifferentTimeSteps(): void
     {
         $guard = $this->createSqliteGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
-        self::assertTrue($guard->markUsed('user-1', '654321', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33334, 1000));
     }
 
     #[Test]
@@ -124,8 +134,17 @@ final class TotpReplayGuardTest extends TestCase
     {
         $guard = $this->createSqliteGuard();
 
-        self::assertTrue($guard->markUsed('user-1', '123456', 1000));
-        self::assertTrue($guard->markUsed('user-2', '123456', 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertTrue($guard->markUsed('user-2', TwoFactorPurpose::Login, 33333, 1000));
+    }
+
+    #[Test]
+    public function sqliteAllowsDifferentPurposes(): void
+    {
+        $guard = $this->createSqliteGuard();
+
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertTrue($guard->markUsed('user-1', TwoFactorPurpose::StepUp, 33333, 1000));
     }
 
     #[Test]
@@ -135,8 +154,8 @@ final class TotpReplayGuardTest extends TestCase
         $guard1 = $this->createSqliteGuard($path);
         $guard2 = $this->createSqliteGuard($path);
 
-        self::assertTrue($guard1->markUsed('user-1', '123456', 1000));
-        self::assertFalse($guard2->markUsed('user-1', '123456', 1000));
+        self::assertTrue($guard1->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
+        self::assertFalse($guard2->markUsed('user-1', TwoFactorPurpose::Login, 33333, 1000));
     }
 
     private function createSqliteGuard(?string $path = null): SqliteTotpReplayGuard

--- a/tests/Unit/Auth/TwoFactor/TotpSecretStoreTest.php
+++ b/tests/Unit/Auth/TwoFactor/TotpSecretStoreTest.php
@@ -1,0 +1,132 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Auth\TwoFactor;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Auth\TwoFactor\InMemoryTotpSecretStore;
+use Pulsar\Security\Crypto\Encryptor;
+use Pulsar\Security\Crypto\MasterKey;
+
+use function random_bytes;
+
+use ReflectionClass;
+
+use function sodium_bin2hex;
+
+#[CoversClass(InMemoryTotpSecretStore::class)]
+final class TotpSecretStoreTest extends TestCase
+{
+    #[Test]
+    public function storeAndRetrieveRoundTripWithoutEncryption(): void
+    {
+        $store = new InMemoryTotpSecretStore();
+
+        $secret = random_bytes(20);
+        $store->store('user-1', $secret);
+
+        self::assertSame($secret, $store->retrieve('user-1'));
+    }
+
+    #[Test]
+    public function storeAndRetrieveRoundTripWithEncryption(): void
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $encryptor = Encryptor::fromDerivedKey($masterKey, 4, 'totpscrt');
+        $store = new InMemoryTotpSecretStore($encryptor);
+
+        $secret = random_bytes(20);
+        $store->store('user-1', $secret);
+
+        self::assertSame($secret, $store->retrieve('user-1'));
+    }
+
+    #[Test]
+    public function retrieveReturnsNullForUnknownIdentity(): void
+    {
+        $store = new InMemoryTotpSecretStore();
+
+        self::assertNull($store->retrieve('unknown'));
+    }
+
+    #[Test]
+    public function deleteRemovesSecret(): void
+    {
+        $store = new InMemoryTotpSecretStore();
+
+        $secret = random_bytes(20);
+        $store->store('user-1', $secret);
+        self::assertNotNull($store->retrieve('user-1'));
+
+        $store->delete('user-1');
+        self::assertNull($store->retrieve('user-1'));
+    }
+
+    #[Test]
+    public function deleteOnNonexistentIdentityIsNoOp(): void
+    {
+        $store = new InMemoryTotpSecretStore();
+        $store->delete('nonexistent');
+
+        self::assertNull($store->retrieve('nonexistent'));
+    }
+
+    #[Test]
+    public function differentIdentitiesAreIsolated(): void
+    {
+        $store = new InMemoryTotpSecretStore();
+
+        $secret1 = random_bytes(20);
+        $secret2 = random_bytes(20);
+
+        $store->store('user-1', $secret1);
+        $store->store('user-2', $secret2);
+
+        self::assertSame($secret1, $store->retrieve('user-1'));
+        self::assertSame($secret2, $store->retrieve('user-2'));
+        self::assertNull($store->retrieve('user-3'));
+    }
+
+    #[Test]
+    public function storeOverwritesPreviousSecret(): void
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $encryptor = Encryptor::fromDerivedKey($masterKey, 4, 'totpscrt');
+        $store = new InMemoryTotpSecretStore($encryptor);
+
+        $secret1 = random_bytes(20);
+        $secret2 = random_bytes(20);
+
+        $store->store('user-1', $secret1);
+        self::assertSame($secret1, $store->retrieve('user-1'));
+
+        $store->store('user-1', $secret2);
+        self::assertSame($secret2, $store->retrieve('user-1'));
+    }
+
+    #[Test]
+    public function encryptedStorageDoesNotLeakPlaintext(): void
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $encryptor = Encryptor::fromDerivedKey($masterKey, 4, 'totpscrt');
+        $store = new InMemoryTotpSecretStore($encryptor);
+
+        $secret = 'this_is_a_known_secret_string';
+        $store->store('user-1', $secret);
+
+        // Retrieve works (decrypted)
+        self::assertSame($secret, $store->retrieve('user-1'));
+
+        // Verify internal state is encrypted (not plaintext)
+        $reflection = new ReflectionClass($store);
+        $property = $reflection->getProperty('secrets');
+        /** @var array<string, string> $secrets */
+        $secrets = $property->getValue($store);
+
+        self::assertArrayHasKey('user-1', $secrets);
+        self::assertNotSame($secret, $secrets['user-1']);
+    }
+}

--- a/tests/Unit/Auth/TwoFactor/TotpVerifierTest.php
+++ b/tests/Unit/Auth/TwoFactor/TotpVerifierTest.php
@@ -10,6 +10,7 @@ use PHPUnit\Framework\TestCase;
 use Pulsar\Auth\TwoFactor\InMemoryTotpReplayGuard;
 use Pulsar\Auth\TwoFactor\TotpGenerator;
 use Pulsar\Auth\TwoFactor\TotpVerifier;
+use Pulsar\Auth\TwoFactor\TwoFactorPurpose;
 
 #[CoversClass(TotpVerifier::class)]
 final class TotpVerifierTest extends TestCase
@@ -32,7 +33,7 @@ final class TotpVerifierTest extends TestCase
 
         $code = $this->generator->computeCode($secret, $timestamp);
 
-        self::assertTrue($this->verifier->verify($secret, $code, $timestamp));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp));
     }
 
     #[Test]
@@ -41,7 +42,7 @@ final class TotpVerifierTest extends TestCase
         $secret = $this->generator->generateSecret();
         $timestamp = 1000000;
 
-        self::assertFalse($this->verifier->verify($secret, '000000', $timestamp));
+        self::assertNull($this->verifier->verify($secret, '000000', $timestamp));
     }
 
     #[Test]
@@ -52,15 +53,28 @@ final class TotpVerifierTest extends TestCase
 
         // Code generated for one period ahead (window allows +1)
         $futureCode = $this->generator->computeCode($secret, $timestamp + 30);
-        self::assertTrue($this->verifier->verify($secret, $futureCode, $timestamp));
+        self::assertNotNull($this->verifier->verify($secret, $futureCode, $timestamp));
 
         // Code generated for one period behind (window allows -1)
         $pastCode = $this->generator->computeCode($secret, $timestamp - 30);
-        self::assertTrue($this->verifier->verify($secret, $pastCode, $timestamp));
+        self::assertNotNull($this->verifier->verify($secret, $pastCode, $timestamp));
 
         // Code generated for two periods ahead (outside window of 1)
         $farFutureCode = $this->generator->computeCode($secret, $timestamp + 60);
-        self::assertFalse($this->verifier->verify($secret, $farFutureCode, $timestamp));
+        self::assertNull($this->verifier->verify($secret, $farFutureCode, $timestamp));
+    }
+
+    #[Test]
+    public function verifyReturnsAcceptedTimeStep(): void
+    {
+        $secret = $this->generator->generateSecret();
+        $timestamp = 1000000;
+        $code = $this->generator->computeCode($secret, $timestamp);
+
+        $timeStep = $this->verifier->verify($secret, $code, $timestamp);
+
+        self::assertNotNull($timeStep);
+        self::assertSame(intdiv($timestamp, 30), $timeStep);
     }
 
     #[Test]
@@ -71,8 +85,8 @@ final class TotpVerifierTest extends TestCase
         $code = $this->generator->computeCode($secret, $timestamp);
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1'));
-        self::assertFalse($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1'));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1'));
+        self::assertNull($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1'));
     }
 
     #[Test]
@@ -83,8 +97,20 @@ final class TotpVerifierTest extends TestCase
         $code = $this->generator->computeCode($secret, $timestamp);
         $guard = new InMemoryTotpReplayGuard();
 
-        self::assertTrue($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1'));
-        self::assertTrue($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-2'));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1'));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-2'));
+    }
+
+    #[Test]
+    public function verifyWithReplayGuardAllowsDifferentPurposes(): void
+    {
+        $secret = $this->generator->generateSecret();
+        $timestamp = 1000000;
+        $code = $this->generator->computeCode($secret, $timestamp);
+        $guard = new InMemoryTotpReplayGuard();
+
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1', TwoFactorPurpose::Login));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp, $guard, 'user-1', TwoFactorPurpose::StepUp));
     }
 
     #[Test]
@@ -94,7 +120,33 @@ final class TotpVerifierTest extends TestCase
         $timestamp = 1000000;
         $code = $this->generator->computeCode($secret, $timestamp);
 
-        self::assertTrue($this->verifier->verify($secret, $code, $timestamp));
-        self::assertTrue($this->verifier->verify($secret, $code, $timestamp));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp));
+        self::assertNotNull($this->verifier->verify($secret, $code, $timestamp));
+    }
+
+    #[Test]
+    public function verifyUsesGeneratorPeriodInsteadOfHardcoded30(): void
+    {
+        $generator60 = new TotpGenerator(period: 60);
+        $verifier60 = new TotpVerifier($generator60, window: 1);
+
+        $secret = $generator60->generateSecret();
+        $timestamp = 1000000;
+
+        // Code at one period ahead (60 seconds) should be accepted within window=1
+        $futureCode = $generator60->computeCode($secret, $timestamp + 60);
+        self::assertNotNull($verifier60->verify($secret, $futureCode, $timestamp));
+
+        // Code at two periods ahead (120 seconds) should be rejected for window=1
+        $farFutureCode = $generator60->computeCode($secret, $timestamp + 120);
+        self::assertNull($verifier60->verify($secret, $farFutureCode, $timestamp));
+
+        // Verify that a code at a timestamp within the same 60s time step produces the same code.
+        // Use a timestamp at the start of a 60s boundary to ensure $timestamp and $timestamp+29
+        // both fall in the same time step.
+        $alignedTimestamp = 1000020; // intdiv(1000020, 60) = 16667
+        $sameStepCode1 = $generator60->computeCode($secret, $alignedTimestamp);
+        $sameStepCode2 = $generator60->computeCode($secret, $alignedTimestamp + 29);
+        self::assertSame($sameStepCode1, $sameStepCode2, 'Same 60s time step should produce same code');
     }
 }

--- a/tests/Unit/Auth/TwoFactor/TwoFactorManagerTest.php
+++ b/tests/Unit/Auth/TwoFactor/TwoFactorManagerTest.php
@@ -7,14 +7,36 @@ namespace Pulsar\Tests\Unit\Auth\TwoFactor;
 use PHPUnit\Framework\Attributes\CoversClass;
 use PHPUnit\Framework\Attributes\Test;
 use PHPUnit\Framework\TestCase;
+use Pulsar\Audit\AuditLoggerInterface;
 use Pulsar\Auth\Identity\IdentityInterface;
+use Pulsar\Auth\TwoFactor\AuthEventCollectorInterface;
+use Pulsar\Auth\TwoFactor\Confirm2faSetupResult;
+use Pulsar\Auth\TwoFactor\InMemoryRecoveryCodeStore;
+use Pulsar\Auth\TwoFactor\InMemoryTotpReplayGuard;
+use Pulsar\Auth\TwoFactor\InMemoryTotpSecretStore;
 use Pulsar\Auth\TwoFactor\RecoveryCodeGenerator;
+use Pulsar\Auth\TwoFactor\RecoveryCodeHasher;
+use Pulsar\Auth\TwoFactor\RecoveryCodeRotationResult;
 use Pulsar\Auth\TwoFactor\RecoveryCodeVerifier;
 use Pulsar\Auth\TwoFactor\TotpGenerator;
 use Pulsar\Auth\TwoFactor\TotpVerifier;
 use Pulsar\Auth\TwoFactor\TwoFactorManager;
+use Pulsar\Auth\TwoFactor\TwoFactorPurpose;
+use Pulsar\Auth\TwoFactor\TwoFactorRateLimiterInterface;
+use Pulsar\Auth\TwoFactor\Verify2faResult;
+use Pulsar\Auth\TwoFactor\VerifyReason;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditOutcome;
+use Pulsar\Security\Crypto\MasterKey;
+use Pulsar\Security\Session\SessionInterface;
+
+use function random_bytes;
+use function sodium_bin2hex;
 
 #[CoversClass(TwoFactorManager::class)]
+#[CoversClass(Verify2faResult::class)]
+#[CoversClass(Confirm2faSetupResult::class)]
+#[CoversClass(RecoveryCodeRotationResult::class)]
 final class TwoFactorManagerTest extends TestCase
 {
     private TwoFactorManager $manager;
@@ -27,12 +49,15 @@ final class TwoFactorManagerTest extends TestCase
 
     private RecoveryCodeVerifier $recoveryCodeVerifier;
 
+    private InMemoryTotpReplayGuard $replayGuard;
+
     protected function setUp(): void
     {
         $this->generator = new TotpGenerator();
         $this->verifier = new TotpVerifier($this->generator);
         $this->recoveryCodeGenerator = new RecoveryCodeGenerator();
         $this->recoveryCodeVerifier = new RecoveryCodeVerifier();
+        $this->replayGuard = new InMemoryTotpReplayGuard();
 
         $this->manager = new TwoFactorManager(
             generator: $this->generator,
@@ -41,6 +66,7 @@ final class TwoFactorManagerTest extends TestCase
             recoveryCodeVerifier: $this->recoveryCodeVerifier,
             issuer: 'TestApp',
             recoveryCodeCount: 8,
+            replayGuard: $this->replayGuard,
         );
     }
 
@@ -49,6 +75,7 @@ final class TwoFactorManagerTest extends TestCase
     {
         $identity = $this->createStub(IdentityInterface::class);
         $identity->method('displayName')->willReturn('test@example.com');
+        $identity->method('id')->willReturn('user-1');
 
         $result = $this->manager->beginSetup($identity);
 
@@ -73,32 +100,87 @@ final class TwoFactorManagerTest extends TestCase
     #[Test]
     public function confirmSetupDelegatesToVerifier(): void
     {
-        // Generate a secret and compute a code at the current time so the real
-        // verifier (which defaults to time()) will accept it within its window.
         $secret = $this->generator->generateSecret();
         $code = $this->generator->computeCode($secret);
 
-        // confirmSetup delegates to TotpVerifier::verify which should accept
-        // a code generated for the current time step.
-        $result = $this->manager->confirmSetup($secret, $code);
+        $result = $this->manager->confirmSetup('user-1', $secret, $code);
 
-        self::assertTrue($result);
+        self::assertInstanceOf(Confirm2faSetupResult::class, $result);
+        self::assertTrue($result->confirmed);
+        self::assertSame(VerifyReason::Valid, $result->reason);
     }
 
     #[Test]
-    public function verifyCodeDelegatesToVerifier(): void
+    public function confirmSetupRejectsInvalidCode(): void
     {
-        // Generate a secret and compute a code at the current time so the real
-        // verifier will accept it.
+        $secret = $this->generator->generateSecret();
+
+        $result = $this->manager->confirmSetup('user-1', $secret, '000000');
+
+        self::assertFalse($result->confirmed);
+        self::assertSame(VerifyReason::InvalidCode, $result->reason);
+    }
+
+    #[Test]
+    public function verifyCodeWithSecretReturnsTypedResult(): void
+    {
         $secret = $this->generator->generateSecret();
         $code = $this->generator->computeCode($secret);
 
-        $result = $this->manager->verifyCode($secret, $code);
+        $result = $this->manager->verifyCodeWithSecret('user-1', $secret, $code);
 
-        self::assertTrue($result);
+        self::assertInstanceOf(Verify2faResult::class, $result);
+        self::assertTrue($result->verified);
+        self::assertSame(VerifyReason::Valid, $result->reason);
+        self::assertSame(TwoFactorPurpose::Login, $result->purpose);
+        self::assertNotNull($result->acceptedTimeStep);
+    }
 
-        // A wrong code should return false
-        self::assertFalse($this->manager->verifyCode($secret, '000000'));
+    #[Test]
+    public function verifyCodeWithSecretRejectsInvalidCode(): void
+    {
+        $secret = $this->generator->generateSecret();
+
+        $result = $this->manager->verifyCodeWithSecret('user-1', $secret, '000000');
+
+        self::assertFalse($result->verified);
+        self::assertSame(VerifyReason::InvalidCode, $result->reason);
+        self::assertNull($result->acceptedTimeStep);
+    }
+
+    #[Test]
+    public function verifyCodeWithSecretRejectsReplayedCode(): void
+    {
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $first = $this->manager->verifyCodeWithSecret('user-1', $secret, $code);
+        self::assertTrue($first->verified);
+
+        $second = $this->manager->verifyCodeWithSecret('user-1', $secret, $code);
+        self::assertFalse($second->verified);
+        self::assertSame(VerifyReason::InvalidCode, $second->reason);
+    }
+
+    #[Test]
+    public function verifyCodeWithoutStoreReturnsNotEnrolled(): void
+    {
+        $result = $this->manager->verifyCode('user-1', '123456');
+
+        self::assertFalse($result->verified);
+        self::assertSame(VerifyReason::NotEnrolled, $result->reason);
+    }
+
+    #[Test]
+    public function verifyCodeWithSecretAcceptsPurpose(): void
+    {
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $result = $this->manager->verifyCodeWithSecret('user-1', $secret, $code, TwoFactorPurpose::StepUp);
+
+        self::assertTrue($result->verified);
+        self::assertSame(TwoFactorPurpose::StepUp, $result->purpose);
     }
 
     #[Test]
@@ -106,11 +188,360 @@ final class TwoFactorManagerTest extends TestCase
     {
         $validCodes = ['ABCD-1234', 'EF56-7890'];
 
-        // Matching code should return its index
-        self::assertSame(0, $this->manager->verifyRecoveryCode('ABCD-1234', $validCodes));
-        self::assertSame(1, $this->manager->verifyRecoveryCode('EF56-7890', $validCodes));
+        self::assertSame(0, $this->manager->verifyRecoveryCode('user-1', 'ABCD-1234', $validCodes));
+        self::assertSame(1, $this->manager->verifyRecoveryCode('user-1', 'EF56-7890', $validCodes));
+        self::assertSame(-1, $this->manager->verifyRecoveryCode('user-1', 'FFFF-FFFF', $validCodes));
+    }
 
-        // Non-matching code should return -1
-        self::assertSame(-1, $this->manager->verifyRecoveryCode('FFFF-FFFF', $validCodes));
+    #[Test]
+    public function verifyCodeWithStoreLoadsSecretAutomatically(): void
+    {
+        $secretStore = new InMemoryTotpSecretStore();
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            replayGuard: $this->replayGuard,
+            secretStore: $secretStore,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $secretStore->store('user-1', $secret);
+        $code = $this->generator->computeCode($secret);
+
+        $result = $manager->verifyCode('user-1', $code);
+
+        self::assertTrue($result->verified);
+        self::assertSame(VerifyReason::Valid, $result->reason);
+    }
+
+    #[Test]
+    public function verifyCodeWithStoreReturnsNotEnrolledWhenNoSecret(): void
+    {
+        $secretStore = new InMemoryTotpSecretStore();
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            secretStore: $secretStore,
+        );
+
+        $result = $manager->verifyCode('user-1', '123456');
+
+        self::assertFalse($result->verified);
+        self::assertSame(VerifyReason::NotEnrolled, $result->reason);
+    }
+
+    #[Test]
+    public function confirmSetupStoresSecretInStore(): void
+    {
+        $secretStore = new InMemoryTotpSecretStore();
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            secretStore: $secretStore,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $result = $manager->confirmSetup('user-1', $secret, $code);
+
+        self::assertTrue($result->confirmed);
+        self::assertSame($secret, $secretStore->retrieve('user-1'));
+    }
+
+    #[Test]
+    public function auditLoggerReceivesEventsOnVerify(): void
+    {
+        $auditLogger = $this->createMock(AuditLoggerInterface::class);
+        $auditLogger->expects(self::once())
+            ->method('log')
+            ->with(
+                AuditEvent::Authentication,
+                AuditOutcome::Success,
+                'user-1',
+                '2fa_code_verified',
+                self::anything(),
+                self::callback(static fn(array $metadata): bool => isset($metadata['purpose'])
+                    && $metadata['purpose'] === 'login'),
+            );
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            replayGuard: $this->replayGuard,
+            auditLogger: $auditLogger,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $manager->verifyCodeWithSecret('user-1', $secret, $code);
+    }
+
+    #[Test]
+    public function auditLoggerReceivesFailureOnInvalidCode(): void
+    {
+        $auditLogger = $this->createMock(AuditLoggerInterface::class);
+        $auditLogger->expects(self::once())
+            ->method('log')
+            ->with(
+                AuditEvent::Authentication,
+                AuditOutcome::Failure,
+                'user-1',
+                '2fa_code_verification_failed',
+            );
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            replayGuard: $this->replayGuard,
+            auditLogger: $auditLogger,
+        );
+
+        $manager->verifyCodeWithSecret('user-1', $this->generator->generateSecret(), '000000');
+    }
+
+    #[Test]
+    public function eventCollectorReceivesEventsOnVerify(): void
+    {
+        $collector = $this->createMock(AuthEventCollectorInterface::class);
+        $collector->expects(self::once())
+            ->method('recordTwoFactorEvent')
+            ->with(
+                '2fa_code_verified',
+                'success',
+                'user-1',
+                self::callback(static fn(array $metadata): bool => isset($metadata['purpose'])
+                    && $metadata['purpose'] === 'login'),
+            );
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            replayGuard: $this->replayGuard,
+            eventCollector: $collector,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $manager->verifyCodeWithSecret('user-1', $secret, $code);
+    }
+
+    #[Test]
+    public function eventCollectorMetadataNeverContainsSensitiveKeys(): void
+    {
+        $collector = $this->createMock(AuthEventCollectorInterface::class);
+        $collector->expects(self::atLeastOnce())
+            ->method('recordTwoFactorEvent')
+            ->with(
+                self::anything(),
+                self::anything(),
+                self::anything(),
+                self::callback(static function (array $metadata): bool {
+                    $forbidden = ['secret', 'code', 'token', 'password', 'key'];
+                    foreach ($forbidden as $key) {
+                        if (isset($metadata[$key])) {
+                            return false;
+                        }
+                    }
+
+                    return true;
+                }),
+            );
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            replayGuard: $this->replayGuard,
+            eventCollector: $collector,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+        $manager->verifyCodeWithSecret('user-1', $secret, $code);
+    }
+
+    #[Test]
+    public function rateLimiterBlocksVerification(): void
+    {
+        $rateLimiter = $this->createStub(TwoFactorRateLimiterInterface::class);
+        $rateLimiter->method('attempt')->willReturn(false);
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            rateLimiter: $rateLimiter,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $result = $manager->verifyCodeWithSecret('user-1', $secret, $code);
+
+        self::assertFalse($result->verified);
+        self::assertSame(VerifyReason::RateLimited, $result->reason);
+    }
+
+    #[Test]
+    public function sessionRegeneratedOnSuccessfulVerify(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->expects(self::once())->method('regenerate');
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            replayGuard: $this->replayGuard,
+            session: $session,
+        );
+
+        $secret = $this->generator->generateSecret();
+        $code = $this->generator->computeCode($secret);
+
+        $manager->verifyCodeWithSecret('user-1', $secret, $code);
+    }
+
+    #[Test]
+    public function sessionNotRegeneratedOnFailedVerify(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->expects(self::never())->method('regenerate');
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            session: $session,
+        );
+
+        $manager->verifyCodeWithSecret('user-1', $this->generator->generateSecret(), '000000');
+    }
+
+    #[Test]
+    public function rotateRecoveryCodesGeneratesNewSet(): void
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $hasherKey = $masterKey->deriveSubKey(3, 'rcvrycod');
+        $hasher = new RecoveryCodeHasher($hasherKey);
+        $store = new InMemoryRecoveryCodeStore();
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            recoveryCodeHasher: $hasher,
+            recoveryCodeStore: $store,
+        );
+
+        $result = $manager->rotateRecoveryCodes('user-1');
+
+        self::assertInstanceOf(RecoveryCodeRotationResult::class, $result);
+        self::assertCount(8, $result->plaintextCodes);
+        self::assertCount(8, $result->set->codeHashes);
+        self::assertSame([], $result->set->usedIndices);
+        self::assertSame(2, $result->set->algorithmVersion);
+
+        // Verify stored in store
+        $loaded = $store->loadSet('user-1');
+        self::assertNotNull($loaded);
+        self::assertSame($result->set->setId, $loaded->setId);
+    }
+
+    #[Test]
+    public function rotatedRecoveryCodesCanBeConsumed(): void
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $hasherKey = $masterKey->deriveSubKey(3, 'rcvrycod');
+        $hasher = new RecoveryCodeHasher($hasherKey);
+        $store = new InMemoryRecoveryCodeStore();
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            recoveryCodeHasher: $hasher,
+            recoveryCodeStore: $store,
+        );
+
+        $result = $manager->rotateRecoveryCodes('user-1');
+        $firstCode = $result->plaintextCodes[0];
+
+        // Verify the code can be consumed
+        $index = $manager->verifyRecoveryCode('user-1', $firstCode);
+        self::assertSame(0, $index);
+
+        // Second attempt for same code should fail (atomic consume)
+        $secondAttempt = $manager->verifyRecoveryCode('user-1', $firstCode);
+        self::assertSame(-1, $secondAttempt);
+    }
+
+    #[Test]
+    public function verifyRecoveryCodeWithStoreRejectsUnknownCode(): void
+    {
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $hasherKey = $masterKey->deriveSubKey(3, 'rcvrycod');
+        $hasher = new RecoveryCodeHasher($hasherKey);
+        $store = new InMemoryRecoveryCodeStore();
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            recoveryCodeHasher: $hasher,
+            recoveryCodeStore: $store,
+        );
+
+        $manager->rotateRecoveryCodes('user-1');
+
+        $index = $manager->verifyRecoveryCode('user-1', 'FFFF-FFFF-FFFF-FFFF');
+        self::assertSame(-1, $index);
+    }
+
+    #[Test]
+    public function sessionRegeneratedOnRecoveryCodeUse(): void
+    {
+        $session = $this->createMock(SessionInterface::class);
+        $session->expects(self::once())->method('regenerate');
+
+        $masterKey = MasterKey::fromHex(sodium_bin2hex(random_bytes(32)));
+        $hasherKey = $masterKey->deriveSubKey(3, 'rcvrycod');
+        $hasher = new RecoveryCodeHasher($hasherKey);
+        $store = new InMemoryRecoveryCodeStore();
+
+        $manager = new TwoFactorManager(
+            generator: $this->generator,
+            verifier: $this->verifier,
+            recoveryCodeGenerator: $this->recoveryCodeGenerator,
+            recoveryCodeVerifier: $this->recoveryCodeVerifier,
+            recoveryCodeHasher: $hasher,
+            recoveryCodeStore: $store,
+            session: $session,
+        );
+
+        $result = $manager->rotateRecoveryCodes('user-1');
+        $manager->verifyRecoveryCode('user-1', $result->plaintextCodes[0]);
     }
 }

--- a/tests/Unit/Extension/SocialSso/Config/ProviderConfigTest.php
+++ b/tests/Unit/Extension/SocialSso/Config/ProviderConfigTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Config\ProviderConfig;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+
+#[CoversClass(ProviderConfig::class)]
+final class ProviderConfigTest extends TestCase
+{
+    #[Test]
+    public function fromArrayCreatesProviderConfig(): void
+    {
+        $config = ProviderConfig::fromArray('google', [
+            'type' => 'oidc',
+            'client_id' => 'test-id',
+            'client_secret' => 'test-secret',
+            'authorization_url' => 'https://auth.example.com/authorize',
+            'token_url' => 'https://auth.example.com/token',
+            'jwks_uri' => 'https://auth.example.com/.well-known/jwks.json',
+            'issuer' => 'https://auth.example.com',
+            'scopes' => ['openid', 'profile'],
+            'redirect_uri' => 'https://app.example.com/callback',
+        ]);
+
+        self::assertSame('google', $config->name);
+        self::assertSame('oidc', $config->type);
+        self::assertSame('test-id', $config->clientId);
+        self::assertSame('test-secret', $config->clientSecret);
+        self::assertSame('https://auth.example.com/authorize', $config->authorizationUrl);
+        self::assertSame('https://auth.example.com/token', $config->tokenUrl);
+        self::assertSame('https://auth.example.com/.well-known/jwks.json', $config->jwksUri);
+        self::assertSame('https://auth.example.com', $config->issuer);
+        self::assertSame(['openid', 'profile'], $config->scopes);
+        self::assertSame('https://app.example.com/callback', $config->redirectUri);
+        self::assertFalse($config->allowUnverifiedIdToken);
+        self::assertSame(120, $config->maxClockSkewSeconds);
+    }
+
+    #[Test]
+    public function fromArrayRejectsNonHttpsJwksUri(): void
+    {
+        $this->expectException(SsoException::class);
+
+        (void) ProviderConfig::fromArray('bad', [
+            'jwks_uri' => 'http://insecure.example.com/jwks',
+        ]);
+    }
+
+    #[Test]
+    public function fromArrayAllowsNullJwksUri(): void
+    {
+        $config = ProviderConfig::fromArray('oauth2-provider', [
+            'type' => 'oauth2',
+            'client_id' => 'id',
+            'client_secret' => 'secret',
+        ]);
+
+        self::assertNull($config->jwksUri);
+    }
+
+    #[Test]
+    public function debugInfoRedactsClientSecret(): void
+    {
+        $config = ProviderConfig::fromArray('test', [
+            'client_id' => 'my-id',
+            'client_secret' => 'super-secret-value',
+        ]);
+
+        $debug = $config->__debugInfo();
+
+        self::assertSame('[REDACTED]', $debug['clientSecret']);
+        self::assertSame('my-id', $debug['clientId']);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Config/RoutesConfigTest.php
+++ b/tests/Unit/Extension/SocialSso/Config/RoutesConfigTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Config\RoutesConfig;
+
+#[CoversClass(RoutesConfig::class)]
+final class RoutesConfigTest extends TestCase
+{
+    #[Test]
+    public function fromArrayCreatesWithDefaults(): void
+    {
+        $config = RoutesConfig::fromArray([]);
+
+        self::assertSame('/sso/{provider}/login', $config->loginPath);
+        self::assertSame('/sso/{provider}/callback', $config->callbackPath);
+    }
+
+    #[Test]
+    public function fromArrayCreatesWithCustomPaths(): void
+    {
+        $config = RoutesConfig::fromArray([
+            'login_path' => '/auth/login/{provider}',
+            'callback_path' => '/auth/callback/{provider}',
+        ]);
+
+        self::assertSame('/auth/login/{provider}', $config->loginPath);
+        self::assertSame('/auth/callback/{provider}', $config->callbackPath);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Config/SocialSsoConfigTest.php
+++ b/tests/Unit/Extension/SocialSso/Config/SocialSsoConfigTest.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Config\ProviderConfig;
+use Pulsar\Extension\SocialSso\Config\RoutesConfig;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+
+#[CoversClass(SocialSsoConfig::class)]
+final class SocialSsoConfigTest extends TestCase
+{
+    #[Test]
+    public function fromArrayCreatesConfigWithDefaults(): void
+    {
+        $config = SocialSsoConfig::fromArray([]);
+
+        self::assertFalse($config->enabled);
+        self::assertSame('', $config->defaultProvider);
+        self::assertTrue($config->requirePkce);
+        self::assertTrue($config->requireNonce);
+        self::assertSame(300, $config->stateTtlSeconds);
+        self::assertSame([], $config->providers);
+        self::assertInstanceOf(RoutesConfig::class, $config->routes);
+    }
+
+    #[Test]
+    public function fromArrayCreatesConfigWithCustomValues(): void
+    {
+        $config = SocialSsoConfig::fromArray([
+            'enabled' => true,
+            'default_provider' => 'google',
+            'require_pkce' => false,
+            'require_nonce' => false,
+            'state_ttl_seconds' => 600,
+            'routes' => [
+                'login_path' => '/auth/{provider}/login',
+                'callback_path' => '/auth/{provider}/callback',
+            ],
+            'providers' => [
+                'google' => [
+                    'type' => 'oidc',
+                    'client_id' => 'test-client-id',
+                    'client_secret' => 'test-secret',
+                    'authorization_url' => 'https://accounts.google.com/o/oauth2/v2/auth',
+                    'token_url' => 'https://oauth2.googleapis.com/token',
+                    'jwks_uri' => 'https://www.googleapis.com/oauth2/v3/certs',
+                    'issuer' => 'https://accounts.google.com',
+                    'scopes' => ['openid', 'email'],
+                ],
+            ],
+        ]);
+
+        self::assertTrue($config->enabled);
+        self::assertSame('google', $config->defaultProvider);
+        self::assertFalse($config->requirePkce);
+        self::assertFalse($config->requireNonce);
+        self::assertSame(600, $config->stateTtlSeconds);
+        self::assertSame('/auth/{provider}/login', $config->routes->loginPath);
+        self::assertCount(1, $config->providers);
+        self::assertArrayHasKey('google', $config->providers);
+        self::assertInstanceOf(ProviderConfig::class, $config->providers['google']);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Domain/IdTokenClaimsTest.php
+++ b/tests/Unit/Extension/SocialSso/Domain/IdTokenClaimsTest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+
+#[CoversClass(IdTokenClaims::class)]
+final class IdTokenClaimsTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsStandardClaims(): void
+    {
+        $claims = new IdTokenClaims(
+            sub: 'user-123',
+            iss: 'https://accounts.google.com',
+            aud: 'client-id',
+            exp: 1700000000,
+            iat: 1699996400,
+            nonce: 'nonce-value',
+            azp: 'client-id',
+            claims: ['email' => 'user@example.com'],
+        );
+
+        self::assertSame('user-123', $claims->sub);
+        self::assertSame('https://accounts.google.com', $claims->iss);
+        self::assertSame('client-id', $claims->aud);
+        self::assertSame(1700000000, $claims->exp);
+        self::assertSame(1699996400, $claims->iat);
+        self::assertSame('nonce-value', $claims->nonce);
+        self::assertSame('client-id', $claims->azp);
+        self::assertSame(['email' => 'user@example.com'], $claims->claims);
+    }
+
+    #[Test]
+    public function audCanBeArray(): void
+    {
+        $claims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://example.com',
+            aud: ['client-1', 'client-2'],
+            exp: 1700000000,
+            iat: 1699996400,
+        );
+
+        self::assertSame(['client-1', 'client-2'], $claims->aud);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Domain/LinkedIdentityResultTest.php
+++ b/tests/Unit/Extension/SocialSso/Domain/LinkedIdentityResultTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\LinkAction;
+use Pulsar\Extension\SocialSso\Domain\LinkedIdentityResult;
+
+#[CoversClass(LinkedIdentityResult::class)]
+final class LinkedIdentityResultTest extends TestCase
+{
+    #[Test]
+    public function linkedResultHasIdentityId(): void
+    {
+        $result = new LinkedIdentityResult(
+            linked: true,
+            identityId: 'user-42',
+            action: LinkAction::Linked,
+        );
+
+        self::assertTrue($result->linked);
+        self::assertSame('user-42', $result->identityId);
+        self::assertSame(LinkAction::Linked, $result->action);
+    }
+
+    #[Test]
+    public function unlinkedResultHasNullIdentityId(): void
+    {
+        $result = new LinkedIdentityResult(
+            linked: false,
+            identityId: null,
+            action: LinkAction::Unlinked,
+        );
+
+        self::assertFalse($result->linked);
+        self::assertNull($result->identityId);
+        self::assertSame(LinkAction::Unlinked, $result->action);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Domain/OAuthTokenSetTest.php
+++ b/tests/Unit/Extension/SocialSso/Domain/OAuthTokenSetTest.php
@@ -1,0 +1,64 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+
+#[CoversClass(OAuthTokenSet::class)]
+final class OAuthTokenSetTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsAllFields(): void
+    {
+        $token = new OAuthTokenSet(
+            accessToken: 'access-123',
+            tokenType: 'Bearer',
+            expiresIn: 3600,
+            refreshToken: 'refresh-456',
+            idToken: 'id.token.jwt',
+            unverifiedClaims: ['sub' => 'user-1'],
+        );
+
+        self::assertSame('access-123', $token->accessToken);
+        self::assertSame('Bearer', $token->tokenType);
+        self::assertSame(3600, $token->expiresIn);
+        self::assertSame('refresh-456', $token->refreshToken);
+        self::assertSame('id.token.jwt', $token->idToken);
+        self::assertSame(['sub' => 'user-1'], $token->unverifiedClaims);
+    }
+
+    #[Test]
+    public function debugInfoRedactsAllTokenMaterial(): void
+    {
+        $token = new OAuthTokenSet(
+            accessToken: 'real-access-token',
+            refreshToken: 'real-refresh-token',
+            idToken: 'real-id-token',
+            unverifiedClaims: ['sub' => 'user-1'],
+        );
+
+        $debug = $token->__debugInfo();
+
+        self::assertSame('[REDACTED]', $debug['accessToken']);
+        self::assertSame('[REDACTED]', $debug['refreshToken']);
+        self::assertSame('[REDACTED]', $debug['idToken']);
+        self::assertSame('[REDACTED]', $debug['unverifiedClaims']);
+    }
+
+    #[Test]
+    public function debugInfoShowsNullForMissingTokens(): void
+    {
+        $token = new OAuthTokenSet(accessToken: 'access-123');
+
+        $debug = $token->__debugInfo();
+
+        self::assertNull($debug['refreshToken']);
+        self::assertNull($debug['idToken']);
+        self::assertNull($debug['unverifiedClaims']);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Domain/PkceChallengeTest.php
+++ b/tests/Unit/Extension/SocialSso/Domain/PkceChallengeTest.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\PkceChallenge;
+
+use function strlen;
+
+#[CoversClass(PkceChallenge::class)]
+final class PkceChallengeTest extends TestCase
+{
+    #[Test]
+    public function generateProducesValidS256Challenge(): void
+    {
+        $challenge = PkceChallenge::generate();
+
+        self::assertSame('S256', $challenge->method);
+        self::assertNotEmpty($challenge->verifier);
+        self::assertNotEmpty($challenge->challenge);
+        self::assertNotSame($challenge->verifier, $challenge->challenge);
+    }
+
+    #[Test]
+    public function generateProducesUniqueValues(): void
+    {
+        $a = PkceChallenge::generate();
+        $b = PkceChallenge::generate();
+
+        self::assertNotSame($a->verifier, $b->verifier);
+        self::assertNotSame($a->challenge, $b->challenge);
+    }
+
+    #[Test]
+    public function challengeIsSha256OfVerifier(): void
+    {
+        $challenge = PkceChallenge::generate();
+
+        // Manually compute the expected challenge
+        $expectedChallenge = rtrim(str_replace(['+', '/'], ['-', '_'], base64_encode(hash('sha256', $challenge->verifier, true))), '=');
+
+        self::assertSame($expectedChallenge, $challenge->challenge);
+    }
+
+    #[Test]
+    public function verifierLengthIs43Characters(): void
+    {
+        // 32 bytes → base64url without padding = 43 chars
+        $challenge = PkceChallenge::generate();
+
+        self::assertSame(43, strlen($challenge->verifier));
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Domain/SocialIdentityTest.php
+++ b/tests/Unit/Extension/SocialSso/Domain/SocialIdentityTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+
+#[CoversClass(SocialIdentity::class)]
+final class SocialIdentityTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsAllFields(): void
+    {
+        $identity = new SocialIdentity(
+            provider: 'google',
+            providerUserId: '12345',
+            email: 'user@example.com',
+            name: 'Test User',
+            avatarUrl: 'https://example.com/avatar.jpg',
+            rawAttributes: ['locale' => 'en'],
+        );
+
+        self::assertSame('google', $identity->provider);
+        self::assertSame('12345', $identity->providerUserId);
+        self::assertSame('user@example.com', $identity->email);
+        self::assertSame('Test User', $identity->name);
+        self::assertSame('https://example.com/avatar.jpg', $identity->avatarUrl);
+        self::assertSame(['locale' => 'en'], $identity->rawAttributes);
+    }
+
+    #[Test]
+    public function optionalFieldsDefaultToNull(): void
+    {
+        $identity = new SocialIdentity(provider: 'github', providerUserId: '999');
+
+        self::assertNull($identity->email);
+        self::assertNull($identity->name);
+        self::assertNull($identity->avatarUrl);
+        self::assertSame([], $identity->rawAttributes);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Domain/SsoLoginResultTest.php
+++ b/tests/Unit/Extension/SocialSso/Domain/SsoLoginResultTest.php
@@ -1,0 +1,50 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Domain;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Domain\LinkAction;
+use Pulsar\Extension\SocialSso\Domain\LinkedIdentityResult;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+use Pulsar\Extension\SocialSso\Domain\SsoLoginResult;
+
+#[CoversClass(SsoLoginResult::class)]
+final class SsoLoginResultTest extends TestCase
+{
+    #[Test]
+    public function constructorSetsAllFields(): void
+    {
+        $identity = new SocialIdentity(provider: 'google', providerUserId: '123');
+        $linkResult = new LinkedIdentityResult(linked: true, identityId: 'user-1', action: LinkAction::Linked);
+        $claims = new IdTokenClaims(sub: '123', iss: 'https://issuer.com', aud: 'client', exp: 9999999999, iat: 1000000000);
+
+        $result = new SsoLoginResult(
+            socialIdentity: $identity,
+            linkResult: $linkResult,
+            verifiedClaims: $claims,
+        );
+
+        self::assertSame($identity, $result->socialIdentity);
+        self::assertSame($linkResult, $result->linkResult);
+        self::assertSame($claims, $result->verifiedClaims);
+    }
+
+    #[Test]
+    public function verifiedClaimsDefaultsToNull(): void
+    {
+        $identity = new SocialIdentity(provider: 'github', providerUserId: '456');
+        $linkResult = new LinkedIdentityResult(linked: false, identityId: null, action: LinkAction::Unlinked);
+
+        $result = new SsoLoginResult(
+            socialIdentity: $identity,
+            linkResult: $linkResult,
+        );
+
+        self::assertNull($result->verifiedClaims);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Exception/SsoExceptionTest.php
+++ b/tests/Unit/Extension/SocialSso/Exception/SsoExceptionTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Exception;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+use RuntimeException;
+
+#[CoversClass(SsoException::class)]
+final class SsoExceptionTest extends TestCase
+{
+    #[Test]
+    public function invalidStateHasCorrectErrorType(): void
+    {
+        $e = SsoException::invalidState();
+
+        self::assertInstanceOf(RuntimeException::class, $e);
+        self::assertSame('invalid_state', $e->errorType);
+        self::assertStringContainsString('state', $e->getMessage());
+    }
+
+    #[Test]
+    public function invalidNonceHasCorrectErrorType(): void
+    {
+        $e = SsoException::invalidNonce();
+
+        self::assertSame('invalid_nonce', $e->errorType);
+    }
+
+    #[Test]
+    public function invalidIdTokenIncludesReason(): void
+    {
+        $e = SsoException::invalidIdToken('expired');
+
+        self::assertSame('invalid_id_token', $e->errorType);
+        self::assertStringContainsString('expired', $e->getMessage());
+    }
+
+    #[Test]
+    public function unexpectedIdTokenHasCorrectType(): void
+    {
+        self::assertSame('unexpected_id_token', SsoException::unexpectedIdToken()->errorType);
+    }
+
+    #[Test]
+    public function tokenExchangeFailedHasCorrectType(): void
+    {
+        self::assertSame('token_exchange_failed', SsoException::tokenExchangeFailed()->errorType);
+    }
+
+    #[Test]
+    public function providerNotFoundHasCorrectType(): void
+    {
+        self::assertSame('provider_not_found', SsoException::providerNotFound()->errorType);
+    }
+
+    #[Test]
+    public function providerErrorHasCorrectType(): void
+    {
+        self::assertSame('provider_error', SsoException::providerError()->errorType);
+    }
+
+    #[Test]
+    public function missingAuthorizationCodeHasCorrectType(): void
+    {
+        self::assertSame('missing_authorization_code', SsoException::missingAuthorizationCode()->errorType);
+    }
+
+    #[Test]
+    public function extensionDisabledHasCorrectType(): void
+    {
+        self::assertSame('extension_disabled', SsoException::extensionDisabled()->errorType);
+    }
+
+    #[Test]
+    public function pkceRequiredHasCorrectType(): void
+    {
+        self::assertSame('pkce_required', SsoException::pkceRequired()->errorType);
+    }
+
+    #[Test]
+    public function jwksFetchFailedHasCorrectType(): void
+    {
+        self::assertSame('jwks_fetch_failed', SsoException::jwksFetchFailed()->errorType);
+    }
+
+    #[Test]
+    public function signatureVerificationFailedHasCorrectType(): void
+    {
+        self::assertSame('signature_verification_failed', SsoException::signatureVerificationFailed()->errorType);
+    }
+
+    #[Test]
+    public function unsupportedAlgorithmIncludesAlgName(): void
+    {
+        $e = SsoException::unsupportedAlgorithm('HS384');
+
+        self::assertSame('unsupported_algorithm', $e->errorType);
+        self::assertStringContainsString('HS384', $e->getMessage());
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Features/ExchangeCodeHandlerTest.php
+++ b/tests/Unit/Extension/SocialSso/Features/ExchangeCodeHandlerTest.php
@@ -1,0 +1,266 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Features;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\IdTokenVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+use Pulsar\Extension\SocialSso\Features\ExchangeCode\ExchangeCodeHandler;
+use Pulsar\Extension\SocialSso\Features\ExchangeCode\ExchangeCodeRequest;
+
+#[CoversClass(ExchangeCodeHandler::class)]
+final class ExchangeCodeHandlerTest extends TestCase
+{
+    #[Test]
+    public function handleExchangesCodeForTokens(): void
+    {
+        $tokenSet = new OAuthTokenSet(accessToken: 'access-token-123');
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('name')->willReturn('google');
+        $provider->method('exchangeCode')->willReturn($tokenSet);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(true);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+
+        $config = SocialSsoConfig::fromArray([
+            'providers' => [
+                'google' => [
+                    'type' => 'oauth2',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'scopes' => [],
+                ],
+            ],
+        ]);
+
+        $handler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+
+        $result = $handler->handle(new ExchangeCodeRequest(
+            providerName: 'google',
+            code: 'auth-code',
+            state: 'valid-state',
+        ));
+
+        self::assertSame('access-token-123', $result->tokenSet->accessToken);
+        self::assertNull($result->verifiedClaims);
+    }
+
+    #[Test]
+    public function handleThrowsForInvalidState(): void
+    {
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(false);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+
+        $config = SocialSsoConfig::fromArray([
+            'providers' => [
+                'google' => [
+                    'type' => 'oidc',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'scopes' => [],
+                ],
+            ],
+        ]);
+
+        $handler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+
+        $this->expectException(SsoException::class);
+
+        $handler->handle(new ExchangeCodeRequest(
+            providerName: 'google',
+            code: 'auth-code',
+            state: 'invalid-state',
+        ));
+    }
+
+    #[Test]
+    public function handleVerifiesIdTokenWhenPresent(): void
+    {
+        $tokenSet = new OAuthTokenSet(
+            accessToken: 'access-token',
+            idToken: 'fake.id.token',
+        );
+
+        $verifiedClaims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://auth.example.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: 'test-nonce',
+        );
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('exchangeCode')->willReturn($tokenSet);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(true);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $nonceVerifier->method('verify')->willReturn(true);
+
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+        $idTokenVerifier->method('verify')->willReturn($verifiedClaims);
+
+        $config = SocialSsoConfig::fromArray([
+            'require_nonce' => true,
+            'providers' => [
+                'google' => [
+                    'type' => 'oidc',
+                    'client_id' => 'client-id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'jwks_uri' => 'https://auth.example.com/jwks',
+                    'issuer' => 'https://auth.example.com',
+                    'scopes' => ['openid'],
+                ],
+            ],
+        ]);
+
+        $handler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+
+        $result = $handler->handle(new ExchangeCodeRequest(
+            providerName: 'google',
+            code: 'code',
+            state: 'state',
+        ));
+
+        self::assertNotNull($result->verifiedClaims);
+        self::assertSame('user-1', $result->verifiedClaims->sub);
+    }
+
+    #[Test]
+    public function handleRejectsUnexpectedIdTokenOnOauth2Provider(): void
+    {
+        $tokenSet = new OAuthTokenSet(
+            accessToken: 'access-token',
+            idToken: 'unexpected.id.token',
+        );
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('exchangeCode')->willReturn($tokenSet);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(true);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+
+        $config = SocialSsoConfig::fromArray([
+            'providers' => [
+                'github' => [
+                    'type' => 'oauth2',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://github.com/authorize',
+                    'token_url' => 'https://github.com/token',
+                    'scopes' => [],
+                    'allow_unverified_id_token' => false,
+                ],
+            ],
+        ]);
+
+        $handler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+
+        $this->expectException(SsoException::class);
+
+        $handler->handle(new ExchangeCodeRequest(
+            providerName: 'github',
+            code: 'code',
+            state: 'state',
+        ));
+    }
+
+    #[Test]
+    public function handleThrowsForInvalidNonce(): void
+    {
+        $tokenSet = new OAuthTokenSet(
+            accessToken: 'access-token',
+            idToken: 'fake.id.token',
+        );
+
+        $verifiedClaims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://auth.example.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: 'bad-nonce',
+        );
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('exchangeCode')->willReturn($tokenSet);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(true);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $nonceVerifier->method('verify')->willReturn(false);
+
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+        $idTokenVerifier->method('verify')->willReturn($verifiedClaims);
+
+        $config = SocialSsoConfig::fromArray([
+            'require_nonce' => true,
+            'providers' => [
+                'google' => [
+                    'type' => 'oidc',
+                    'client_id' => 'client-id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'jwks_uri' => 'https://auth.example.com/jwks',
+                    'issuer' => 'https://auth.example.com',
+                    'scopes' => ['openid'],
+                ],
+            ],
+        ]);
+
+        $handler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+
+        $this->expectException(SsoException::class);
+
+        $handler->handle(new ExchangeCodeRequest(
+            providerName: 'google',
+            code: 'code',
+            state: 'state',
+        ));
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Features/InitiateLoginHandlerTest.php
+++ b/tests/Unit/Extension/SocialSso/Features/InitiateLoginHandlerTest.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Features;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Features\InitiateLogin\InitiateLoginHandler;
+use Pulsar\Extension\SocialSso\Features\InitiateLogin\InitiateLoginRequest;
+
+#[CoversClass(InitiateLoginHandler::class)]
+final class InitiateLoginHandlerTest extends TestCase
+{
+    #[Test]
+    public function handleGeneratesStatePkceAndAuthorizationUrl(): void
+    {
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('name')->willReturn('google');
+        $provider->method('authorizationUrl')->willReturn('https://auth.example.com/authorize?state=abc');
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('generate')->willReturn('generated-state-123');
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $nonceVerifier->method('generate')->willReturn('generated-nonce-456');
+
+        $config = SocialSsoConfig::fromArray([
+            'enabled' => true,
+            'require_pkce' => true,
+            'require_nonce' => true,
+            'providers' => [
+                'google' => [
+                    'type' => 'oidc',
+                    'client_id' => 'test-id',
+                    'client_secret' => 'test-secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'jwks_uri' => 'https://auth.example.com/jwks',
+                    'issuer' => 'https://auth.example.com',
+                    'scopes' => ['openid', 'email'],
+                ],
+            ],
+        ]);
+
+        $handler = new InitiateLoginHandler($registry, $stateManager, $nonceVerifier, $config);
+
+        $result = $handler->handle(new InitiateLoginRequest(providerName: 'google'));
+
+        self::assertSame('https://auth.example.com/authorize?state=abc', $result->authorizationUrl);
+        self::assertSame('generated-state-123', $result->state);
+        self::assertNotNull($result->pkceChallenge);
+        self::assertSame('S256', $result->pkceChallenge->method);
+    }
+
+    #[Test]
+    public function handleSkipsPkceWhenDisabled(): void
+    {
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('name')->willReturn('github');
+        $provider->method('authorizationUrl')->willReturn('https://github.com/login/oauth/authorize');
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('generate')->willReturn('state-abc');
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+
+        $config = SocialSsoConfig::fromArray([
+            'require_pkce' => false,
+            'require_nonce' => false,
+            'providers' => [
+                'github' => [
+                    'type' => 'oauth2',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://github.com/login/oauth/authorize',
+                    'token_url' => 'https://github.com/login/oauth/access_token',
+                    'scopes' => ['user:email'],
+                ],
+            ],
+        ]);
+
+        $handler = new InitiateLoginHandler($registry, $stateManager, $nonceVerifier, $config);
+
+        $result = $handler->handle(new InitiateLoginRequest(providerName: 'github'));
+
+        self::assertNull($result->pkceChallenge);
+    }
+
+    #[Test]
+    public function handleSkipsNonceForOAuth2Providers(): void
+    {
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('name')->willReturn('github');
+        $provider->method('authorizationUrl')->willReturn('https://github.com/login/oauth/authorize');
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('generate')->willReturn('state-abc');
+
+        $nonceVerifier = $this->createMock(NonceVerifierInterface::class);
+        $nonceVerifier->expects(self::never())->method('generate');
+
+        $config = SocialSsoConfig::fromArray([
+            'require_pkce' => false,
+            'require_nonce' => true, // enabled, but provider is oauth2
+            'providers' => [
+                'github' => [
+                    'type' => 'oauth2',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://github.com/login/oauth/authorize',
+                    'token_url' => 'https://github.com/login/oauth/access_token',
+                    'scopes' => ['user:email'],
+                ],
+            ],
+        ]);
+
+        $handler = new InitiateLoginHandler($registry, $stateManager, $nonceVerifier, $config);
+
+        $handler->handle(new InitiateLoginRequest(providerName: 'github'));
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Features/MapIdentityHandlerTest.php
+++ b/tests/Unit/Extension/SocialSso/Features/MapIdentityHandlerTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Features;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+use Pulsar\Extension\SocialSso\Features\MapIdentity\MapIdentityHandler;
+use Pulsar\Extension\SocialSso\Features\MapIdentity\MapIdentityRequest;
+
+#[CoversClass(MapIdentityHandler::class)]
+final class MapIdentityHandlerTest extends TestCase
+{
+    #[Test]
+    public function handleMapsTokenSetToSocialIdentity(): void
+    {
+        $identity = new SocialIdentity(
+            provider: 'google',
+            providerUserId: 'google-user-123',
+            email: 'user@gmail.com',
+            name: 'Google User',
+        );
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('mapIdentity')->willReturn($identity);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->with('google')->willReturn($provider);
+
+        $handler = new MapIdentityHandler($registry);
+
+        $tokenSet = new OAuthTokenSet(accessToken: 'access-token');
+        $result = $handler->handle(new MapIdentityRequest(tokenSet: $tokenSet, providerName: 'google'));
+
+        self::assertSame('google-user-123', $result->socialIdentity->providerUserId);
+        self::assertSame('user@gmail.com', $result->socialIdentity->email);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Gateway/SsoGatewayTest.php
+++ b/tests/Unit/Extension/SocialSso/Gateway/SsoGatewayTest.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Gateway;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\IdTokenVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Contracts\SocialIdentityLinkerInterface;
+use Pulsar\Extension\SocialSso\Domain\LinkAction;
+use Pulsar\Extension\SocialSso\Domain\LinkedIdentityResult;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+use Pulsar\Extension\SocialSso\Features\ExchangeCode\ExchangeCodeHandler;
+use Pulsar\Extension\SocialSso\Features\MapIdentity\MapIdentityHandler;
+use Pulsar\Extension\SocialSso\Gateway\SsoGateway;
+
+#[CoversClass(SsoGateway::class)]
+final class SsoGatewayTest extends TestCase
+{
+    #[Test]
+    public function fullLoginOrchestratesExchangeMapAndLink(): void
+    {
+        $tokenSet = new OAuthTokenSet(accessToken: 'token-abc');
+        $identity = new SocialIdentity(provider: 'google', providerUserId: '123', email: 'user@gmail.com');
+        $linkResult = new LinkedIdentityResult(linked: true, identityId: 'local-42', action: LinkAction::Linked);
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('exchangeCode')->willReturn($tokenSet);
+        $provider->method('mapIdentity')->willReturn($identity);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(true);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+
+        $config = SocialSsoConfig::fromArray([
+            'providers' => [
+                'google' => [
+                    'type' => 'oauth2',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'scopes' => [],
+                ],
+            ],
+        ]);
+
+        $exchangeHandler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+        $mapHandler = new MapIdentityHandler($registry);
+
+        $linker = $this->createStub(SocialIdentityLinkerInterface::class);
+        $linker->method('link')->willReturn($linkResult);
+
+        $gateway = new SsoGateway($exchangeHandler, $mapHandler, $linker);
+
+        $result = $gateway->fullLogin('google', 'auth-code', 'valid-state');
+
+        self::assertSame('123', $result->socialIdentity->providerUserId);
+        self::assertTrue($result->linkResult->linked);
+        self::assertSame('local-42', $result->linkResult->identityId);
+        self::assertSame(LinkAction::Linked, $result->linkResult->action);
+        self::assertNull($result->verifiedClaims);
+    }
+
+    #[Test]
+    public function fullLoginReturnsUnlinkedResultWhenLinkerRejectsIdentity(): void
+    {
+        $tokenSet = new OAuthTokenSet(accessToken: 'token-abc');
+        $identity = new SocialIdentity(provider: 'google', providerUserId: '456');
+        $linkResult = new LinkedIdentityResult(linked: false, identityId: null, action: LinkAction::Unlinked);
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('exchangeCode')->willReturn($tokenSet);
+        $provider->method('mapIdentity')->willReturn($identity);
+
+        $registry = $this->createStub(OAuthProviderRegistryInterface::class);
+        $registry->method('get')->willReturn($provider);
+
+        $stateManager = $this->createStub(OAuthStateManagerInterface::class);
+        $stateManager->method('verify')->willReturn(true);
+
+        $nonceVerifier = $this->createStub(NonceVerifierInterface::class);
+        $idTokenVerifier = $this->createStub(IdTokenVerifierInterface::class);
+
+        $config = SocialSsoConfig::fromArray([
+            'providers' => [
+                'google' => [
+                    'type' => 'oauth2',
+                    'client_id' => 'id',
+                    'client_secret' => 'secret',
+                    'authorization_url' => 'https://auth.example.com/authorize',
+                    'token_url' => 'https://auth.example.com/token',
+                    'scopes' => [],
+                ],
+            ],
+        ]);
+
+        $exchangeHandler = new ExchangeCodeHandler($registry, $stateManager, $nonceVerifier, $idTokenVerifier, $config);
+        $mapHandler = new MapIdentityHandler($registry);
+
+        $linker = $this->createStub(SocialIdentityLinkerInterface::class);
+        $linker->method('link')->willReturn($linkResult);
+
+        $gateway = new SsoGateway($exchangeHandler, $mapHandler, $linker);
+
+        $result = $gateway->fullLogin('google', 'code', 'state');
+
+        self::assertFalse($result->linkResult->linked);
+        self::assertSame(LinkAction::Unlinked, $result->linkResult->action);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Internal/Linker/NullSocialIdentityLinkerTest.php
+++ b/tests/Unit/Extension/SocialSso/Internal/Linker/NullSocialIdentityLinkerTest.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Internal\Linker;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\LinkAction;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+use Pulsar\Extension\SocialSso\Internal\Linker\NullSocialIdentityLinker;
+
+#[CoversClass(NullSocialIdentityLinker::class)]
+final class NullSocialIdentityLinkerTest extends TestCase
+{
+    #[Test]
+    public function alwaysReturnsUnlinked(): void
+    {
+        $linker = new NullSocialIdentityLinker();
+
+        $identity = new SocialIdentity(provider: 'google', providerUserId: '123');
+        $result = $linker->link($identity);
+
+        self::assertFalse($result->linked);
+        self::assertNull($result->identityId);
+        self::assertSame(LinkAction::Unlinked, $result->action);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Internal/Provider/LocalMockProviderTest.php
+++ b/tests/Unit/Extension/SocialSso/Internal/Provider/LocalMockProviderTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Internal\Provider;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\OAuthRequest;
+use Pulsar\Extension\SocialSso\Domain\OAuthTokenSet;
+use Pulsar\Extension\SocialSso\Domain\SocialIdentity;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+use Pulsar\Extension\SocialSso\Internal\Provider\LocalMockProvider;
+
+#[CoversClass(LocalMockProvider::class)]
+final class LocalMockProviderTest extends TestCase
+{
+    #[Test]
+    public function nameReturnsConfiguredName(): void
+    {
+        $provider = new LocalMockProvider('test-provider');
+
+        self::assertSame('test-provider', $provider->name());
+    }
+
+    #[Test]
+    public function nameDefaultsToMock(): void
+    {
+        $provider = new LocalMockProvider();
+
+        self::assertSame('mock', $provider->name());
+    }
+
+    #[Test]
+    public function authorizationUrlContainsAllParameters(): void
+    {
+        $provider = new LocalMockProvider();
+
+        $request = new OAuthRequest(
+            redirectUri: 'https://app.local/callback',
+            scopes: ['openid', 'email'],
+            state: 'test-state',
+            nonce: 'test-nonce',
+            codeChallenge: 'test-challenge',
+        );
+
+        $url = $provider->authorizationUrl($request);
+
+        self::assertStringContainsString('https://mock.local/authorize?', $url);
+        self::assertStringContainsString('state=test-state', $url);
+        self::assertStringContainsString('nonce=test-nonce', $url);
+        self::assertStringContainsString('code_challenge=test-challenge', $url);
+        self::assertStringContainsString('code_challenge_method=S256', $url);
+    }
+
+    #[Test]
+    public function exchangeCodeReturnsPreConfiguredTokens(): void
+    {
+        $provider = new LocalMockProvider();
+
+        $tokenSet = new OAuthTokenSet(accessToken: 'mock-access-token');
+        $provider->setTokenForCode('auth-code-123', $tokenSet);
+
+        $result = $provider->exchangeCode('auth-code-123', 'https://app.local/callback');
+
+        self::assertSame('mock-access-token', $result->accessToken);
+    }
+
+    #[Test]
+    public function exchangeCodeThrowsForUnknownCode(): void
+    {
+        $provider = new LocalMockProvider();
+
+        $this->expectException(SsoException::class);
+
+        $provider->exchangeCode('unknown-code', 'https://app.local/callback');
+    }
+
+    #[Test]
+    public function mapIdentityReturnsPreConfiguredIdentity(): void
+    {
+        $provider = new LocalMockProvider();
+
+        $tokenSet = new OAuthTokenSet(accessToken: 'access-123');
+        $identity = new SocialIdentity(provider: 'mock', providerUserId: 'custom-id', email: 'custom@test.com');
+
+        $provider->setTokenForCode('code-1', $tokenSet);
+        $provider->setIdentityForCode('code-1', $identity);
+
+        $result = $provider->mapIdentity($tokenSet);
+
+        self::assertSame('custom-id', $result->providerUserId);
+        self::assertSame('custom@test.com', $result->email);
+    }
+
+    #[Test]
+    public function mapIdentityReturnsFallbackForUnmappedToken(): void
+    {
+        $provider = new LocalMockProvider();
+
+        $tokenSet = new OAuthTokenSet(accessToken: 'some-token');
+
+        $result = $provider->mapIdentity($tokenSet);
+
+        self::assertSame('mock', $result->provider);
+        self::assertStringStartsWith('mock-user-', $result->providerUserId);
+        self::assertSame('mock@example.com', $result->email);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Internal/Provider/OAuthProviderRegistryTest.php
+++ b/tests/Unit/Extension/SocialSso/Internal/Provider/OAuthProviderRegistryTest.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Internal\Provider;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderInterface;
+use Pulsar\Extension\SocialSso\Exception\SsoException;
+use Pulsar\Extension\SocialSso\Internal\Provider\OAuthProviderRegistry;
+
+#[CoversClass(OAuthProviderRegistry::class)]
+final class OAuthProviderRegistryTest extends TestCase
+{
+    #[Test]
+    public function registerAndGetProvider(): void
+    {
+        $registry = new OAuthProviderRegistry();
+
+        $provider = $this->createStub(OAuthProviderInterface::class);
+        $provider->method('name')->willReturn('google');
+
+        $registry->register($provider);
+
+        self::assertSame($provider, $registry->get('google'));
+    }
+
+    #[Test]
+    public function getThrowsForUnregisteredProvider(): void
+    {
+        $registry = new OAuthProviderRegistry();
+
+        $this->expectException(SsoException::class);
+
+        $registry->get('nonexistent');
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Internal/Session/SessionNonceVerifierTest.php
+++ b/tests/Unit/Extension/SocialSso/Internal/Session/SessionNonceVerifierTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Internal\Session;
+
+use function array_key_exists;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Domain\IdTokenClaims;
+use Pulsar\Extension\SocialSso\Internal\Session\SessionNonceVerifier;
+use Pulsar\Security\Session\SessionInterface;
+
+use function strlen;
+
+#[CoversClass(SessionNonceVerifier::class)]
+final class SessionNonceVerifierTest extends TestCase
+{
+    private SessionInterface $session;
+
+    protected function setUp(): void
+    {
+        $this->session = $this->createArraySession();
+    }
+
+    #[Test]
+    public function generateReturnsHexString(): void
+    {
+        $verifier = new SessionNonceVerifier($this->session);
+
+        $nonce = $verifier->generate();
+
+        self::assertSame(64, strlen($nonce));
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $nonce);
+    }
+
+    #[Test]
+    public function verifyReturnsTrueForMatchingNonce(): void
+    {
+        $verifier = new SessionNonceVerifier($this->session);
+
+        $nonce = $verifier->generate();
+
+        $claims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://issuer.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: $nonce,
+        );
+
+        self::assertTrue($verifier->verify($nonce, $claims));
+    }
+
+    #[Test]
+    public function verifyConsumesNonceOnFirstUse(): void
+    {
+        $verifier = new SessionNonceVerifier($this->session);
+
+        $nonce = $verifier->generate();
+
+        $claims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://issuer.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: $nonce,
+        );
+
+        self::assertTrue($verifier->verify($nonce, $claims));
+        self::assertFalse($verifier->verify($nonce, $claims));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForMismatchedNonce(): void
+    {
+        $verifier = new SessionNonceVerifier($this->session);
+
+        $nonce = $verifier->generate();
+
+        $claims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://issuer.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: 'wrong-nonce-value',
+        );
+
+        self::assertFalse($verifier->verify($nonce, $claims));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseWhenClaimsHaveNullNonce(): void
+    {
+        $verifier = new SessionNonceVerifier($this->session);
+
+        $nonce = $verifier->generate();
+
+        $claims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://issuer.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: null,
+        );
+
+        self::assertFalse($verifier->verify($nonce, $claims));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForUnknownNonce(): void
+    {
+        $verifier = new SessionNonceVerifier($this->session);
+
+        $claims = new IdTokenClaims(
+            sub: 'user-1',
+            iss: 'https://issuer.com',
+            aud: 'client-id',
+            exp: 9999999999,
+            iat: 1000000000,
+            nonce: 'never-generated-nonce',
+        );
+
+        self::assertFalse($verifier->verify('never-generated-nonce', $claims));
+    }
+
+    private function createArraySession(): SessionInterface
+    {
+        return new class implements SessionInterface {
+            /** @var array<string, mixed> */
+            private array $data = [];
+
+            public function start(): void {}
+
+            public function isStarted(): bool
+            {
+                return true;
+            }
+
+            public function get(string $key, mixed $default = null): mixed
+            {
+                return $this->data[$key] ?? $default;
+            }
+
+            public function set(string $key, mixed $value): void
+            {
+                $this->data[$key] = $value;
+            }
+
+            public function has(string $key): bool
+            {
+                return array_key_exists($key, $this->data);
+            }
+
+            public function remove(string $key): void
+            {
+                unset($this->data[$key]);
+            }
+
+            public function id(): string
+            {
+                return 'test-session-id';
+            }
+
+            public function regenerate(bool $deleteOldSession = true): void {}
+
+            public function destroy(): void
+            {
+                $this->data = [];
+            }
+
+            /** @return array<string, mixed> */
+            public function all(): array
+            {
+                return $this->data;
+            }
+        };
+    }
+}

--- a/tests/Unit/Extension/SocialSso/Internal/Session/SessionOAuthStateManagerTest.php
+++ b/tests/Unit/Extension/SocialSso/Internal/Session/SessionOAuthStateManagerTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso\Internal\Session;
+
+use function array_key_exists;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\SocialSso\Internal\Session\SessionOAuthStateManager;
+use Pulsar\Security\Session\SessionInterface;
+
+use function strlen;
+
+#[CoversClass(SessionOAuthStateManager::class)]
+final class SessionOAuthStateManagerTest extends TestCase
+{
+    private SessionInterface $session;
+
+    protected function setUp(): void
+    {
+        $this->session = $this->createArraySession();
+    }
+
+    #[Test]
+    public function generateReturnsHexString(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        $state = $manager->generate();
+
+        self::assertSame(64, strlen($state)); // 32 bytes = 64 hex chars
+        self::assertMatchesRegularExpression('/^[0-9a-f]{64}$/', $state);
+    }
+
+    #[Test]
+    public function verifyReturnsTrueForValidState(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        $state = $manager->generate();
+
+        self::assertTrue($manager->verify($state));
+    }
+
+    #[Test]
+    public function verifyConsumesStateOnFirstUse(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        $state = $manager->generate();
+        self::assertTrue($manager->verify($state));
+
+        // Second use should fail — consumed
+        self::assertFalse($manager->verify($state));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForInvalidState(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        self::assertFalse($manager->verify('nonexistent-state-value'));
+    }
+
+    #[Test]
+    public function verifyReturnsFalseForExpiredState(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session, ttlSeconds: 0);
+
+        $state = $manager->generate();
+
+        // Sleep 1 second to ensure expiry (TTL=0 means immediate expiry)
+        sleep(1);
+
+        self::assertFalse($manager->verify($state));
+    }
+
+    #[Test]
+    public function storePkceVerifierAndRetrieve(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        $state = $manager->generate();
+        $manager->storePkceVerifier($state, 'my-pkce-verifier-abc');
+
+        $retrieved = $manager->retrievePkceVerifier($state);
+
+        self::assertSame('my-pkce-verifier-abc', $retrieved);
+    }
+
+    #[Test]
+    public function retrievePkceVerifierConsumesOnFirstRead(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        $state = $manager->generate();
+        $manager->storePkceVerifier($state, 'verifier-xyz');
+
+        self::assertSame('verifier-xyz', $manager->retrievePkceVerifier($state));
+        self::assertNull($manager->retrievePkceVerifier($state));
+    }
+
+    #[Test]
+    public function retrievePkceVerifierReturnsNullForUnknownState(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        self::assertNull($manager->retrievePkceVerifier('unknown-state'));
+    }
+
+    #[Test]
+    public function pkceVerifierIsolatedByState(): void
+    {
+        $manager = new SessionOAuthStateManager($this->session);
+
+        $stateA = $manager->generate();
+        $stateB = $manager->generate();
+
+        $manager->storePkceVerifier($stateA, 'verifier-A');
+        $manager->storePkceVerifier($stateB, 'verifier-B');
+
+        self::assertSame('verifier-A', $manager->retrievePkceVerifier($stateA));
+        self::assertSame('verifier-B', $manager->retrievePkceVerifier($stateB));
+    }
+
+    /**
+     * Create an in-memory session implementation backed by a simple array.
+     */
+    private function createArraySession(): SessionInterface
+    {
+        return new class implements SessionInterface {
+            /** @var array<string, mixed> */
+            private array $data = [];
+
+            public function start(): void {}
+
+            public function isStarted(): bool
+            {
+                return true;
+            }
+
+            public function get(string $key, mixed $default = null): mixed
+            {
+                return $this->data[$key] ?? $default;
+            }
+
+            public function set(string $key, mixed $value): void
+            {
+                $this->data[$key] = $value;
+            }
+
+            public function has(string $key): bool
+            {
+                return array_key_exists($key, $this->data);
+            }
+
+            public function remove(string $key): void
+            {
+                unset($this->data[$key]);
+            }
+
+            public function id(): string
+            {
+                return 'test-session-id';
+            }
+
+            public function regenerate(bool $deleteOldSession = true): void {}
+
+            public function destroy(): void
+            {
+                $this->data = [];
+            }
+
+            /** @return array<string, mixed> */
+            public function all(): array
+            {
+                return $this->data;
+            }
+        };
+    }
+}

--- a/tests/Unit/Extension/SocialSso/SocialSsoExtensionTest.php
+++ b/tests/Unit/Extension/SocialSso/SocialSsoExtensionTest.php
@@ -1,0 +1,61 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Container\Container;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\SocialSsoExtension;
+use Pulsar\Extension\SocialSso\SocialSsoServiceProvider;
+use Pulsar\Routing\Router;
+
+#[CoversClass(SocialSsoExtension::class)]
+final class SocialSsoExtensionTest extends TestCase
+{
+    #[Test]
+    public function nameReturnsPulsarSocialSso(): void
+    {
+        $extension = new SocialSsoExtension();
+
+        self::assertSame('pulsar/social-sso', $extension->name());
+    }
+
+    #[Test]
+    public function registerIsNoOp(): void
+    {
+        $extension = new SocialSsoExtension();
+        $container = new Container();
+
+        $extension->register($container);
+
+        self::assertSame([], $container->getBindings());
+    }
+
+    #[Test]
+    public function providersReturnsServiceProviderClass(): void
+    {
+        $extension = new SocialSsoExtension();
+
+        self::assertSame([SocialSsoServiceProvider::class], $extension->providers());
+    }
+
+    #[Test]
+    public function bootSkipsWhenDisabled(): void
+    {
+        $extension = new SocialSsoExtension();
+        $container = new Container();
+        $router = new Router();
+
+        $config = SocialSsoConfig::fromArray(['enabled' => false]);
+        $container->instance(SocialSsoConfig::class, $config);
+
+        $extension->boot($container, $router);
+
+        // No routes should have been registered
+        self::assertEmpty($router->routes);
+    }
+}

--- a/tests/Unit/Extension/SocialSso/SocialSsoServiceProviderTest.php
+++ b/tests/Unit/Extension/SocialSso/SocialSsoServiceProviderTest.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\SocialSso;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Container\Container;
+use Pulsar\Extension\SocialSso\Config\SocialSsoConfig;
+use Pulsar\Extension\SocialSso\Contracts\IdTokenVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\JwtSignatureDriverInterface;
+use Pulsar\Extension\SocialSso\Contracts\NonceVerifierInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthProviderRegistryInterface;
+use Pulsar\Extension\SocialSso\Contracts\OAuthStateManagerInterface;
+use Pulsar\Extension\SocialSso\Contracts\SocialIdentityLinkerInterface;
+use Pulsar\Extension\SocialSso\Contracts\SsoGatewayInterface;
+use Pulsar\Extension\SocialSso\Gateway\SsoGateway;
+use Pulsar\Extension\SocialSso\Internal\Token\JwksFetcher;
+use Pulsar\Extension\SocialSso\SocialSsoServiceProvider;
+
+#[CoversClass(SocialSsoServiceProvider::class)]
+final class SocialSsoServiceProviderTest extends TestCase
+{
+    #[Test]
+    public function registerBindsAllServices(): void
+    {
+        $provider = new SocialSsoServiceProvider();
+        $container = new Container();
+
+        $provider->register($container);
+
+        self::assertTrue($container->has(SocialSsoConfig::class));
+        self::assertTrue($container->has(OAuthProviderRegistryInterface::class));
+        self::assertTrue($container->has(JwtSignatureDriverInterface::class));
+        self::assertTrue($container->has(JwksFetcher::class));
+        self::assertTrue($container->has(IdTokenVerifierInterface::class));
+        self::assertTrue($container->has(SocialIdentityLinkerInterface::class));
+        self::assertTrue($container->has(SsoGateway::class));
+        self::assertTrue($container->has(SsoGatewayInterface::class));
+    }
+
+    #[Test]
+    public function providesReturnsAllBoundClasses(): void
+    {
+        $provider = new SocialSsoServiceProvider();
+
+        $provides = $provider->provides();
+
+        self::assertContains(SocialSsoConfig::class, $provides);
+        self::assertContains(OAuthProviderRegistryInterface::class, $provides);
+        self::assertContains(OAuthStateManagerInterface::class, $provides);
+        self::assertContains(NonceVerifierInterface::class, $provides);
+        self::assertContains(JwtSignatureDriverInterface::class, $provides);
+        self::assertContains(JwksFetcher::class, $provides);
+        self::assertContains(IdTokenVerifierInterface::class, $provides);
+        self::assertContains(SocialIdentityLinkerInterface::class, $provides);
+        self::assertContains(SsoGateway::class, $provides);
+        self::assertContains(SsoGatewayInterface::class, $provides);
+    }
+}

--- a/tools/api/public-api.snapshot.json
+++ b/tools/api/public-api.snapshot.json
@@ -95,12 +95,72 @@
       "methods": [],
       "constants": []
     },
+    "Pulsar\\Auth\\TwoFactor\\AuthEventCollectorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\Confirm2faSetupResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\ConsumeReason": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\ConsumeResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeRotationResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeSet": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeStoreInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
     "Pulsar\\Auth\\TwoFactor\\TotpReplayGuardInterface": {
       "since": "1.0.0",
       "methods": [],
       "constants": []
     },
+    "Pulsar\\Auth\\TwoFactor\\TotpSecretStoreInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
     "Pulsar\\Auth\\TwoFactor\\TwoFactorManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TwoFactorPurpose": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TwoFactorRateLimiterInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\Verify2faResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\VerifyReason": {
       "since": "1.0.0",
       "methods": [],
       "constants": []
@@ -1365,6 +1425,11 @@
       "methods": [],
       "constants": []
     },
+    "Pulsar\\Security\\Crypto\\Hmac": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
     "Pulsar\\Security\\Crypto\\HmacInterface": {
       "since": "1.0.0",
       "methods": [],
@@ -1607,7 +1672,10 @@
     }
   },
   "internal_classes": [
+    "Pulsar\\Auth\\TwoFactor\\InMemoryRecoveryCodeStore",
     "Pulsar\\Auth\\TwoFactor\\InMemoryTotpReplayGuard",
+    "Pulsar\\Auth\\TwoFactor\\InMemoryTotpSecretStore",
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeHasher",
     "Pulsar\\Auth\\TwoFactor\\SqliteTotpReplayGuard",
     "Pulsar\\Cache\\CacheAllowedClasses",
     "Pulsar\\Cache\\CacheIntegrity",

--- a/tools/php/deptrac.yaml
+++ b/tools/php/deptrac.yaml
@@ -607,6 +607,37 @@ deptrac:
         - type: classLike
           value: ^Pulsar\\Extension\\ObservabilityExport\\
 
+    # --- Social SSO Extension (Pulsar\\Extension\\Social-sso → SocialSso) ---
+
+    # --- Social SSO: public contracts ---
+    - name: SocialSsoContracts
+      collectors:
+        - type: classLike
+          value: ^Pulsar\\Extension\\SocialSso\\Contracts\\
+
+    # --- Social SSO: domain types (value objects, enums, exceptions, config) ---
+    - name: SocialSsoDomain
+      collectors:
+        - type: classLike
+          value: ^Pulsar\\Extension\\SocialSso\\Domain\\
+        - type: classLike
+          value: ^Pulsar\\Extension\\SocialSso\\Exception\\
+        - type: classLike
+          value: ^Pulsar\\Extension\\SocialSso\\Config\\
+
+    # --- Social SSO: internal implementation ---
+    - name: SocialSsoInternal
+      collectors:
+        - type: bool
+          must:
+            - type: classLike
+              value: ^Pulsar\\Extension\\SocialSso\\
+          must_not:
+            - type: layer
+              value: SocialSsoContracts
+            - type: layer
+              value: SocialSsoDomain
+
     # --- Example Extension ---
     - name: ExampleExtension
       collectors:
@@ -883,6 +914,79 @@ deptrac:
       - Webhook
       - PaymentsContracts
       - PaymentsDomain
+
+    SocialSsoContracts:
+      - CompositionRoot
+      - Api
+      - Support
+      - Container
+      - Config
+      - Core
+      - ErrorHandling
+      - Http
+      - Routing
+      - Console
+      - Extensibility
+      - Audit
+      - Auth
+      - Cache
+      - Context
+      - Database
+      - DataProtection
+      - Deploy
+      - Event
+      - FeatureFlag
+      - Idempotency
+      - Integrity
+      - Observability
+      - Queue
+      - Resilience
+      - Runtime
+      - Scheduler
+      - Security
+      - Storage
+      - Supervisor
+      - Tenancy
+      - Webhook
+      - SocialSsoDomain
+
+    SocialSsoDomain: *public_deps
+
+    SocialSsoInternal:
+      - CompositionRoot
+      - Api
+      - Support
+      - Container
+      - Config
+      - Core
+      - ErrorHandling
+      - Http
+      - Routing
+      - Console
+      - Extensibility
+      - Audit
+      - Auth
+      - Cache
+      - Context
+      - Database
+      - DataProtection
+      - Deploy
+      - Event
+      - FeatureFlag
+      - Idempotency
+      - Integrity
+      - Observability
+      - Queue
+      - Resilience
+      - Runtime
+      - Scheduler
+      - Security
+      - Storage
+      - Supervisor
+      - Tenancy
+      - Webhook
+      - SocialSsoContracts
+      - SocialSsoDomain
 
     ObservabilityExportExtension: *public_deps
     Psr7BridgeExtension: *public_deps

--- a/tools/php/phpunit.xml
+++ b/tools/php/phpunit.xml
@@ -26,6 +26,7 @@
             <directory>../../extensions/psr7-bridge/src</directory>
             <directory>../../extensions/studio/src</directory>
             <directory>../../extensions/observability-export/src</directory>
+            <directory>../../extensions/social-sso/src</directory>
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
## Summary

- **Core Introspection Module** (`src/Introspection/`): Public snapshot model + orchestrator with internal runtime crawling. Extensions contribute metadata via `MetadataContributorInterface` with hard per-contributor resource limits (64 sections, 8 depth, 256KB). Three-layer sanitization pipeline (contribution → generation → export). CLI `metadata:export` command with `--section` and `--pretty` options.
- **MCP Server Extension** (`extensions/mcp-server/`): JSON-RPC 2.0 over stdio (protocol version `2025-11-25`). 6 read tools returning `structuredContent` + text fallback, 3 action tools with subprocess execution (no shell, array commands). Full security stack: environment gating, per-tool allowlists, path validation with realpath + symlink-safe checks, rate limiting, concurrency cap, strict param validation, value-based redaction, and audit trail.
- **Documentation**: ADR-0017 introspection layer rationale. `docs/AI_TOOLING.md` threat model, safe enablement guide, dev-only posture, incident response.
- **Architecture tooling**: Updated deptrac layers, boundary baselines, and regenerated API snapshot for new modules.

## Test plan

- [x] `composer qa` passes (PHPStan 0, Psalm 0, 4930 tests / 0 failures)
- [x] `pnpm format:check` passes
- [x] `php bin/pulsar metadata:export --pretty` outputs valid JSON with no secrets or absolute paths
- [x] MCP stdio round-trip: `initialize` → `ping` → `tools/list` → `tools/call` (read + action)
- [x] Verify `structuredContent` in all tool responses
- [x] Verify audit entries logged for MCP tool calls
- [x] Verify param validation rejects malicious inputs (path traversal, invalid client_id, oversized filter)
- [x] Verify environment gating blocks staging/production without confirmation env vars

## Linked Issues
Resolves #96
Resolves #103
Resolves #168
