### PR TITLE
feat(ext): add MCP server extension + project metadata introspection layer

### DIFF
--- a/bin/pulsar
+++ b/bin/pulsar
@@ -40,6 +40,7 @@ use Pulsar\Config\SupervisorConfig;
 use Pulsar\Console\Application;
 use Pulsar\Console\Command\DeployCheckCommand;
 use Pulsar\Console\Command\DiagnosticsCommand;
+use Pulsar\Console\Command\MetadataExportCommand;
 use Pulsar\Console\Command\InitCommand;
 use Pulsar\Console\Command\KeyGenerateCommand;
 use Pulsar\Console\Command\KeyRotateCommand;
@@ -100,6 +101,8 @@ use Pulsar\Integrity\ManifestVerifierInterface;
 use Pulsar\Queue\DeadLetterQueue;
 use Pulsar\Queue\QueueDriverInterface;
 use Pulsar\Queue\QueueManager;
+use Pulsar\Introspection\ProjectMetadataService;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
 use Pulsar\Security\Audit\AuditLogger;
 use Pulsar\Security\Crypto\HmacInterface;
 use Pulsar\Security\Crypto\HmacService;
@@ -250,6 +253,17 @@ $application->addCommands([
     new KeyGenerateCommand($basePath),
     new KeyRotateCommand($basePath),
 ]);
+
+// Register metadata export command (if introspection is enabled)
+if ($kernel->container()->has(ProjectMetadataService::class)) {
+    /** @var ProjectMetadataService $metadataService */
+    $metadataService = $kernel->container()->get(ProjectMetadataService::class);
+    $scrubber = $kernel->container()->has(SensitiveDataScrubber::class)
+        ? $kernel->container()->get(SensitiveDataScrubber::class)
+        : new SensitiveDataScrubber();
+    /** @var SensitiveDataScrubber $scrubber */
+    $application->add(new MetadataExportCommand($metadataService, $scrubber));
+}
 
 // Register queue commands (only if queue is configured)
 if ($kernel->container()->has(QueueConfig::class)) {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,8 @@
       "Pulsar\\Extension\\Psr7Bridge\\": "extensions/psr7-bridge/src/",
       "Pulsar\\Extension\\ObservabilityExport\\": "extensions/observability-export/src/",
       "Pulsar\\Extension\\SocialSso\\": "extensions/social-sso/src/",
-      "Pulsar\\Extension\\Studio\\": "extensions/studio/src/"
+      "Pulsar\\Extension\\Studio\\": "extensions/studio/src/",
+      "Pulsar\\Extension\\McpServer\\": "extensions/mcp-server/src/"
     }
   },
   "autoload-dev": {

--- a/config/introspection.php
+++ b/config/introspection.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'enabled' => true,
+];

--- a/config/queue.php
+++ b/config/queue.php
@@ -53,7 +53,7 @@ return [
     */
     'worker' => [
         'max_jobs' => 1000,
-        'max_memory_mb' => 128,
+        'max_memory_mb' => 256,
         'time_limit_seconds' => 3600,
         'sleep_ms' => 1000,
     ],

--- a/docs/AI_TOOLING.md
+++ b/docs/AI_TOOLING.md
@@ -1,0 +1,323 @@
+# AI Tooling — MCP Server Extension
+
+## Overview
+
+Pulsar ships an optional MCP (Model Context Protocol) server extension that exposes framework metadata and developer tools to AI assistants over the JSON-RPC 2.0 stdio transport.
+
+**Intended audience**: Developers using AI-assisted IDEs (Claude Code, Cursor, Windsurf) who want their AI agent to understand the Pulsar project structure — routes, bindings, config schemas, commands, and the public API surface — without manually copying context.
+
+**Design philosophy**: Read-heavy, action-cautious. Read tools are always available (individually disablable). Action tools (run tests, run formatter, run static analysis) require explicit allowlisting. The server is disabled by default and intended for local development only.
+
+## Threat Model
+
+### 1. Prompt Injection via Tool Output
+
+**Risk**: A malicious or compromised dependency could inject prompt-manipulating text into tool output (e.g., route names, command descriptions, config property names).
+
+**Mitigations**:
+
+- All tool output passes through `McpRedactionPipeline` which scrubs sensitive patterns
+- Structured content (`structuredContent`) is preferred over free-text — AI clients consume typed fields rather than parsing prose
+- Output size is capped per tool (`max_output_bytes`, default 1 MB) preventing context flooding
+- Route handlers are formatted as `Class::method` — no raw file paths or closure source
+
+### 2. Secret Exfiltration
+
+**Risk**: Tool output could inadvertently contain secrets (env var values, database passwords, API keys).
+
+**Mitigations**:
+
+- Three-layer sanitization: contributor limits → `SensitiveDataScrubber` at generation → `McpRedactionPipeline` at export
+- Container bindings filtered to FQCN-like keys only — service locator keys like `db.password` excluded
+- Config schema exposes property names and types only — never instantiated values
+- Subprocess output (tests, formatter, analysis) redacted in real-time with streaming pattern matching
+- Value-based redaction collects high-risk env var values (`*_KEY`, `*_TOKEN`, `*_SECRET`, `*_PASSWORD`, `*_DSN`) at boot and replaces exact matches in stdout/stderr
+- No absolute file paths in any output
+
+### 3. Unauthorized Code Execution
+
+**Risk**: An AI agent could use action tools to execute arbitrary commands or modify files.
+
+**Mitigations**:
+
+- Action tools are disabled by default — require explicit allowlisting in `tools.allowed_actions`
+- All subprocess commands use `proc_open()` with array command (no shell invocation)
+- Parameters are strictly validated: `--filter` allows only `[A-Za-z0-9_:.\\\-]`, `--path` rejects `..` and validates with `realpath()` + root confinement
+- Binary paths resolved at boot via `realpath()` and verified against expected directories
+- Working directory locked to project root
+- Subprocess environment forces non-interactive mode (`--no-interaction --no-ansi`, `CI=1`)
+- Hard timeout per action (configurable, default 120s)
+
+### 4. Denial of Service via Action Tools
+
+**Risk**: Repeated or concurrent action tool calls could overwhelm the local machine.
+
+**Mitigations**:
+
+- Concurrency cap: max 1 concurrent action tool (configurable `max_concurrent_actions`)
+- Rate limiting: default 60 requests/minute per tool, with per-tool overrides
+- Action timeout: subprocess killed after deadline
+- Output cap: stdout/stderr truncated at `max_output_bytes`
+
+## Enabling Safely
+
+### Step 1: Create Config File
+
+```php
+// config/mcp.php
+return [
+    'enabled' => true,
+    'client_id' => 'my-editor',
+    'tools' => [
+        'disabled_read_tools' => [],
+        'allowed_actions' => ['pulsar.tests.run', 'pulsar.formatter.run', 'pulsar.analysis.run'],
+        'max_output_bytes' => 1_048_576,
+        'action_timeout' => 120,
+        'commands' => [
+            'phpunit' => null,   // auto-resolve from PATH
+            'composer' => null,
+            'pnpm' => null,
+        ],
+    ],
+    'security' => [
+        'path_allowlist' => ['src/**', 'tests/**', 'extensions/**', 'config/**', 'docs/**'],
+        'rate_limit_per_minute' => 60,
+        'tool_rate_limits' => [],
+        'max_concurrent_actions' => 1,
+    ],
+];
+```
+
+### Step 2: Set Environment Variable
+
+```bash
+export MCP_ENABLED=true
+```
+
+### Step 3: Start the Server
+
+```bash
+php bin/pulsar mcp:serve
+```
+
+The server reads from stdin and writes to stdout using newline-delimited JSON (JSON-RPC 2.0). Configure your AI client to launch this command as an MCP server.
+
+### Step 4: Verify
+
+Send an initialize request:
+
+```json
+{ "jsonrpc": "2.0", "id": 1, "method": "initialize", "params": { "protocolVersion": "2025-11-25" } }
+```
+
+Expected response includes `serverInfo.name: "pulsar-mcp"` and the negotiated protocol version.
+
+## Security Architecture
+
+### Environment Gating
+
+| Environment | Requirements                     |
+| ----------- | -------------------------------- |
+| Local       | `MCP_ENABLED=true` + config file |
+| Staging     | + `MCP_STAGING_CONFIRM=true`     |
+| Production  | + `MCP_PRODUCTION_CONFIRM=true`  |
+
+### Permission Model
+
+1. **Read tools**: Always allowed unless individually disabled via `disabled_read_tools`
+2. **Action tools**: Require explicit listing in `tools.allowed_actions`
+3. **Path validation**: All `--path` parameters validated with `realpath()` + root confinement + glob allowlist
+
+### Rate Limiting
+
+- Global default: 60 requests/minute per tool
+- Per-tool overrides via `security.tool_rate_limits`
+- Uses framework `RateLimiterInterface` with key format `mcp:tool:{name}`
+
+### Concurrency Control
+
+- Maximum 1 concurrent action tool execution (configurable)
+- Excess requests rejected with structured error response
+
+### Parameter Validation
+
+| Parameter   | Validation                                           |
+| ----------- | ---------------------------------------------------- |
+| `client_id` | `[A-Za-z0-9_-]{1,64}`                                |
+| `--filter`  | Max 256 chars, `[A-Za-z0-9_:.\\\-]` only             |
+| `--path`    | No `..`, realpath + root confinement, glob allowlist |
+| `type`      | Enum: `php` or `js`                                  |
+| `analyzer`  | Enum: `phpstan` or `psalm`                           |
+
+### Redaction Pipeline
+
+Composes `SensitiveDataScrubber` with MCP-specific patterns:
+
+- Env var values (`PULSAR_MASTER_KEY=...`, `DB_PASSWORD=...`)
+- Connection strings (`://user:pass@host`)
+- Bearer tokens in command output
+- Value-based redaction of known secret env var values
+- Truncation-safe: patterns redact `key=` until line end even if value is split at cap boundary
+
+## Dev-Only Posture
+
+The MCP server is designed for local development. Production and staging environments require explicit confirmation environment variables as a safety net against accidental enablement.
+
+**Why production stays disabled**:
+
+- Introspection exposes internal architecture details (bindings, routes, config schemas)
+- Action tools execute subprocesses on the host
+- The stdio transport has no authentication layer — security relies on process-level access control
+- In production, the framework should serve requests, not expose diagnostic tooling
+
+**Exception flow for staging/production**:
+
+1. Set `MCP_ENABLED=true` in config
+2. Set `MCP_STAGING_CONFIRM=true` or `MCP_PRODUCTION_CONFIRM=true`
+3. Both must be present — config alone is insufficient
+4. All MCP activity is audit-logged regardless of environment
+
+## Audit and Monitoring
+
+### Audit Trail
+
+Every `tools/call` invocation is logged via `AuditLoggerInterface`:
+
+| Scenario            | AuditEvent    | AuditOutcome |
+| ------------------- | ------------- | ------------ |
+| Read tool success   | DataAccess    | Success      |
+| Action tool success | SystemEvent   | Success      |
+| Permission denied   | Authorization | Denied       |
+| Rate limited        | SecurityEvent | Denied       |
+| Concurrency limited | SecurityEvent | Denied       |
+| Tool error          | SystemEvent   | Error        |
+| Tool cancelled      | SystemEvent   | Failure      |
+
+**Metadata fields**: `tool`, `category`, `params` (redacted), `duration_ms`, `output_bytes`, `client_id`
+
+**Actor format**: `mcp:{clientId}`
+
+### Reviewing Activity
+
+If Studio is enabled, MCP audit entries appear in the Studio dashboard under the Security Events timeline. Filter by actor prefix `mcp:` to isolate MCP activity.
+
+### Abuse Detection
+
+Watch for:
+
+- High rate limit hit counts on action tools
+- Unusual `--path` parameters (even though traversal is blocked, attempts indicate probing)
+- Repeated permission-denied entries for action tools not in the allowlist
+- Concurrent action rejections (may indicate multiple clients sharing a config)
+
+## Incident Response
+
+### 1. Disable Immediately
+
+```bash
+unset MCP_ENABLED
+# or set enabled: false in config/mcp.php
+```
+
+Kill any running `mcp:serve` process.
+
+### 2. Review Audit Logs
+
+Check audit entries with actor prefix `mcp:` for:
+
+- Which tools were called
+- What parameters were passed
+- Whether any action tools executed
+- Duration and output sizes (unusually large may indicate data exfiltration attempts)
+
+### 3. Rotate Keys
+
+If secrets may have been exposed:
+
+- Rotate `PULSAR_MASTER_KEY`
+- Rotate any application-level API keys, tokens, database passwords
+- Invalidate active sessions
+
+### 4. Assess Exposure
+
+- Review action tool output for any sensitive data that may have bypassed redaction
+- Check subprocess execution history for unexpected commands
+- Verify no files were modified outside the path allowlist
+
+## Tool Reference
+
+### Read Tools
+
+#### `pulsar.api.snapshot`
+
+Returns the public API snapshot (classes marked with `#[Api]`).
+
+- **Category**: Read
+- **Parameters**: `class` (string, optional), `namespacePrefix` (string, optional), `cursor` (string, optional), `limit` (integer, optional, default 100)
+- **Output**: `{ "classes": { ... }, "totalCount": N, "nextCursor": null }`
+
+#### `pulsar.architecture.map`
+
+Returns the architecture map: registered extensions and container bindings.
+
+- **Category**: Read
+- **Parameters**: none
+- **Output**: `{ "extensions": [...], "bindings": [...] }`
+
+#### `pulsar.config.schema`
+
+Returns config DTO schemas (property names, types, scrubbed defaults).
+
+- **Category**: Read
+- **Parameters**: `name` (string, optional — filter by config name)
+- **Output**: `{ "schemas": [...] }`
+
+#### `pulsar.routes.list`
+
+Returns all registered routes with method, path, handler, and middleware.
+
+- **Category**: Read
+- **Parameters**: `method` (string, optional), `path` (string, optional), `cursor` (string, optional), `limit` (integer, optional, default 100)
+- **Output**: `{ "routes": [...], "totalCount": N, "nextCursor": null }`
+
+#### `pulsar.commands.list`
+
+Returns all registered console commands with arguments and options.
+
+- **Category**: Read
+- **Parameters**: `namespace` (string, optional), `cursor` (string, optional), `limit` (integer, optional, default 100)
+- **Output**: `{ "commands": [...], "totalCount": N, "nextCursor": null }`
+
+#### `pulsar.container.bindings`
+
+Returns container binding keys (FQCN-like patterns only).
+
+- **Category**: Read
+- **Parameters**: `filter` (string, optional — substring match), `cursor` (string, optional), `limit` (integer, optional, default 100)
+- **Output**: `{ "bindings": [...], "totalCount": N, "nextCursor": null }`
+
+### Action Tools
+
+#### `pulsar.tests.run`
+
+Runs PHPUnit with the project configuration.
+
+- **Category**: Action
+- **Parameters**: `filter` (string, optional — test name filter), `path` (string, optional — test file/directory)
+- **Output**: `{ "exitCode": 0, "stdout": "...", "stderr": "...", "timedOut": false, "wasCancelled": false, "truncated": false }`
+
+#### `pulsar.formatter.run`
+
+Runs code formatters.
+
+- **Category**: Action
+- **Parameters**: `type` (string, required — `php` or `js`), `path` (string, optional)
+- **Output**: `{ "exitCode": 0, "stdout": "...", "stderr": "...", "timedOut": false, "wasCancelled": false, "truncated": false }`
+
+#### `pulsar.analysis.run`
+
+Runs static analysis tools.
+
+- **Category**: Action
+- **Parameters**: `analyzer` (string, required — `phpstan` or `psalm`)
+- **Output**: `{ "exitCode": 0, "stdout": "...", "stderr": "...", "timedOut": false, "wasCancelled": false, "truncated": false }`

--- a/docs/adr/0017-introspection-layer.md
+++ b/docs/adr/0017-introspection-layer.md
@@ -1,0 +1,127 @@
+# ADR-0017: Introspection Layer
+
+## Status
+
+Accepted
+
+## Context
+
+Pulsar needs a structured way to expose project metadata — registered routes, container bindings, extension state, config schemas, console commands, and the public API snapshot — to developer tooling. Three consumers need this data:
+
+1. **CLI** (`metadata:export`) for human/script consumption
+2. **Studio** dashboard for visual introspection
+3. **MCP Server** extension for AI-assisted development
+
+Without a unified introspection layer, each consumer would independently crawl framework internals, creating coupling to `#[Internal]` types and duplicating sanitization logic. Extensions that contribute metadata (e.g., a payments extension exposing its webhook routes) have no safe channel to do so.
+
+The introspection layer must balance openness (useful metadata) with security (no secrets, no absolute paths, bounded resource usage from untrusted contributors).
+
+## Decision Drivers
+
+1. **Single source of truth**: All consumers read the same `ProjectMetadataSnapshot` DTO — no divergent crawling logic.
+2. **Security boundary**: Only `Introspection\Internal\` touches `#[Internal]` core types. The public surface is stable DTOs and a service facade.
+3. **Contributor safety**: Extensions contribute metadata through `ProjectMetadataBuilder` with hard resource limits — preventing memory bombs, deep recursion, and key injection from untrusted payloads.
+4. **No secrets in output**: Three-layer sanitization (contribution time, generation time, export time) ensures sensitive data never reaches consumers.
+
+## Decision
+
+Introduce `src/Introspection/` as a new core module with the following architecture:
+
+### Public API (`#[Api]`)
+
+- `ProjectMetadataSnapshot` — aggregate readonly DTO carrying all metadata sections plus warnings
+- `ProjectMetadataService` — orchestrator that assembles the snapshot (memoized per-process)
+- `MetadataContributorInterface` — extension hook for contributing custom metadata
+- `ProjectMetadataBuilder` — mutable builder with per-contributor resource limits
+- `IntrospectionConfig` — configuration DTO (enabled by default in local/staging, disabled in production)
+- `Data/` — readonly DTOs for each metadata section (routes, commands, bindings, extensions, config schemas, API snapshot, contributed metadata)
+
+### Internal (`#[Internal]`)
+
+- `CoreRuntimeProbe` — crawls Container, ExtensionRegistry, Router, Console Application for runtime metadata
+- `ConfigSchemaReflector` — reflects on config DTO classes to extract property schemas (no instantiation, no env var reading)
+- `SnapshotFileReader` — reads `tools/api/public-api.snapshot.json` from disk
+
+### Resource Limits
+
+| Limit                              | Value                   | Rationale                         |
+| ---------------------------------- | ----------------------- | --------------------------------- |
+| Max sections per contributor       | 64                      | Prevent memory bombs              |
+| Max nesting depth                  | 8                       | Prevent pathological recursion    |
+| Max keys per object                | 200                     | Prevent wide-object DoS           |
+| Max bytes per contributor          | 256 KB                  | Prevent memory exhaustion         |
+| Max total bytes (all contributors) | 4 MB                    | Global memory cap                 |
+| Allowed types                      | Scalars + arrays only   | Reject objects/resources/closures |
+| Key format                         | `[a-z0-9_.-]`           | Prevent injection via keys        |
+| Max warnings                       | 100, each max 512 chars | Prevent warning spam              |
+
+### Sanitization (defense in depth)
+
+1. **At contribution**: Builder enforces resource limits, normalizes keys, rejects non-serializable types
+2. **At generation**: `build()` scrubs with `SensitiveDataScrubber`; `ConfigSchemaReflector` scrubs sensitive property defaults
+3. **At export**: CLI and MCP apply final `SensitiveDataScrubber::scrub()` pass
+
+### Path Handling
+
+All paths in snapshot output are project-root-relative. Route handlers formatted as `Namespace\Class::method`. Config schema uses DTO class names. Bindings filtered to FQCN-like keys only (regex: `~^\\?[A-Za-z_][A-Za-z0-9_]*(?:\\[A-Za-z_][A-Za-z0-9_]*)*$~`).
+
+### Wiring
+
+`IntrospectionWiring` registers the module in the Kernel boot pipeline. The service is available to extensions during the boot phase.
+
+## Alternatives Considered
+
+### Expose Container/Router/Registry directly to consumers
+
+Rejected: creates coupling to `#[Internal]` types, no sanitization boundary, each consumer must independently filter secrets and normalize paths.
+
+### Static file-only metadata (no runtime)
+
+Rejected: misses dynamic state (registered bindings, extension lifecycle, runtime routes). The API snapshot file covers compile-time API surface but not runtime configuration.
+
+### Unstructured contributor interface (extensions return raw arrays)
+
+Rejected: no resource limits, no type safety, no sanitization guarantee. The builder pattern with validation ensures every contributor operates within safe bounds.
+
+## Consequences
+
+### Positive
+
+- Unified metadata access for CLI, Studio, and MCP — no duplicated crawling logic
+- Extension-contributed metadata is resource-bounded and sanitized
+- Public API surface is stable DTOs — internal probe logic can evolve without breaking consumers
+- Three-layer sanitization prevents secret leakage at every boundary
+
+### Negative
+
+- New core module adds ~15 files to `src/Introspection/`
+- `CoreRuntimeProbe` depends on `#[Internal]` types (Container, ExtensionRegistry, Router, Application) — this coupling is intentional and contained
+
+### Neutral
+
+- Snapshot is memoized per-process — stale if services change after first call (acceptable for diagnostic tooling)
+- Contributors run synchronously during snapshot generation — acceptable for the expected contributor count
+
+## Security Impact
+
+The introspection layer is a potential information disclosure vector. Mitigations:
+
+- Production default: disabled unless `INTROSPECTION_ENABLED=true`
+- No config values or env var values in output — only schema (property names, types, defaults with sensitive ones scrubbed)
+- No absolute file paths — all paths project-root-relative
+- Binding keys filtered to FQCN patterns — service-locator keys like `db.password` excluded
+- Contributor payloads scrubbed through `SensitiveDataScrubber`
+
+## Performance Impact
+
+Snapshot generation involves reflection (config DTOs), registry iteration (extensions, routes, commands), and file I/O (API snapshot JSON). All operations are O(n) in the number of registered services/routes/extensions. Memoization ensures at most one generation per process. Not on the hot path — only invoked by CLI commands, Studio dashboard, or MCP tool calls.
+
+## Migration / Rollback Plan
+
+Additive change — no existing APIs modified. To roll back: remove `src/Introspection/`, `IntrospectionWiring`, and `config/introspection.php`. No data migrations required.
+
+## Links
+
+- ADR-0002: Module boundaries and `#[Internal]` namespace convention
+- ADR-0009: `#[Api]` attribute-based public API surface
+- ADR-0014: Kernel service wiring decomposition

--- a/extensions/mcp-server/composer.json
+++ b/extensions/mcp-server/composer.json
@@ -1,0 +1,19 @@
+{
+  "name": "pulsar/mcp-server",
+  "description": "MCP server extension for Pulsar Framework",
+  "type": "pulsar-extension",
+  "license": "MIT",
+  "require": {
+    "php": ">=8.5"
+  },
+  "autoload": {
+    "psr-4": {
+      "Pulsar\\Extension\\McpServer\\": "src/"
+    }
+  },
+  "autoload-dev": {
+    "psr-4": {
+      "Pulsar\\Extension\\McpServer\\Tests\\": "tests/"
+    }
+  }
+}

--- a/extensions/mcp-server/composer.json
+++ b/extensions/mcp-server/composer.json
@@ -10,10 +10,5 @@
     "psr-4": {
       "Pulsar\\Extension\\McpServer\\": "src/"
     }
-  },
-  "autoload-dev": {
-    "psr-4": {
-      "Pulsar\\Extension\\McpServer\\Tests\\": "tests/"
-    }
   }
 }

--- a/extensions/mcp-server/config/mcp.php
+++ b/extensions/mcp-server/config/mcp.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    'enabled' => false,
+    'client_id' => 'default',
+    'project_root' => '',
+    'tools' => [
+        'disabled_read_tools' => [],
+        'allowed_actions' => [],
+        'max_output_bytes' => 1_048_576,
+        'action_timeout' => 120,
+        'commands' => [
+            'phpunit' => null,
+            'composer' => null,
+            'pnpm' => null,
+        ],
+    ],
+    'security' => [
+        'path_allowlist' => [],
+        'rate_limit_per_minute' => 60,
+        'tool_rate_limits' => [],
+        'max_concurrent_actions' => 1,
+    ],
+];

--- a/extensions/mcp-server/pulsar.json
+++ b/extensions/mcp-server/pulsar.json
@@ -1,0 +1,14 @@
+{
+  "name": "pulsar/mcp-server",
+  "version": "1.0.0-rc.9",
+  "description": "MCP server for AI-assisted development tooling",
+  "extension_class": "Pulsar\\Extension\\McpServer\\McpServerExtension",
+  "pulsar": {
+    "min_version": "1.0.0-rc.9"
+  },
+  "provides": {
+    "services": ["McpToolRegistryInterface"],
+    "routes": false,
+    "commands": ["mcp:serve"]
+  }
+}

--- a/extensions/mcp-server/src/Config/McpConfig.php
+++ b/extensions/mcp-server/src/Config/McpConfig.php
@@ -1,0 +1,70 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Config;
+
+use NoDiscard;
+use Pulsar\Api\Internal;
+use Pulsar\Config\Environment;
+
+/**
+ * Top-level MCP server configuration DTO.
+ *
+ * Environment variables MCP_ENABLED and MCP_CLIENT_ID override
+ * their corresponding config file values.
+ */
+#[Internal]
+final readonly class McpConfig
+{
+    public function __construct(
+        public bool $enabled,
+        public string $clientId,
+        public string $projectRoot,
+        public McpToolsConfig $tools,
+        public McpSecurityConfig $security,
+    ) {}
+
+    /**
+     * Build from the raw MCP config array with environment overrides.
+     *
+     * @param array<string, mixed> $data Raw array from config/mcp.php
+     * @param Environment $environment Environment for variable overrides
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data, Environment $environment): self
+    {
+        /** @var bool $enabled */
+        $enabled = (bool) ($data['enabled'] ?? false);
+
+        $envEnabled = $environment->get('MCP_ENABLED');
+        if ($envEnabled !== null) {
+            $enabled = $envEnabled === '1' || $envEnabled === 'true';
+        }
+
+        /** @var string $clientId */
+        $clientId = (string) ($data['client_id'] ?? 'default');
+
+        $envClientId = $environment->get('MCP_CLIENT_ID');
+        if ($envClientId !== null) {
+            $clientId = $envClientId;
+        }
+
+        /** @var string $projectRoot */
+        $projectRoot = (string) ($data['project_root'] ?? '');
+
+        /** @var array<string, mixed> $toolsData */
+        $toolsData = (array) ($data['tools'] ?? []);
+
+        /** @var array<string, mixed> $securityData */
+        $securityData = (array) ($data['security'] ?? []);
+
+        return new self(
+            enabled: $enabled,
+            clientId: $clientId,
+            projectRoot: $projectRoot,
+            tools: McpToolsConfig::fromArray($toolsData),
+            security: McpSecurityConfig::fromArray($securityData),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Config/McpConfig.php
+++ b/extensions/mcp-server/src/Config/McpConfig.php
@@ -34,7 +34,6 @@ final readonly class McpConfig
     #[NoDiscard]
     public static function fromArray(array $data, Environment $environment): self
     {
-        /** @var bool $enabled */
         $enabled = (bool) ($data['enabled'] ?? false);
 
         $envEnabled = $environment->get('MCP_ENABLED');
@@ -42,7 +41,6 @@ final readonly class McpConfig
             $enabled = $envEnabled === '1' || $envEnabled === 'true';
         }
 
-        /** @var string $clientId */
         $clientId = (string) ($data['client_id'] ?? 'default');
 
         $envClientId = $environment->get('MCP_CLIENT_ID');
@@ -50,7 +48,6 @@ final readonly class McpConfig
             $clientId = $envClientId;
         }
 
-        /** @var string $projectRoot */
         $projectRoot = (string) ($data['project_root'] ?? '');
 
         /** @var array<string, mixed> $toolsData */

--- a/extensions/mcp-server/src/Config/McpSecurityConfig.php
+++ b/extensions/mcp-server/src/Config/McpSecurityConfig.php
@@ -35,13 +35,11 @@ final readonly class McpSecurityConfig
         /** @var list<string> $pathAllowlist */
         $pathAllowlist = (array) ($data['path_allowlist'] ?? []);
 
-        /** @var int $rateLimitPerMinute */
         $rateLimitPerMinute = (int) ($data['rate_limit_per_minute'] ?? 60);
 
         /** @var array<string, int> $toolRateLimits */
         $toolRateLimits = (array) ($data['tool_rate_limits'] ?? []);
 
-        /** @var int $maxConcurrentActions */
         $maxConcurrentActions = (int) ($data['max_concurrent_actions'] ?? 1);
 
         return new self(

--- a/extensions/mcp-server/src/Config/McpSecurityConfig.php
+++ b/extensions/mcp-server/src/Config/McpSecurityConfig.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Config;
+
+use NoDiscard;
+use Pulsar\Api\Internal;
+
+/**
+ * Security sub-configuration for MCP access control.
+ */
+#[Internal]
+final readonly class McpSecurityConfig
+{
+    /**
+     * @param list<string> $pathAllowlist Allowed filesystem paths for tool access
+     * @param int $rateLimitPerMinute Global rate limit for tool calls
+     * @param array<string, int> $toolRateLimits Per-tool rate limit overrides
+     * @param int $maxConcurrentActions Maximum simultaneous action tool executions
+     */
+    public function __construct(
+        public array $pathAllowlist,
+        public int $rateLimitPerMinute,
+        public array $toolRateLimits,
+        public int $maxConcurrentActions,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        /** @var list<string> $pathAllowlist */
+        $pathAllowlist = (array) ($data['path_allowlist'] ?? []);
+
+        /** @var int $rateLimitPerMinute */
+        $rateLimitPerMinute = (int) ($data['rate_limit_per_minute'] ?? 60);
+
+        /** @var array<string, int> $toolRateLimits */
+        $toolRateLimits = (array) ($data['tool_rate_limits'] ?? []);
+
+        /** @var int $maxConcurrentActions */
+        $maxConcurrentActions = (int) ($data['max_concurrent_actions'] ?? 1);
+
+        return new self(
+            pathAllowlist: $pathAllowlist,
+            rateLimitPerMinute: $rateLimitPerMinute,
+            toolRateLimits: $toolRateLimits,
+            maxConcurrentActions: $maxConcurrentActions,
+        );
+    }
+}

--- a/extensions/mcp-server/src/Config/McpToolsConfig.php
+++ b/extensions/mcp-server/src/Config/McpToolsConfig.php
@@ -40,10 +40,8 @@ final readonly class McpToolsConfig
         /** @var list<string> $allowedActions */
         $allowedActions = (array) ($data['allowed_actions'] ?? []);
 
-        /** @var int $maxOutputBytes */
         $maxOutputBytes = (int) ($data['max_output_bytes'] ?? 1_048_576);
 
-        /** @var int $actionTimeout */
         $actionTimeout = (int) ($data['action_timeout'] ?? 120);
 
         /** @var array<string, mixed> $commandsRaw */

--- a/extensions/mcp-server/src/Config/McpToolsConfig.php
+++ b/extensions/mcp-server/src/Config/McpToolsConfig.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Config;
+
+use NoDiscard;
+use Pulsar\Api\Internal;
+
+/**
+ * Tool execution sub-configuration.
+ */
+#[Internal]
+final readonly class McpToolsConfig
+{
+    /**
+     * @param list<string> $disabledReadTools Tool names explicitly disabled
+     * @param list<string> $allowedActions Action tool names explicitly allowed
+     * @param int $maxOutputBytes Maximum bytes in tool output before truncation
+     * @param int $actionTimeout Timeout in seconds for action tool execution
+     * @param array{phpunit: ?string, composer: ?string, pnpm: ?string} $commands External command paths
+     */
+    public function __construct(
+        public array $disabledReadTools,
+        public array $allowedActions,
+        public int $maxOutputBytes,
+        public int $actionTimeout,
+        public array $commands,
+    ) {}
+
+    /**
+     * @param array<string, mixed> $data
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data): self
+    {
+        /** @var list<string> $disabledReadTools */
+        $disabledReadTools = (array) ($data['disabled_read_tools'] ?? []);
+
+        /** @var list<string> $allowedActions */
+        $allowedActions = (array) ($data['allowed_actions'] ?? []);
+
+        /** @var int $maxOutputBytes */
+        $maxOutputBytes = (int) ($data['max_output_bytes'] ?? 1_048_576);
+
+        /** @var int $actionTimeout */
+        $actionTimeout = (int) ($data['action_timeout'] ?? 120);
+
+        /** @var array<string, mixed> $commandsRaw */
+        $commandsRaw = (array) ($data['commands'] ?? []);
+
+        /** @var ?string $phpunit */
+        $phpunit = isset($commandsRaw['phpunit']) ? (string) $commandsRaw['phpunit'] : null;
+        /** @var ?string $composer */
+        $composer = isset($commandsRaw['composer']) ? (string) $commandsRaw['composer'] : null;
+        /** @var ?string $pnpm */
+        $pnpm = isset($commandsRaw['pnpm']) ? (string) $commandsRaw['pnpm'] : null;
+
+        return new self(
+            disabledReadTools: $disabledReadTools,
+            allowedActions: $allowedActions,
+            maxOutputBytes: $maxOutputBytes,
+            actionTimeout: $actionTimeout,
+            commands: [
+                'phpunit' => $phpunit,
+                'composer' => $composer,
+                'pnpm' => $pnpm,
+            ],
+        );
+    }
+}

--- a/extensions/mcp-server/src/Console/McpServeCommand.php
+++ b/extensions/mcp-server/src/Console/McpServeCommand.php
@@ -1,0 +1,90 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Console;
+
+use Override;
+use Pulsar\Console\Command;
+use Pulsar\Console\ExitCode;
+use Pulsar\Console\InputInterface;
+use Pulsar\Console\OutputInterface;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Exception\McpException;
+use Pulsar\Extension\McpServer\Internal\Protocol\JsonRpcCodec;
+use Pulsar\Extension\McpServer\Internal\Protocol\MessageHandler;
+use Pulsar\Extension\McpServer\Internal\Protocol\StdioTransport;
+use Throwable;
+
+/**
+ * Starts the MCP server on stdin/stdout using the JSON-RPC 2.0 protocol.
+ */
+final class McpServeCommand extends Command
+{
+    public function __construct(
+        private readonly MessageHandler $messageHandler,
+        private readonly StdioTransport $transport,
+        private readonly McpAccessGateInterface $accessGate,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this->name = 'mcp:serve';
+        $this->description = 'Start the MCP server (JSON-RPC 2.0 over stdio)';
+    }
+
+    #[Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        // Environment gating check
+        try {
+            $this->accessGate->assertEnvironmentAllowed();
+        } catch (Throwable $e) {
+            $output->errorln('MCP server blocked: ' . $e->getMessage());
+
+            return ExitCode::Error->value;
+        }
+
+        $codec = new JsonRpcCodec();
+
+        $this->transport->writeError('Pulsar MCP server started. Listening on stdio...');
+
+        while (true) {
+            $line = $this->transport->readLine();
+
+            if ($line === null) {
+                // EOF — client disconnected
+                break;
+            }
+
+            if ($line === '') {
+                continue;
+            }
+
+            try {
+                $request = $codec->decode($line);
+                $response = $this->messageHandler->handle($request);
+
+                if ($response !== null) {
+                    $this->transport->writeLine($response);
+                }
+            } catch (McpException $e) {
+                // Protocol-level errors get a JSON-RPC error response
+                $errorResponse = $codec->encodeError(null, $e->getCode(), $e->getMessage());
+                $this->transport->writeLine($errorResponse);
+            } catch (Throwable $e) {
+                // Unexpected errors — log to stderr, send generic error to client
+                $this->transport->writeError('Internal error: ' . $e->getMessage());
+                $errorResponse = $codec->encodeError(null, -32603, 'Internal error');
+                $this->transport->writeLine($errorResponse);
+            }
+        }
+
+        $this->transport->writeError('MCP server shutting down.');
+
+        return ExitCode::Success->value;
+    }
+}

--- a/extensions/mcp-server/src/Contracts/McpAccessGateInterface.php
+++ b/extensions/mcp-server/src/Contracts/McpAccessGateInterface.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+
+/**
+ * Access gate for MCP operations.
+ *
+ * Enforces environment-level, path-level, and concurrency constraints.
+ */
+#[Api(since: '1.0.0')]
+interface McpAccessGateInterface
+{
+    /**
+     * Assert that the current environment allows MCP operations.
+     *
+     * @throws McpSecurityException When the environment blocks MCP access
+     */
+    public function assertEnvironmentAllowed(): void;
+
+    /**
+     * Assert that accessing the given path is permitted.
+     *
+     * @throws McpSecurityException When the path is not in the allowlist
+     */
+    public function assertPathAllowed(string $path): void;
+
+    /**
+     * Assert that a concurrent action slot is available.
+     *
+     * @throws McpSecurityException When the concurrency limit is reached
+     */
+    public function assertConcurrencyAllowed(): void;
+
+    /**
+     * Release a concurrent action slot after completion.
+     */
+    public function releaseConcurrencySlot(): void;
+}

--- a/extensions/mcp-server/src/Contracts/McpRedactionPipelineInterface.php
+++ b/extensions/mcp-server/src/Contracts/McpRedactionPipelineInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+
+/**
+ * Pipeline for redacting sensitive data from tool results before wire transmission.
+ */
+#[Api(since: '1.0.0')]
+interface McpRedactionPipelineInterface
+{
+    /**
+     * Redact sensitive data from a tool result.
+     */
+    public function redact(ToolResult $result): ToolResult;
+
+    /**
+     * Redact sensitive data from a raw string.
+     */
+    public function redactString(string $input): string;
+}

--- a/extensions/mcp-server/src/Contracts/McpToolInterface.php
+++ b/extensions/mcp-server/src/Contracts/McpToolInterface.php
@@ -1,0 +1,55 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+
+/**
+ * Contract for an executable MCP tool.
+ *
+ * Implementations provide schema metadata for discovery and an execute
+ * method for invocation via the MCP protocol.
+ */
+#[Api(since: '1.0.0')]
+interface McpToolInterface
+{
+    /**
+     * Unique tool identifier used in tools/call requests.
+     */
+    public function name(): string;
+
+    /**
+     * Human-readable description shown to MCP clients.
+     */
+    public function description(): string;
+
+    /**
+     * JSON Schema describing accepted input parameters.
+     *
+     * @return array<string, mixed>
+     */
+    public function inputSchema(): array;
+
+    /**
+     * JSON Schema describing the structured output shape.
+     *
+     * @return array<string, mixed>
+     */
+    public function outputSchema(): array;
+
+    /**
+     * Tool category for permission classification.
+     */
+    public function category(): ToolCategory;
+
+    /**
+     * Execute the tool with the given parameters.
+     *
+     * @param array<string, mixed> $params Validated input parameters
+     */
+    public function execute(array $params): ToolResult;
+}

--- a/extensions/mcp-server/src/Contracts/McpToolRegistryInterface.php
+++ b/extensions/mcp-server/src/Contracts/McpToolRegistryInterface.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\McpServer\Domain\ToolDefinition;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Exception\McpException;
+
+/**
+ * Registry of available MCP tools.
+ *
+ * Manages tool registration, lookup, and invocation.
+ */
+#[Api(since: '1.0.0')]
+interface McpToolRegistryInterface
+{
+    /**
+     * Register a tool in the registry.
+     */
+    public function register(McpToolInterface $tool): void;
+
+    /**
+     * List all registered tool definitions.
+     *
+     * @return list<ToolDefinition>
+     */
+    public function list(): array;
+
+    /**
+     * Get a registered tool by name.
+     *
+     * @throws McpException When the tool is not found
+     */
+    public function get(string $name): McpToolInterface;
+
+    /**
+     * Check if a tool is registered.
+     */
+    public function has(string $name): bool;
+
+    /**
+     * Execute a tool by name with the given parameters.
+     *
+     * @param array<string, mixed> $params Tool input parameters
+     *
+     * @throws McpException When the tool is not found
+     */
+    public function call(string $name, array $params): ToolResult;
+}

--- a/extensions/mcp-server/src/Contracts/ToolPermissionCheckerInterface.php
+++ b/extensions/mcp-server/src/Contracts/ToolPermissionCheckerInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Contracts;
+
+use Pulsar\Api\Api;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+
+/**
+ * Determines whether a tool invocation is permitted.
+ *
+ * Checks tool-level allow/deny lists and category-based restrictions.
+ */
+#[Api(since: '1.0.0')]
+interface ToolPermissionCheckerInterface
+{
+    /**
+     * Assert that the named tool is allowed to execute.
+     *
+     * @throws McpSecurityException When the tool is not permitted
+     */
+    public function assertAllowed(string $toolName): void;
+
+    /**
+     * Check if the named tool is allowed without throwing.
+     */
+    public function isAllowed(string $toolName): bool;
+}

--- a/extensions/mcp-server/src/Domain/ToolCategory.php
+++ b/extensions/mcp-server/src/Domain/ToolCategory.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Classification of MCP tools by their side-effect profile.
+ *
+ * Read tools are safe to execute without explicit user approval.
+ * Action tools may modify state and require permission checks.
+ */
+#[Api(since: '1.0.0')]
+enum ToolCategory: string
+{
+    case Read = 'read';
+    case Action = 'action';
+}

--- a/extensions/mcp-server/src/Domain/ToolDefinition.php
+++ b/extensions/mcp-server/src/Domain/ToolDefinition.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Domain;
+
+use Pulsar\Api\Api;
+
+/**
+ * Immutable description of an MCP tool for the wire protocol.
+ *
+ * Maps directly to the MCP tools/list response shape.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ToolDefinition
+{
+    /**
+     * @param string $name Unique tool identifier
+     * @param string $description Human-readable description
+     * @param array<string, mixed> $inputSchema JSON Schema for tool parameters
+     * @param array<string, mixed> $outputSchema JSON Schema for tool output
+     * @param ToolCategory $category Read or action classification
+     */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public array $inputSchema,
+        public array $outputSchema,
+        public ToolCategory $category,
+    ) {}
+}

--- a/extensions/mcp-server/src/Domain/ToolResult.php
+++ b/extensions/mcp-server/src/Domain/ToolResult.php
@@ -1,0 +1,93 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Domain;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+
+/**
+ * Immutable result of an MCP tool execution.
+ *
+ * Carries both structured data (for programmatic consumption) and
+ * a text fallback (for display in clients that don't parse structured output).
+ */
+#[Api(since: '1.0.0')]
+final readonly class ToolResult
+{
+    /**
+     * @param array<string, mixed> $structuredContent Machine-readable result data
+     * @param string $textContent Human-readable text fallback
+     * @param bool $isError Whether the tool execution failed
+     * @param array<string, mixed> $meta Additional metadata (timing, truncation info, etc.)
+     */
+    public function __construct(
+        public array $structuredContent,
+        public string $textContent,
+        public bool $isError,
+        public array $meta = [],
+    ) {}
+
+    /**
+     * Create a successful tool result.
+     *
+     * @param array<string, mixed> $structuredContent Structured result data
+     * @param string $textContent Human-readable summary
+     * @param array<string, mixed> $meta Optional metadata
+     */
+    #[NoDiscard]
+    public static function success(array $structuredContent, string $textContent, array $meta = []): self
+    {
+        return new self(
+            structuredContent: $structuredContent,
+            textContent: $textContent,
+            isError: false,
+            meta: $meta,
+        );
+    }
+
+    /**
+     * Create an error tool result.
+     *
+     * @param string $message Error description
+     * @param array<string, mixed> $meta Optional metadata
+     */
+    #[NoDiscard]
+    public static function error(string $message, array $meta = []): self
+    {
+        return new self(
+            structuredContent: ['error' => $message],
+            textContent: $message,
+            isError: true,
+            meta: $meta,
+        );
+    }
+
+    /**
+     * Create a result indicating the output was truncated.
+     *
+     * @param array<string, mixed> $structuredContent Truncated structured data
+     * @param string $textContent Truncated text
+     * @param int $originalBytes Original output size before truncation
+     * @param int $truncatedBytes Size after truncation
+     */
+    #[NoDiscard]
+    public static function truncated(
+        array $structuredContent,
+        string $textContent,
+        int $originalBytes,
+        int $truncatedBytes,
+    ): self {
+        return new self(
+            structuredContent: $structuredContent,
+            textContent: $textContent,
+            isError: false,
+            meta: [
+                'truncated' => true,
+                'original_bytes' => $originalBytes,
+                'truncated_bytes' => $truncatedBytes,
+            ],
+        );
+    }
+}

--- a/extensions/mcp-server/src/Exception/McpException.php
+++ b/extensions/mcp-server/src/Exception/McpException.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Exception;
+
+use NoDiscard;
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * MCP protocol and tool execution exceptions.
+ */
+final class McpException extends RuntimeException
+{
+    #[NoDiscard]
+    public static function toolNotFound(string $name): self
+    {
+        return new self(sprintf('MCP tool not found: %s', $name));
+    }
+
+    #[NoDiscard]
+    public static function protocolError(string $message, int $code): self
+    {
+        return new self(sprintf('MCP protocol error (%d): %s', $code, $message), $code);
+    }
+
+    #[NoDiscard]
+    public static function executionFailed(string $tool, string $reason): self
+    {
+        return new self(sprintf('MCP tool "%s" execution failed: %s', $tool, $reason));
+    }
+
+    #[NoDiscard]
+    public static function outputTruncated(string $tool): self
+    {
+        return new self(sprintf('MCP tool "%s" output exceeded maximum size and was truncated', $tool));
+    }
+}

--- a/extensions/mcp-server/src/Exception/McpSecurityException.php
+++ b/extensions/mcp-server/src/Exception/McpSecurityException.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Exception;
+
+use NoDiscard;
+use RuntimeException;
+
+use function sprintf;
+
+/**
+ * Security-related MCP exceptions for access control violations.
+ */
+final class McpSecurityException extends RuntimeException
+{
+    #[NoDiscard]
+    public static function toolNotAllowed(string $tool): self
+    {
+        return new self(sprintf('MCP tool not allowed: %s', $tool));
+    }
+
+    #[NoDiscard]
+    public static function pathNotAllowed(string $path): self
+    {
+        return new self(sprintf('Path access not allowed: %s', $path));
+    }
+
+    #[NoDiscard]
+    public static function rateLimited(string $tool, int $retryAfter): self
+    {
+        return new self(
+            sprintf('MCP tool "%s" rate limited, retry after %d seconds', $tool, $retryAfter),
+        );
+    }
+
+    #[NoDiscard]
+    public static function concurrencyLimited(): self
+    {
+        return new self('Maximum concurrent MCP action executions reached');
+    }
+
+    #[NoDiscard]
+    public static function environmentBlocked(string $mode): self
+    {
+        return new self(sprintf('MCP access blocked in "%s" environment', $mode));
+    }
+}

--- a/extensions/mcp-server/src/Internal/McpToolRegistry.php
+++ b/extensions/mcp-server/src/Internal/McpToolRegistry.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Domain\ToolDefinition;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Exception\McpException;
+
+use function array_map;
+use function array_values;
+
+/**
+ * In-memory registry of available MCP tools.
+ */
+#[Internal]
+final class McpToolRegistry implements McpToolRegistryInterface
+{
+    /** @var array<string, McpToolInterface> */
+    private array $tools = [];
+
+    public function register(McpToolInterface $tool): void
+    {
+        $this->tools[$tool->name()] = $tool;
+    }
+
+    /**
+     * @return list<ToolDefinition>
+     */
+    public function list(): array
+    {
+        return array_values(array_map(
+            static fn(McpToolInterface $tool): ToolDefinition => new ToolDefinition(
+                name: $tool->name(),
+                description: $tool->description(),
+                inputSchema: $tool->inputSchema(),
+                outputSchema: $tool->outputSchema(),
+                category: $tool->category(),
+            ),
+            $this->tools,
+        ));
+    }
+
+    public function get(string $name): McpToolInterface
+    {
+        if (!$this->has($name)) {
+            throw McpException::toolNotFound($name);
+        }
+
+        return $this->tools[$name];
+    }
+
+    public function has(string $name): bool
+    {
+        return isset($this->tools[$name]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    public function call(string $name, array $params): ToolResult
+    {
+        $tool = $this->get($name);
+
+        return $tool->execute($params);
+    }
+}

--- a/extensions/mcp-server/src/Internal/Protocol/JsonRpcCodec.php
+++ b/extensions/mcp-server/src/Internal/Protocol/JsonRpcCodec.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Pulsar\Extension\McpServer\Internal\Protocol;
 
+use JsonException;
 use Pulsar\Api\Internal;
 use Pulsar\Extension\McpServer\Exception\McpException;
 
@@ -38,7 +39,7 @@ final readonly class JsonRpcCodec
     {
         try {
             $data = json_decode($line, true, 64, JSON_THROW_ON_ERROR);
-        } catch (\JsonException $e) {
+        } catch (JsonException $e) {
             throw McpException::protocolError('Parse error: ' . $e->getMessage(), self::PARSE_ERROR);
         }
 

--- a/extensions/mcp-server/src/Internal/Protocol/JsonRpcCodec.php
+++ b/extensions/mcp-server/src/Internal/Protocol/JsonRpcCodec.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Protocol;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Exception\McpException;
+
+use function is_array;
+use function is_int;
+use function is_string;
+use function json_decode;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+use const JSON_UNESCAPED_UNICODE;
+
+/**
+ * JSON-RPC 2.0 codec for MCP message encoding and decoding.
+ *
+ * Handles parse validation, protocol version checks, and compact JSON serialization.
+ */
+#[Internal]
+final readonly class JsonRpcCodec
+{
+    private const string JSONRPC_VERSION = '2.0';
+    private const int PARSE_ERROR = -32700;
+    private const int INVALID_REQUEST = -32600;
+
+    /**
+     * Decode a JSON-RPC 2.0 request from a raw JSON string.
+     *
+     * @throws McpException On parse errors (-32700) or invalid requests (-32600)
+     */
+    public function decode(string $line): JsonRpcRequest
+    {
+        try {
+            $data = json_decode($line, true, 64, JSON_THROW_ON_ERROR);
+        } catch (\JsonException $e) {
+            throw McpException::protocolError('Parse error: ' . $e->getMessage(), self::PARSE_ERROR);
+        }
+
+        if (!is_array($data)) {
+            throw McpException::protocolError('Request must be a JSON object', self::INVALID_REQUEST);
+        }
+
+        /** @var array<string, mixed> $data */
+        $version = $data['jsonrpc'] ?? null;
+        if ($version !== self::JSONRPC_VERSION) {
+            throw McpException::protocolError(
+                'Invalid or missing jsonrpc version, expected "2.0"',
+                self::INVALID_REQUEST,
+            );
+        }
+
+        $method = $data['method'] ?? null;
+        if (!is_string($method) || $method === '') {
+            throw McpException::protocolError('Missing or invalid method field', self::INVALID_REQUEST);
+        }
+
+        $id = $data['id'] ?? null;
+        if ($id !== null && !is_string($id) && !is_int($id)) {
+            throw McpException::protocolError('Request id must be a string, integer, or null', self::INVALID_REQUEST);
+        }
+
+        /** @var array<string, mixed> $params */
+        $params = is_array($data['params'] ?? null) ? $data['params'] : [];
+
+        return new JsonRpcRequest(
+            id: $id,
+            method: $method,
+            params: $params,
+        );
+    }
+
+    /**
+     * Encode a successful JSON-RPC 2.0 response.
+     *
+     * @param string|int $id Request ID
+     * @param array<string, mixed> $result Result payload
+     *
+     * @return string Compact JSON with trailing newline
+     */
+    public function encodeResult(string|int $id, array $result): string
+    {
+        return json_encode(
+            [
+                'jsonrpc' => self::JSONRPC_VERSION,
+                'id' => $id,
+                'result' => $result,
+            ],
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ) . "\n";
+    }
+
+    /**
+     * Encode a JSON-RPC 2.0 error response.
+     *
+     * @param string|int|null $id Request ID (null if the request could not be parsed)
+     * @param int $code JSON-RPC error code
+     * @param string $message Human-readable error message
+     * @param array<string, mixed>|null $data Optional additional error data
+     *
+     * @return string Compact JSON with trailing newline
+     */
+    public function encodeError(string|int|null $id, int $code, string $message, ?array $data = null): string
+    {
+        $error = [
+            'code' => $code,
+            'message' => $message,
+        ];
+
+        if ($data !== null) {
+            $error['data'] = $data;
+        }
+
+        return json_encode(
+            [
+                'jsonrpc' => self::JSONRPC_VERSION,
+                'id' => $id,
+                'error' => $error,
+            ],
+            JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE,
+        ) . "\n";
+    }
+}

--- a/extensions/mcp-server/src/Internal/Protocol/JsonRpcRequest.php
+++ b/extensions/mcp-server/src/Internal/Protocol/JsonRpcRequest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Protocol;
+
+use Pulsar\Api\Internal;
+
+/**
+ * Parsed JSON-RPC 2.0 request.
+ *
+ * Notifications have a null id. Requests always have a non-null id.
+ */
+#[Internal]
+final readonly class JsonRpcRequest
+{
+    /**
+     * @param string|int|null $id Request ID (null for notifications)
+     * @param string $method JSON-RPC method name
+     * @param array<string, mixed> $params Method parameters
+     */
+    public function __construct(
+        public string|int|null $id,
+        public string $method,
+        public array $params,
+    ) {}
+
+    /**
+     * Whether this is a notification (no response expected).
+     */
+    public function isNotification(): bool
+    {
+        return $this->id === null;
+    }
+}

--- a/extensions/mcp-server/src/Internal/Protocol/MessageHandler.php
+++ b/extensions/mcp-server/src/Internal/Protocol/MessageHandler.php
@@ -7,7 +7,6 @@ namespace Pulsar\Extension\McpServer\Internal\Protocol;
 use Pulsar\Api\Internal;
 use Pulsar\Audit\AuditLoggerInterface;
 use Pulsar\Extension\McpServer\Config\McpConfig;
-use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
 use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
 use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
 use Pulsar\Extension\McpServer\Contracts\ToolPermissionCheckerInterface;
@@ -40,7 +39,6 @@ final readonly class MessageHandler
     private const string SERVER_VERSION = '1.0.0-rc.9';
     private const int METHOD_NOT_FOUND = -32601;
     private const int INVALID_PARAMS = -32602;
-    private const int INTERNAL_ERROR = -32603;
 
     /** @var list<string> Known MCP protocol versions in descending preference order */
     private const array KNOWN_PROTOCOL_VERSIONS = [
@@ -54,7 +52,6 @@ final readonly class MessageHandler
     public function __construct(
         private McpToolRegistryInterface $registry,
         private ToolPermissionCheckerInterface $permissionChecker,
-        private McpAccessGateInterface $accessGate,
         private McpRedactionPipelineInterface $redactionPipeline,
         private ?AuditLoggerInterface $auditLogger,
         private ?RateLimiterInterface $rateLimiter,
@@ -93,12 +90,11 @@ final readonly class MessageHandler
 
     private function handleNotification(JsonRpcRequest $request): ?string
     {
-        match ($request->method) {
-            'notifications/initialized' => null,
-            'notifications/cancelled' => $this->handleCancelled($request->params),
-            default => null,
-        };
+        if ($request->method === 'notifications/cancelled') {
+            $this->handleCancelled($request->params);
+        }
 
+        // All notifications (including notifications/initialized) return null per spec
         return null;
     }
 
@@ -110,8 +106,8 @@ final readonly class MessageHandler
         // Best-effort cancel tracking. The requestId identifies which in-flight
         // request the client wants cancelled. Since tool execution is synchronous
         // in the current implementation, this is a no-op acknowledgment.
-        // Future async execution can check a cancellation registry keyed by requestId.
-        $_ = $params['requestId'] ?? null;
+        // Future async execution can check a cancellation registry keyed by
+        // $params['requestId'].
     }
 
     /**

--- a/extensions/mcp-server/src/Internal/Protocol/MessageHandler.php
+++ b/extensions/mcp-server/src/Internal/Protocol/MessageHandler.php
@@ -1,0 +1,303 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Protocol;
+
+use Pulsar\Api\Internal;
+use Pulsar\Audit\AuditLoggerInterface;
+use Pulsar\Extension\McpServer\Config\McpConfig;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Contracts\ToolPermissionCheckerInterface;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Exception\McpException;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+use Pulsar\Http\RateLimit\RateLimiterInterface;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use Pulsar\Security\Audit\AuditEvent;
+use Pulsar\Security\Audit\AuditOutcome;
+use Throwable;
+
+use function array_map;
+use function in_array;
+use function is_string;
+use function preg_match;
+use function sprintf;
+
+/**
+ * Dispatches incoming JSON-RPC requests to MCP protocol handlers.
+ *
+ * Handles the full MCP method set: initialize, ping, tools/list, tools/call,
+ * and notification methods. Integrates permission checks, rate limiting,
+ * audit logging, and output redaction into the tool call pipeline.
+ */
+#[Internal]
+final readonly class MessageHandler
+{
+    private const string SERVER_NAME = 'pulsar-mcp';
+    private const string SERVER_VERSION = '1.0.0-rc.9';
+    private const int METHOD_NOT_FOUND = -32601;
+    private const int INVALID_PARAMS = -32602;
+    private const int INTERNAL_ERROR = -32603;
+
+    /** @var list<string> Known MCP protocol versions in descending preference order */
+    private const array KNOWN_PROTOCOL_VERSIONS = [
+        '2025-11-25',
+        '2025-03-26',
+        '2024-11-05',
+    ];
+
+    private JsonRpcCodec $codec;
+
+    public function __construct(
+        private McpToolRegistryInterface $registry,
+        private ToolPermissionCheckerInterface $permissionChecker,
+        private McpAccessGateInterface $accessGate,
+        private McpRedactionPipelineInterface $redactionPipeline,
+        private ?AuditLoggerInterface $auditLogger,
+        private ?RateLimiterInterface $rateLimiter,
+        private McpConfig $config,
+        private SensitiveDataScrubber $scrubber,
+    ) {
+        $this->codec = new JsonRpcCodec();
+    }
+
+    /**
+     * Handle a parsed JSON-RPC request and return the response string.
+     *
+     * Returns null for notifications (no response expected by the protocol).
+     */
+    public function handle(JsonRpcRequest $request): ?string
+    {
+        if ($request->isNotification()) {
+            return $this->handleNotification($request);
+        }
+
+        /** @var string|int $id */
+        $id = $request->id;
+
+        return match ($request->method) {
+            'initialize' => $this->handleInitialize($id, $request->params),
+            'ping' => $this->codec->encodeResult($id, []),
+            'tools/list' => $this->handleToolsList($id, $request->params),
+            'tools/call' => $this->handleToolsCall($id, $request->params),
+            default => $this->codec->encodeError(
+                $id,
+                self::METHOD_NOT_FOUND,
+                sprintf('Method not found: %s', $request->method),
+            ),
+        };
+    }
+
+    private function handleNotification(JsonRpcRequest $request): ?string
+    {
+        match ($request->method) {
+            'notifications/initialized' => null,
+            'notifications/cancelled' => $this->handleCancelled($request->params),
+            default => null,
+        };
+
+        return null;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function handleCancelled(array $params): void
+    {
+        // Best-effort cancel tracking. The requestId identifies which in-flight
+        // request the client wants cancelled. Since tool execution is synchronous
+        // in the current implementation, this is a no-op acknowledgment.
+        // Future async execution can check a cancellation registry keyed by requestId.
+        $_ = $params['requestId'] ?? null;
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function handleInitialize(string|int $id, array $params): string
+    {
+        $clientProtocolVersion = $params['protocolVersion'] ?? null;
+
+        if (!is_string($clientProtocolVersion) || $clientProtocolVersion === '') {
+            return $this->codec->encodeError(
+                $id,
+                self::INVALID_PARAMS,
+                'Missing or invalid protocolVersion parameter',
+            );
+        }
+
+        // Validate the version looks like a date (YYYY-MM-DD)
+        if (preg_match('/^\d{4}-\d{2}-\d{2}$/', $clientProtocolVersion) !== 1) {
+            return $this->codec->encodeError(
+                $id,
+                self::INVALID_PARAMS,
+                'protocolVersion must be a valid date string (YYYY-MM-DD)',
+            );
+        }
+
+        // Negotiate protocol version
+        $negotiatedVersion = $this->negotiateProtocolVersion($clientProtocolVersion);
+
+        return $this->codec->encodeResult($id, [
+            'protocolVersion' => $negotiatedVersion,
+            'capabilities' => [
+                'tools' => [
+                    'listChanged' => false,
+                ],
+            ],
+            'serverInfo' => [
+                'name' => self::SERVER_NAME,
+                'version' => self::SERVER_VERSION,
+            ],
+        ]);
+    }
+
+    private function negotiateProtocolVersion(string $clientVersion): string
+    {
+        // If the client requests a known version, use it
+        if (in_array($clientVersion, self::KNOWN_PROTOCOL_VERSIONS, true)) {
+            return $clientVersion;
+        }
+
+        // Unknown but valid date format: negotiate to the latest known version
+        return self::KNOWN_PROTOCOL_VERSIONS[0];
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function handleToolsList(string|int $id, array $params): string
+    {
+        $tools = $this->registry->list();
+
+        $toolDefinitions = array_map(
+            static fn($tool): array => [
+                'name' => $tool->name,
+                'description' => $tool->description,
+                'inputSchema' => $tool->inputSchema,
+                'outputSchema' => $tool->outputSchema,
+            ],
+            $tools,
+        );
+
+        return $this->codec->encodeResult($id, [
+            'tools' => $toolDefinitions,
+            'nextCursor' => $params['cursor'] ?? null,
+        ]);
+    }
+
+    /**
+     * @param array<string, mixed> $params
+     */
+    private function handleToolsCall(string|int $id, array $params): string
+    {
+        $toolName = $params['name'] ?? null;
+
+        if (!is_string($toolName) || $toolName === '') {
+            return $this->codec->encodeError($id, self::INVALID_PARAMS, 'Missing tool name');
+        }
+
+        /** @var array<string, mixed> $arguments */
+        $arguments = (array) ($params['arguments'] ?? []);
+
+        // Permission check
+        try {
+            $this->permissionChecker->assertAllowed($toolName);
+        } catch (McpSecurityException $e) {
+            $this->auditToolCall($toolName, AuditOutcome::Denied, $e->getMessage());
+
+            return $this->encodeToolResult($id, ToolResult::error($e->getMessage()));
+        }
+
+        // Rate limiting
+        if ($this->rateLimiter !== null) {
+            $rateLimitKey = sprintf('mcp:tool:%s', $toolName);
+            $rateLimitResult = $this->rateLimiter->hit($rateLimitKey);
+
+            if ($rateLimitResult->exceeded()) {
+                $this->auditToolCall($toolName, AuditOutcome::Denied, 'Rate limited');
+
+                return $this->encodeToolResult(
+                    $id,
+                    ToolResult::error(
+                        sprintf('Rate limited, retry after %d seconds', $rateLimitResult->retryAfter),
+                    ),
+                );
+            }
+        }
+
+        // Execute
+        try {
+            $result = $this->registry->call($toolName, $arguments);
+        } catch (McpException $e) {
+            $this->auditToolCall($toolName, AuditOutcome::Error, $e->getMessage());
+
+            return $this->encodeToolResult($id, ToolResult::error($e->getMessage()));
+        } catch (Throwable $e) {
+            $this->auditToolCall($toolName, AuditOutcome::Error, $e->getMessage());
+
+            return $this->encodeToolResult($id, ToolResult::error('Internal tool execution error'));
+        }
+
+        // Redact sensitive data
+        $result = $this->redactionPipeline->redact($result);
+
+        // Scrub any remaining sensitive fields
+        $scrubbed = $this->scrubber->scrub($result->structuredContent);
+        if ($scrubbed !== $result->structuredContent) {
+            $result = new ToolResult(
+                structuredContent: $scrubbed,
+                textContent: $result->textContent,
+                isError: $result->isError,
+                meta: $result->meta,
+            );
+        }
+
+        // Audit success
+        $this->auditToolCall(
+            $toolName,
+            $result->isError ? AuditOutcome::Failure : AuditOutcome::Success,
+            $result->isError ? $result->textContent : 'OK',
+        );
+
+        return $this->encodeToolResult($id, $result);
+    }
+
+    private function encodeToolResult(string|int $id, ToolResult $result): string
+    {
+        $response = [
+            'content' => [
+                [
+                    'type' => 'text',
+                    'text' => $result->textContent,
+                ],
+            ],
+            'isError' => $result->isError,
+        ];
+
+        if ($result->structuredContent !== []) {
+            $response['structuredContent'] = $result->structuredContent;
+        }
+
+        if ($result->meta !== []) {
+            $response['_meta'] = $result->meta;
+        }
+
+        return $this->codec->encodeResult($id, $response);
+    }
+
+    private function auditToolCall(string $toolName, AuditOutcome $outcome, string $detail): void
+    {
+        $this->auditLogger?->log(
+            event: AuditEvent::DataAccess,
+            outcome: $outcome,
+            actor: sprintf('mcp-client:%s', $this->config->clientId),
+            action: sprintf('mcp:tools/call:%s', $toolName),
+            resource: $toolName,
+            metadata: ['detail' => $detail],
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Protocol/StdioTransport.php
+++ b/extensions/mcp-server/src/Internal/Protocol/StdioTransport.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Protocol;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Exception\McpException;
+
+use function fgets;
+use function fwrite;
+use function strlen;
+
+use const STDERR;
+use const STDIN;
+use const STDOUT;
+
+/**
+ * STDIO transport for MCP JSON-RPC communication.
+ *
+ * Reads line-delimited JSON from STDIN, writes responses to STDOUT,
+ * and emits diagnostic messages to STDERR.
+ */
+#[Internal]
+final readonly class StdioTransport
+{
+    /**
+     * Maximum allowed message size in bytes (2 MB).
+     */
+    public const int MAX_MESSAGE_SIZE = 2_097_152;
+
+    /**
+     * Read a single line from STDIN.
+     *
+     * @return string|null The line content (without trailing newline), or null on EOF
+     *
+     * @throws McpException When a line exceeds MAX_MESSAGE_SIZE
+     */
+    public function readLine(): ?string
+    {
+        $line = fgets(STDIN);
+
+        if ($line === false) {
+            return null;
+        }
+
+        $line = rtrim($line, "\r\n");
+
+        if (strlen($line) > self::MAX_MESSAGE_SIZE) {
+            throw McpException::protocolError(
+                'Message exceeds maximum size of ' . self::MAX_MESSAGE_SIZE . ' bytes',
+                -32700,
+            );
+        }
+
+        return $line;
+    }
+
+    /**
+     * Write a line to STDOUT.
+     *
+     * The caller is responsible for ensuring the data does not exceed MAX_MESSAGE_SIZE.
+     * This method enforces the limit as a safety net.
+     *
+     * @throws McpException When the data exceeds MAX_MESSAGE_SIZE
+     */
+    public function writeLine(string $data): void
+    {
+        if (strlen($data) > self::MAX_MESSAGE_SIZE) {
+            throw McpException::protocolError(
+                'Response exceeds maximum size of ' . self::MAX_MESSAGE_SIZE . ' bytes',
+                -32603,
+            );
+        }
+
+        fwrite(STDOUT, $data);
+    }
+
+    /**
+     * Write a diagnostic message to STDERR.
+     */
+    public function writeError(string $message): void
+    {
+        fwrite(STDERR, $message . "\n");
+    }
+}

--- a/extensions/mcp-server/src/Internal/Redaction/McpRedactionPipeline.php
+++ b/extensions/mcp-server/src/Internal/Redaction/McpRedactionPipeline.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Redaction;
+
+use Pulsar\Api\Internal;
+use Pulsar\Config\Environment;
+use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+use function preg_replace;
+use function str_contains;
+use function str_replace;
+use function strtoupper;
+
+/**
+ * Redacts sensitive data from MCP tool results before wire transmission.
+ *
+ * Applies regex-based pattern matching for common secret formats (env vars,
+ * connection strings, bearer tokens) and value-based matching for known secrets
+ * collected from the environment.
+ */
+#[Internal]
+final readonly class McpRedactionPipeline implements McpRedactionPipelineInterface
+{
+    /** @var list<string> Patterns matching sensitive environment variable assignments */
+    private const array ENV_VAR_PATTERNS = [
+        '/(?:PULSAR_MASTER_KEY|DB_PASSWORD|DB_USERNAME|API_KEY|API_SECRET|APP_KEY|AUTH_TOKEN|JWT_SECRET|REDIS_PASSWORD|MAIL_PASSWORD|AWS_SECRET_ACCESS_KEY)=\S+/i',
+    ];
+
+    private const string CONNECTION_STRING_PATTERN = '/\:\/\/[^:]+:[^@]+@/';
+    private const string BEARER_PATTERN = '/Bearer\s+[A-Za-z0-9\-._~+\/]+=*/i';
+    private const string REDACTED = '[REDACTED]';
+
+    /**
+     * @param SensitiveDataScrubber $scrubber Recursive key-based scrubber for structured data
+     * @param list<string> $knownSecretValues Known secret values to match exactly
+     */
+    public function __construct(
+        private SensitiveDataScrubber $scrubber,
+        private array $knownSecretValues = [],
+    ) {}
+
+    public function redact(ToolResult $result): ToolResult
+    {
+        $structured = $this->scrubber->scrub($result->structuredContent);
+        $text = $this->redactString($result->textContent);
+
+        return new ToolResult(
+            structuredContent: $structured,
+            textContent: $text,
+            isError: $result->isError,
+            meta: $result->meta,
+        );
+    }
+
+    public function redactString(string $input): string
+    {
+        $output = $input;
+
+        foreach (self::ENV_VAR_PATTERNS as $pattern) {
+            $output = preg_replace($pattern, self::REDACTED, $output) ?? $output;
+        }
+
+        $output = preg_replace(self::CONNECTION_STRING_PATTERN, '://[REDACTED]@', $output) ?? $output;
+        $output = preg_replace(self::BEARER_PATTERN, 'Bearer [REDACTED]', $output) ?? $output;
+
+        foreach ($this->knownSecretValues as $secret) {
+            if ($secret !== '' && str_contains($output, $secret)) {
+                $output = str_replace($secret, self::REDACTED, $output);
+            }
+        }
+
+        return $output;
+    }
+
+    /**
+     * Collect environment variable values that look like secrets.
+     *
+     * Scans environment variables for keys containing common secret-indicating
+     * substrings and returns their values for use in value-based redaction.
+     *
+     * @return list<string>
+     */
+    public static function collectKnownSecrets(Environment $environment): array
+    {
+        $secretPatterns = ['_KEY', '_TOKEN', '_SECRET', '_PASSWORD', '_DSN'];
+        $secrets = [];
+
+        foreach ($environment->all() as $key => $value) {
+            $upperKey = strtoupper($key);
+
+            foreach ($secretPatterns as $pattern) {
+                if (str_contains($upperKey, $pattern) && $value !== '') {
+                    $secrets[] = $value;
+
+                    break;
+                }
+            }
+        }
+
+        return $secrets;
+    }
+}

--- a/extensions/mcp-server/src/Internal/Redaction/McpRedactionPipeline.php
+++ b/extensions/mcp-server/src/Internal/Redaction/McpRedactionPipeline.php
@@ -30,7 +30,7 @@ final readonly class McpRedactionPipeline implements McpRedactionPipelineInterfa
         '/(?:PULSAR_MASTER_KEY|DB_PASSWORD|DB_USERNAME|API_KEY|API_SECRET|APP_KEY|AUTH_TOKEN|JWT_SECRET|REDIS_PASSWORD|MAIL_PASSWORD|AWS_SECRET_ACCESS_KEY)=\S+/i',
     ];
 
-    private const string CONNECTION_STRING_PATTERN = '/\:\/\/[^:]+:[^@]+@/';
+    private const string CONNECTION_STRING_PATTERN = '/:\/\/[^:]+:[^@]+@/';
     private const string BEARER_PATTERN = '/Bearer\s+[A-Za-z0-9\-._~+\/]+=*/i';
     private const string REDACTED = '[REDACTED]';
 

--- a/extensions/mcp-server/src/Internal/Security/McpAccessGate.php
+++ b/extensions/mcp-server/src/Internal/Security/McpAccessGate.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Security;
+
+use Pulsar\Api\Internal;
+use Pulsar\Config\Environment;
+use Pulsar\Config\EnvironmentMode;
+use Pulsar\Extension\McpServer\Config\McpSecurityConfig;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+
+use function fnmatch;
+use function realpath;
+use function str_contains;
+use function str_replace;
+use function str_starts_with;
+
+use const DIRECTORY_SEPARATOR;
+use const FNM_PATHNAME;
+
+/**
+ * Enforces environment-level, path-level, and concurrency constraints for MCP operations.
+ */
+#[Internal]
+final class McpAccessGate implements McpAccessGateInterface
+{
+    private int $activeActions = 0;
+
+    public function __construct(
+        private readonly McpSecurityConfig $securityConfig,
+        private readonly EnvironmentMode $mode,
+        private readonly Environment $environment,
+        private readonly string $projectRoot,
+    ) {}
+
+    public function assertEnvironmentAllowed(): void
+    {
+        match ($this->mode) {
+            EnvironmentMode::Staging => $this->assertStagingConfirmed(),
+            EnvironmentMode::Production => $this->assertProductionConfirmed(),
+            EnvironmentMode::Local => null,
+        };
+    }
+
+    public function assertPathAllowed(string $path): void
+    {
+        if (str_contains($path, '..')) {
+            throw McpSecurityException::pathNotAllowed($path);
+        }
+
+        $normalizedRoot = $this->normalizePath($this->projectRoot);
+        $absolute = $this->buildAbsolutePath($path, $normalizedRoot);
+
+        if (file_exists($absolute)) {
+            $real = realpath($absolute);
+
+            if ($real === false || !str_starts_with($real, $normalizedRoot)) {
+                throw McpSecurityException::pathNotAllowed($path);
+            }
+
+            $checkPath = $real;
+        } else {
+            $checkPath = $absolute;
+        }
+
+        $this->assertPathMatchesAllowlist($checkPath, $normalizedRoot, $path);
+    }
+
+    public function assertConcurrencyAllowed(): void
+    {
+        if ($this->activeActions >= $this->securityConfig->maxConcurrentActions) {
+            throw McpSecurityException::concurrencyLimited();
+        }
+
+        $this->activeActions++;
+    }
+
+    public function releaseConcurrencySlot(): void
+    {
+        if ($this->activeActions > 0) {
+            $this->activeActions--;
+        }
+    }
+
+    private function assertStagingConfirmed(): void
+    {
+        $confirm = $this->environment->get('MCP_STAGING_CONFIRM');
+
+        if ($confirm !== '1' && $confirm !== 'true') {
+            throw McpSecurityException::environmentBlocked($this->mode->value);
+        }
+    }
+
+    private function assertProductionConfirmed(): void
+    {
+        $confirm = $this->environment->get('MCP_PRODUCTION_CONFIRM');
+
+        if ($confirm !== '1' && $confirm !== 'true') {
+            throw McpSecurityException::environmentBlocked($this->mode->value);
+        }
+    }
+
+    private function buildAbsolutePath(string $path, string $normalizedRoot): string
+    {
+        $normalized = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+        $normalized = ltrim($normalized, DIRECTORY_SEPARATOR);
+
+        return $normalizedRoot . DIRECTORY_SEPARATOR . $normalized;
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $real = realpath($path);
+
+        return $real !== false ? $real : $path;
+    }
+
+    private function assertPathMatchesAllowlist(string $absolute, string $normalizedRoot, string $originalPath): void
+    {
+        $relative = $absolute;
+
+        if (str_starts_with($absolute, $normalizedRoot . DIRECTORY_SEPARATOR)) {
+            $relative = substr($absolute, strlen($normalizedRoot) + 1);
+        }
+
+        foreach ($this->securityConfig->pathAllowlist as $pattern) {
+            if (fnmatch($pattern, $relative, FNM_PATHNAME)) {
+                return;
+            }
+
+            if (fnmatch($pattern, $absolute, FNM_PATHNAME)) {
+                return;
+            }
+        }
+
+        throw McpSecurityException::pathNotAllowed($originalPath);
+    }
+}

--- a/extensions/mcp-server/src/Internal/Security/ParamValidator.php
+++ b/extensions/mcp-server/src/Internal/Security/ParamValidator.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Security;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Exception\McpException;
+
+use function file_exists;
+use function ltrim;
+use function mb_strlen;
+use function preg_match;
+use function realpath;
+use function str_contains;
+use function str_replace;
+use function str_starts_with;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * Validates and sanitizes MCP tool input parameters against strict format constraints.
+ */
+#[Internal]
+final readonly class ParamValidator
+{
+    private const string CLIENT_ID_PATTERN = '/^[A-Za-z0-9_-]{1,64}$/';
+    private const string FILTER_PATTERN = '/^[A-Za-z0-9_:.\\\\-]{1,256}$/';
+    private const int FILTER_MAX_LENGTH = 256;
+
+    public static function validateClientId(string $clientId): string
+    {
+        if (preg_match(self::CLIENT_ID_PATTERN, $clientId) !== 1) {
+            throw McpException::protocolError('Invalid client_id format', -32602);
+        }
+
+        return $clientId;
+    }
+
+    public static function validateFilter(?string $filter): ?string
+    {
+        if ($filter === null) {
+            return null;
+        }
+
+        if (mb_strlen($filter) > self::FILTER_MAX_LENGTH) {
+            throw McpException::protocolError('Filter exceeds maximum length', -32602);
+        }
+
+        if (preg_match(self::FILTER_PATTERN, $filter) !== 1) {
+            throw McpException::protocolError('Filter contains invalid characters', -32602);
+        }
+
+        return $filter;
+    }
+
+    public static function validatePath(?string $path, string $projectRoot): ?string
+    {
+        if ($path === null) {
+            return null;
+        }
+
+        if (str_contains($path, '..')) {
+            throw McpException::protocolError('Path traversal not allowed', -32602);
+        }
+
+        $normalized = str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $path);
+        $absolute = $projectRoot . DIRECTORY_SEPARATOR . ltrim($normalized, DIRECTORY_SEPARATOR);
+
+        if (file_exists($absolute)) {
+            $real = realpath($absolute);
+
+            if ($real === false || !str_starts_with($real, realpath($projectRoot) ?: $projectRoot)) {
+                throw McpException::protocolError('Path escapes project root', -32602);
+            }
+
+            return $real;
+        }
+
+        return $absolute;
+    }
+
+    public static function validateType(string $type): string
+    {
+        if ($type !== 'php' && $type !== 'js') {
+            throw McpException::protocolError('type must be "php" or "js"', -32602);
+        }
+
+        return $type;
+    }
+
+    public static function validateAnalyzer(string $analyzer): string
+    {
+        if ($analyzer !== 'phpstan' && $analyzer !== 'psalm') {
+            throw McpException::protocolError('analyzer must be "phpstan" or "psalm"', -32602);
+        }
+
+        return $analyzer;
+    }
+}

--- a/extensions/mcp-server/src/Internal/Security/ToolPermissionChecker.php
+++ b/extensions/mcp-server/src/Internal/Security/ToolPermissionChecker.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Security;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Config\McpToolsConfig;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Contracts\ToolPermissionCheckerInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+
+use function in_array;
+
+/**
+ * Determines whether a tool invocation is permitted based on tool-level allow/deny lists
+ * and category-based restrictions.
+ *
+ * Read tools are allowed by default unless explicitly disabled.
+ * Action tools must be explicitly listed in the allowed_actions config.
+ */
+#[Internal]
+final readonly class ToolPermissionChecker implements ToolPermissionCheckerInterface
+{
+    public function __construct(
+        private McpToolsConfig $toolsConfig,
+        private McpToolRegistryInterface $registry,
+    ) {}
+
+    public function assertAllowed(string $toolName): void
+    {
+        if (!$this->registry->has($toolName)) {
+            throw McpSecurityException::toolNotAllowed($toolName);
+        }
+
+        $tool = $this->registry->get($toolName);
+
+        if (in_array($toolName, $this->toolsConfig->disabledReadTools, true)) {
+            throw McpSecurityException::toolNotAllowed($toolName);
+        }
+
+        if ($tool->category() === ToolCategory::Action && !in_array($toolName, $this->toolsConfig->allowedActions, true)) {
+            throw McpSecurityException::toolNotAllowed($toolName);
+        }
+    }
+
+    public function isAllowed(string $toolName): bool
+    {
+        try {
+            $this->assertAllowed($toolName);
+
+            return true;
+        } catch (McpSecurityException) {
+            return false;
+        }
+    }
+}

--- a/extensions/mcp-server/src/Internal/Subprocess/SubprocessRunner.php
+++ b/extensions/mcp-server/src/Internal/Subprocess/SubprocessRunner.php
@@ -1,0 +1,178 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Subprocess;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+
+use function array_merge;
+use function fclose;
+use function fread;
+use function getenv;
+use function hrtime;
+use function is_resource;
+use function max;
+use function proc_close;
+use function proc_get_status;
+use function proc_open;
+use function proc_terminate;
+use function stream_set_blocking;
+use function strlen;
+use function substr;
+use function usleep;
+
+/**
+ * Executes external processes with timeout, output capping, and automatic redaction.
+ *
+ * All subprocess output is passed through the redaction pipeline before being
+ * returned, ensuring sensitive data never reaches the MCP wire protocol.
+ */
+#[Internal]
+final class SubprocessRunner
+{
+    /** @var resource|null Track active process for cancellation */
+    private mixed $activeProcess = null;
+
+    /**
+     * @param string $projectRoot Working directory for subprocess execution
+     * @param int $timeout Maximum execution time in seconds
+     * @param int $maxOutputBytes Maximum combined stdout+stderr bytes before truncation
+     * @param McpRedactionPipelineInterface $redactionPipeline Pipeline for redacting sensitive output
+     */
+    public function __construct(
+        private readonly string $projectRoot,
+        private readonly int $timeout,
+        private readonly int $maxOutputBytes,
+        private readonly McpRedactionPipelineInterface $redactionPipeline,
+    ) {}
+
+    /**
+     * Run a subprocess command with timeout and output capping.
+     *
+     * @param list<string> $command Command and arguments (array form for proc_open)
+     * @param array<string, string> $env Additional environment variables
+     */
+    public function run(array $command, array $env = []): ToolResult
+    {
+        $descriptors = [
+            0 => ['pipe', 'r'],
+            1 => ['pipe', 'w'],
+            2 => ['pipe', 'w'],
+        ];
+
+        /** @var array<string, string> $osEnv */
+        $osEnv = getenv();
+        $mergedEnv = array_merge($osEnv, ['CI' => '1'], $env);
+
+        $process = proc_open($command, $descriptors, $pipes, $this->projectRoot, $mergedEnv);
+
+        if (!is_resource($process)) {
+            return ToolResult::error('Failed to start subprocess');
+        }
+
+        $this->activeProcess = $process;
+
+        fclose($pipes[0]);
+
+        stream_set_blocking($pipes[1], false);
+        stream_set_blocking($pipes[2], false);
+
+        $stdout = '';
+        $stderr = '';
+        $timedOut = false;
+        $startTime = hrtime(true);
+        $deadline = $startTime + ($this->timeout * 1_000_000_000);
+
+        while (true) {
+            $status = proc_get_status($process);
+            $nowNs = hrtime(true);
+
+            if ($nowNs >= $deadline) {
+                $timedOut = true;
+                proc_terminate($process, 15);
+
+                break;
+            }
+
+            $chunk1 = fread($pipes[1], 8192);
+            $chunk2 = fread($pipes[2], 8192);
+
+            if ($chunk1 !== false && $chunk1 !== '') {
+                $stdout .= $chunk1;
+            }
+
+            if ($chunk2 !== false && $chunk2 !== '') {
+                $stderr .= $chunk2;
+            }
+
+            if (!$status['running']) {
+                break;
+            }
+
+            if (strlen($stdout) + strlen($stderr) > $this->maxOutputBytes) {
+                break;
+            }
+
+            usleep(10_000);
+        }
+
+        fclose($pipes[1]);
+        fclose($pipes[2]);
+
+        $exitCode = proc_close($process);
+        $this->activeProcess = null;
+
+        $totalBytes = strlen($stdout) + strlen($stderr);
+        $truncated = false;
+
+        if ($totalBytes > $this->maxOutputBytes) {
+            $truncated = true;
+            $stdout = substr($stdout, 0, $this->maxOutputBytes);
+            $stderr = substr($stderr, 0, max(0, $this->maxOutputBytes - strlen($stdout)));
+        }
+
+        $stdout = $this->redactionPipeline->redactString($stdout);
+        $stderr = $this->redactionPipeline->redactString($stderr);
+
+        $structured = [
+            'exitCode' => $timedOut ? -1 : $exitCode,
+            'stdout' => $stdout,
+            'stderr' => $stderr,
+            'timedOut' => $timedOut,
+            'wasCancelled' => false,
+            'truncated' => $truncated,
+        ];
+
+        $text = $stdout !== '' ? $stdout : $stderr;
+
+        if ($timedOut) {
+            return ToolResult::error('Process timed out after ' . $this->timeout . 's', ['timedOut' => true]);
+        }
+
+        if ($truncated) {
+            return ToolResult::truncated($structured, $text, $totalBytes, strlen($stdout) + strlen($stderr));
+        }
+
+        return new ToolResult(
+            structuredContent: $structured,
+            textContent: $text,
+            isError: $exitCode !== 0,
+            meta: [],
+        );
+    }
+
+    /**
+     * Best-effort cancellation of the active subprocess.
+     *
+     * Used by the notifications/cancelled handler to terminate a running process.
+     */
+    public function cancel(): void
+    {
+        if ($this->activeProcess !== null && is_resource($this->activeProcess)) {
+            proc_terminate($this->activeProcess, 15);
+        }
+    }
+}

--- a/extensions/mcp-server/src/Internal/Subprocess/SubprocessRunner.php
+++ b/extensions/mcp-server/src/Internal/Subprocess/SubprocessRunner.php
@@ -13,7 +13,6 @@ use function fclose;
 use function fread;
 use function getenv;
 use function hrtime;
-use function is_resource;
 use function max;
 use function proc_close;
 use function proc_get_status;
@@ -33,8 +32,7 @@ use function usleep;
 #[Internal]
 final class SubprocessRunner
 {
-    /** @var resource|null Track active process for cancellation */
-    private mixed $activeProcess = null;
+    private bool $cancelled = false;
 
     /**
      * @param string $projectRoot Working directory for subprocess execution
@@ -73,7 +71,7 @@ final class SubprocessRunner
             return ToolResult::error('Failed to start subprocess');
         }
 
-        $this->activeProcess = $process;
+        $this->cancelled = false;
 
         fclose($pipes[0]);
 
@@ -90,9 +88,15 @@ final class SubprocessRunner
             $status = proc_get_status($process);
             $nowNs = hrtime(true);
 
+            if ($this->cancelled) {
+                proc_terminate($process);
+
+                break;
+            }
+
             if ($nowNs >= $deadline) {
                 $timedOut = true;
-                proc_terminate($process, 15);
+                proc_terminate($process);
 
                 break;
             }
@@ -123,7 +127,6 @@ final class SubprocessRunner
         fclose($pipes[2]);
 
         $exitCode = proc_close($process);
-        $this->activeProcess = null;
 
         $totalBytes = strlen($stdout) + strlen($stderr);
         $truncated = false;
@@ -142,7 +145,7 @@ final class SubprocessRunner
             'stdout' => $stdout,
             'stderr' => $stderr,
             'timedOut' => $timedOut,
-            'wasCancelled' => false,
+            'wasCancelled' => $this->cancelled,
             'truncated' => $truncated,
         ];
 
@@ -171,8 +174,6 @@ final class SubprocessRunner
      */
     public function cancel(): void
     {
-        if ($this->activeProcess !== null && is_resource($this->activeProcess)) {
-            proc_terminate($this->activeProcess, 15);
-        }
+        $this->cancelled = true;
     }
 }

--- a/extensions/mcp-server/src/Internal/Tools/ReadApiSnapshotTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadApiSnapshotTool.php
@@ -1,0 +1,123 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function array_slice;
+use function array_values;
+use function count;
+use function is_string;
+use function json_encode;
+use function str_starts_with;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Introspection\ProjectMetadataService;
+
+use const JSON_THROW_ON_ERROR;
+
+#[Internal]
+final readonly class ReadApiSnapshotTool implements McpToolInterface
+{
+    public function __construct(
+        private ProjectMetadataService $metadataService,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.api.snapshot';
+    }
+
+    public function description(): string
+    {
+        return 'Returns the public API snapshot (classes marked with #[Api])';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'class' => ['type' => 'string', 'description' => 'Filter by exact class name'],
+                'namespacePrefix' => ['type' => 'string', 'description' => 'Filter by namespace prefix'],
+                'cursor' => ['type' => 'string', 'description' => 'Pagination cursor'],
+                'limit' => ['type' => 'integer', 'description' => 'Maximum results (default 100)'],
+            ],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'classes' => ['type' => 'object'],
+                'totalCount' => ['type' => 'integer'],
+                'nextCursor' => ['type' => ['string', 'null']],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Read;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $snapshot = $this->metadataService->snapshot();
+        $classes = $snapshot->apiSnapshot->classes;
+
+        // Filter by exact class name
+        $classFilter = $params['class'] ?? null;
+        if (is_string($classFilter) && $classFilter !== '') {
+            $classes = isset($classes[$classFilter])
+                ? [$classFilter => $classes[$classFilter]]
+                : [];
+        }
+
+        // Filter by namespace prefix
+        $nsPrefix = $params['namespacePrefix'] ?? null;
+        if (is_string($nsPrefix) && $nsPrefix !== '') {
+            $classes = array_filter(
+                $classes,
+                static fn(string $fqcn): bool => str_starts_with($fqcn, $nsPrefix),
+                ARRAY_FILTER_USE_KEY,
+            );
+        }
+
+        // Pagination
+        $limit = (int) ($params['limit'] ?? 100);
+        $cursor = $params['cursor'] ?? null;
+        $allKeys = array_keys($classes);
+        $totalCount = count($allKeys);
+
+        $offset = 0;
+        if (is_string($cursor) && $cursor !== '') {
+            $pos = array_search($cursor, $allKeys, true);
+            $offset = $pos !== false ? (int) $pos : 0;
+        }
+
+        $pageKeys = array_slice($allKeys, $offset, $limit);
+        $pageClasses = [];
+        foreach ($pageKeys as $key) {
+            $pageClasses[$key] = $classes[$key];
+        }
+
+        $nextCursor = ($offset + $limit < $totalCount) ? $allKeys[$offset + $limit] : null;
+
+        $structured = [
+            'classes' => $pageClasses,
+            'totalCount' => $totalCount,
+            'nextCursor' => $nextCursor,
+        ];
+
+        return ToolResult::success(
+            $structured,
+            json_encode($structured, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/ReadApiSnapshotTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadApiSnapshotTool.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Pulsar\Extension\McpServer\Internal\Tools;
 
 use function array_slice;
-use function array_values;
 use function count;
 use function is_string;
 use function json_encode;

--- a/extensions/mcp-server/src/Internal/Tools/ReadArchitectureMapTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadArchitectureMapTool.php
@@ -7,6 +7,8 @@ namespace Pulsar\Extension\McpServer\Internal\Tools;
 use function json_encode;
 
 use Pulsar\Api\Internal;
+
+use stdClass;
 use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
 use Pulsar\Extension\McpServer\Domain\ToolCategory;
 use Pulsar\Extension\McpServer\Domain\ToolResult;
@@ -35,7 +37,7 @@ final readonly class ReadArchitectureMapTool implements McpToolInterface
     {
         return [
             'type' => 'object',
-            'properties' => new \stdClass(),
+            'properties' => new stdClass(),
         ];
     }
 

--- a/extensions/mcp-server/src/Internal/Tools/ReadArchitectureMapTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadArchitectureMapTool.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function json_encode;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Introspection\ProjectMetadataService;
+
+use const JSON_THROW_ON_ERROR;
+
+#[Internal]
+final readonly class ReadArchitectureMapTool implements McpToolInterface
+{
+    public function __construct(
+        private ProjectMetadataService $metadataService,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.architecture.map';
+    }
+
+    public function description(): string
+    {
+        return 'Returns the architecture map: registered extensions and container bindings';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => new \stdClass(),
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'extensions' => ['type' => 'array'],
+                'bindings' => ['type' => 'array'],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Read;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $snapshot = $this->metadataService->snapshot();
+        $structured = $snapshot->architectureMap->toArray();
+
+        return ToolResult::success(
+            $structured,
+            json_encode($structured, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/ReadCommandsTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadCommandsTool.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function array_filter;
+use function array_map;
+use function array_slice;
+use function array_values;
+use function count;
+use function is_string;
+use function json_encode;
+use function str_starts_with;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Introspection\ProjectMetadataService;
+
+use const JSON_THROW_ON_ERROR;
+
+#[Internal]
+final readonly class ReadCommandsTool implements McpToolInterface
+{
+    public function __construct(
+        private ProjectMetadataService $metadataService,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.commands.list';
+    }
+
+    public function description(): string
+    {
+        return 'List all registered console commands with arguments and options';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'namespace' => ['type' => 'string', 'description' => 'Filter by command namespace (e.g. make)'],
+                'cursor' => ['type' => 'string', 'description' => 'Pagination cursor'],
+                'limit' => ['type' => 'integer', 'description' => 'Maximum results (default 100)'],
+            ],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'commands' => ['type' => 'array'],
+                'totalCount' => ['type' => 'integer'],
+                'nextCursor' => ['type' => ['string', 'null']],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Read;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $snapshot = $this->metadataService->snapshot();
+        $commands = $snapshot->commandReference->commands;
+
+        // Filter by namespace
+        $nsFilter = $params['namespace'] ?? null;
+        if (is_string($nsFilter) && $nsFilter !== '') {
+            $prefix = $nsFilter . ':';
+            $commands = array_filter(
+                $commands,
+                static fn($c): bool => str_starts_with($c->name, $prefix),
+            );
+            $commands = array_values($commands);
+        }
+
+        // Pagination
+        $limit = (int) ($params['limit'] ?? 100);
+        $totalCount = count($commands);
+        $cursor = $params['cursor'] ?? null;
+        $offset = is_string($cursor) && $cursor !== '' ? (int) $cursor : 0;
+
+        $page = array_slice($commands, $offset, $limit);
+        $nextCursor = ($offset + $limit < $totalCount) ? (string) ($offset + $limit) : null;
+
+        $structured = [
+            'commands' => array_map(static fn($c): array => $c->toArray(), $page),
+            'totalCount' => $totalCount,
+            'nextCursor' => $nextCursor,
+        ];
+
+        return ToolResult::success(
+            $structured,
+            json_encode($structured, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/ReadConfigSchemaTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadConfigSchemaTool.php
@@ -1,0 +1,86 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function is_string;
+use function json_encode;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Introspection\ProjectMetadataService;
+
+use const JSON_THROW_ON_ERROR;
+
+#[Internal]
+final readonly class ReadConfigSchemaTool implements McpToolInterface
+{
+    public function __construct(
+        private ProjectMetadataService $metadataService,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.config.schema';
+    }
+
+    public function description(): string
+    {
+        return 'Returns config DTO schemas (property names, types, scrubbed defaults)';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'name' => ['type' => 'string', 'description' => 'Filter by config class name'],
+            ],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'schemas' => ['type' => 'array'],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Read;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $snapshot = $this->metadataService->snapshot();
+        $schemas = $snapshot->configSchema->schemas;
+
+        $nameFilter = $params['name'] ?? null;
+        if (is_string($nameFilter) && $nameFilter !== '') {
+            $schemas = array_filter(
+                $schemas,
+                static fn($entry): bool => str_contains($entry->className, $nameFilter),
+            );
+            $schemas = array_values($schemas);
+        }
+
+        $structured = [
+            'schemas' => array_map(
+                static fn($e): array => $e->toArray(),
+                $schemas,
+            ),
+        ];
+
+        return ToolResult::success(
+            $structured,
+            json_encode($structured, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/ReadContainerBindingsTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadContainerBindingsTool.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function array_filter;
+use function array_slice;
+use function array_values;
+use function count;
+use function is_string;
+use function json_encode;
+use function str_contains;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Introspection\ProjectMetadataService;
+
+use const JSON_THROW_ON_ERROR;
+
+#[Internal]
+final readonly class ReadContainerBindingsTool implements McpToolInterface
+{
+    public function __construct(
+        private ProjectMetadataService $metadataService,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.container.bindings';
+    }
+
+    public function description(): string
+    {
+        return 'Returns container binding keys (FQCN-like patterns only)';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'filter' => ['type' => 'string', 'description' => 'Substring match filter'],
+                'cursor' => ['type' => 'string', 'description' => 'Pagination cursor'],
+                'limit' => ['type' => 'integer', 'description' => 'Maximum results (default 100)'],
+            ],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'bindings' => ['type' => 'array'],
+                'totalCount' => ['type' => 'integer'],
+                'nextCursor' => ['type' => ['string', 'null']],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Read;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $snapshot = $this->metadataService->snapshot();
+        $bindings = $snapshot->architectureMap->bindings;
+
+        // Filter by substring
+        $filter = $params['filter'] ?? null;
+        if (is_string($filter) && $filter !== '') {
+            $bindings = array_filter(
+                $bindings,
+                static fn(string $b): bool => str_contains($b, $filter),
+            );
+            $bindings = array_values($bindings);
+        }
+
+        // Pagination
+        $limit = (int) ($params['limit'] ?? 100);
+        $totalCount = count($bindings);
+        $cursor = $params['cursor'] ?? null;
+        $offset = is_string($cursor) && $cursor !== '' ? (int) $cursor : 0;
+
+        $page = array_slice($bindings, $offset, $limit);
+        $nextCursor = ($offset + $limit < $totalCount) ? (string) ($offset + $limit) : null;
+
+        $structured = [
+            'bindings' => $page,
+            'totalCount' => $totalCount,
+            'nextCursor' => $nextCursor,
+        ];
+
+        return ToolResult::success(
+            $structured,
+            json_encode($structured, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/ReadRoutesTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/ReadRoutesTool.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function array_filter;
+use function array_map;
+use function array_slice;
+use function array_values;
+use function count;
+use function in_array;
+use function is_string;
+use function json_encode;
+use function str_contains;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Introspection\ProjectMetadataService;
+
+use const JSON_THROW_ON_ERROR;
+
+#[Internal]
+final readonly class ReadRoutesTool implements McpToolInterface
+{
+    public function __construct(
+        private ProjectMetadataService $metadataService,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.routes.list';
+    }
+
+    public function description(): string
+    {
+        return 'List all registered routes with method, path, handler, and middleware';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'method' => ['type' => 'string', 'description' => 'Filter by HTTP method (e.g. GET)'],
+                'path' => ['type' => 'string', 'description' => 'Filter by path substring'],
+                'cursor' => ['type' => 'string', 'description' => 'Pagination cursor'],
+                'limit' => ['type' => 'integer', 'description' => 'Maximum results (default 100)'],
+            ],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'routes' => ['type' => 'array'],
+                'totalCount' => ['type' => 'integer'],
+                'nextCursor' => ['type' => ['string', 'null']],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Read;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $snapshot = $this->metadataService->snapshot();
+        $routes = $snapshot->routeMap->routes;
+
+        // Filter by method
+        $methodFilter = $params['method'] ?? null;
+        if (is_string($methodFilter) && $methodFilter !== '') {
+            $methodUpper = strtoupper($methodFilter);
+            $routes = array_filter(
+                $routes,
+                static fn($r): bool => in_array($methodUpper, $r->methods, true),
+            );
+            $routes = array_values($routes);
+        }
+
+        // Filter by path
+        $pathFilter = $params['path'] ?? null;
+        if (is_string($pathFilter) && $pathFilter !== '') {
+            $routes = array_filter(
+                $routes,
+                static fn($r): bool => str_contains($r->path, $pathFilter),
+            );
+            $routes = array_values($routes);
+        }
+
+        // Pagination
+        $limit = (int) ($params['limit'] ?? 100);
+        $totalCount = count($routes);
+        $cursor = $params['cursor'] ?? null;
+        $offset = is_string($cursor) && $cursor !== '' ? (int) $cursor : 0;
+
+        $page = array_slice($routes, $offset, $limit);
+        $nextCursor = ($offset + $limit < $totalCount) ? (string) ($offset + $limit) : null;
+
+        $structured = [
+            'routes' => array_map(static fn($r): array => $r->toArray(), $page),
+            'totalCount' => $totalCount,
+            'nextCursor' => $nextCursor,
+        ];
+
+        return ToolResult::success(
+            $structured,
+            json_encode($structured, JSON_THROW_ON_ERROR),
+        );
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/RunAnalysisTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/RunAnalysisTool.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Internal\Security\ParamValidator;
+use Pulsar\Extension\McpServer\Internal\Subprocess\SubprocessRunner;
+
+#[Internal]
+final readonly class RunAnalysisTool implements McpToolInterface
+{
+    public function __construct(
+        private SubprocessRunner $runner,
+        private McpAccessGateInterface $accessGate,
+        private string $composerBinary,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.analysis.run';
+    }
+
+    public function description(): string
+    {
+        return 'Run static analysis (PHPStan or Psalm)';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'analyzer' => [
+                    'type' => 'string',
+                    'enum' => ['phpstan', 'psalm'],
+                    'description' => 'Which analyzer to run',
+                ],
+            ],
+            'required' => ['analyzer'],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'exitCode' => ['type' => 'integer'],
+                'stdout' => ['type' => 'string'],
+                'stderr' => ['type' => 'string'],
+                'timedOut' => ['type' => 'boolean'],
+                'wasCancelled' => ['type' => 'boolean'],
+                'truncated' => ['type' => 'boolean'],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Action;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $analyzer = ParamValidator::validateAnalyzer((string) ($params['analyzer'] ?? ''));
+
+        $this->accessGate->assertConcurrencyAllowed();
+
+        try {
+            $command = [$this->composerBinary, $analyzer, '--no-interaction', '--no-ansi'];
+
+            return $this->runner->run($command);
+        } finally {
+            $this->accessGate->releaseConcurrencySlot();
+        }
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/RunFormatterTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/RunFormatterTool.php
@@ -1,0 +1,104 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function is_string;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Internal\Security\ParamValidator;
+use Pulsar\Extension\McpServer\Internal\Subprocess\SubprocessRunner;
+
+#[Internal]
+final readonly class RunFormatterTool implements McpToolInterface
+{
+    public function __construct(
+        private SubprocessRunner $runner,
+        private McpAccessGateInterface $accessGate,
+        private string $composerBinary,
+        private string $pnpmBinary,
+        private string $projectRoot,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.formatter.run';
+    }
+
+    public function description(): string
+    {
+        return 'Run code formatters (PHP-CS-Fixer or Prettier)';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'type' => [
+                    'type' => 'string',
+                    'enum' => ['php', 'js'],
+                    'description' => 'Formatter type: php (PHP-CS-Fixer) or js (Prettier)',
+                ],
+                'path' => ['type' => 'string', 'description' => 'Optional path to format'],
+            ],
+            'required' => ['type'],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'exitCode' => ['type' => 'integer'],
+                'stdout' => ['type' => 'string'],
+                'stderr' => ['type' => 'string'],
+                'timedOut' => ['type' => 'boolean'],
+                'wasCancelled' => ['type' => 'boolean'],
+                'truncated' => ['type' => 'boolean'],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Action;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $type = ParamValidator::validateType((string) ($params['type'] ?? ''));
+
+        $this->accessGate->assertConcurrencyAllowed();
+
+        try {
+            $command = match ($type) {
+                'php' => [$this->composerBinary, 'cs:fix', '--no-interaction', '--no-ansi'],
+                'js' => [$this->pnpmBinary, 'format:fix'],
+            };
+
+            // Validate and handle optional path for PHP formatter
+            $path = $params['path'] ?? null;
+            if ($type === 'php' && is_string($path) && $path !== '') {
+                $validated = ParamValidator::validatePath($path, $this->projectRoot);
+
+                if ($validated !== null) {
+                    $this->accessGate->assertPathAllowed($path);
+                    // PHP-CS-Fixer accepts path via --path-mode=override and positional arg
+                    $command[] = '--';
+                    $command[] = $validated;
+                }
+            }
+
+            return $this->runner->run($command);
+        } finally {
+            $this->accessGate->releaseConcurrencySlot();
+        }
+    }
+}

--- a/extensions/mcp-server/src/Internal/Tools/RunTestsTool.php
+++ b/extensions/mcp-server/src/Internal/Tools/RunTestsTool.php
@@ -1,0 +1,99 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer\Internal\Tools;
+
+use function is_string;
+
+use Pulsar\Api\Internal;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Internal\Security\ParamValidator;
+use Pulsar\Extension\McpServer\Internal\Subprocess\SubprocessRunner;
+
+#[Internal]
+final readonly class RunTestsTool implements McpToolInterface
+{
+    public function __construct(
+        private SubprocessRunner $runner,
+        private McpAccessGateInterface $accessGate,
+        private string $phpunitBinary,
+        private string $projectRoot,
+    ) {}
+
+    public function name(): string
+    {
+        return 'pulsar.tests.run';
+    }
+
+    public function description(): string
+    {
+        return 'Run PHPUnit tests with the project configuration';
+    }
+
+    public function inputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'filter' => ['type' => 'string', 'description' => 'Test name filter (--filter)'],
+                'path' => ['type' => 'string', 'description' => 'Test file or directory path'],
+            ],
+        ];
+    }
+
+    public function outputSchema(): array
+    {
+        return [
+            'type' => 'object',
+            'properties' => [
+                'exitCode' => ['type' => 'integer'],
+                'stdout' => ['type' => 'string'],
+                'stderr' => ['type' => 'string'],
+                'timedOut' => ['type' => 'boolean'],
+                'wasCancelled' => ['type' => 'boolean'],
+                'truncated' => ['type' => 'boolean'],
+            ],
+        ];
+    }
+
+    public function category(): ToolCategory
+    {
+        return ToolCategory::Action;
+    }
+
+    public function execute(array $params): ToolResult
+    {
+        $this->accessGate->assertConcurrencyAllowed();
+
+        try {
+            $command = [$this->phpunitBinary, '-c', 'tools/php/phpunit.xml', '--no-interaction'];
+
+            // Validate and append filter
+            $filter = $params['filter'] ?? null;
+            if (is_string($filter) && $filter !== '') {
+                $filter = ParamValidator::validateFilter($filter);
+                $command[] = '--filter';
+                $command[] = $filter;
+            }
+
+            // Validate and append path
+            $path = $params['path'] ?? null;
+            if (is_string($path) && $path !== '') {
+                $validated = ParamValidator::validatePath($path, $this->projectRoot);
+
+                if ($validated !== null) {
+                    $this->accessGate->assertPathAllowed($path);
+                    $command[] = $validated;
+                }
+            }
+
+            return $this->runner->run($command);
+        } finally {
+            $this->accessGate->releaseConcurrencySlot();
+        }
+    }
+}

--- a/extensions/mcp-server/src/McpServerExtension.php
+++ b/extensions/mcp-server/src/McpServerExtension.php
@@ -7,11 +7,12 @@ namespace Pulsar\Extension\McpServer;
 use function is_array;
 use function is_file;
 
+use function dirname;
+use function getcwd;
+
 use Pulsar\Audit\AuditLoggerInterface;
 use Pulsar\Config\AppConfig;
 use Pulsar\Config\ConfigManagerInterface;
-use Pulsar\Config\Environment;
-use Pulsar\Config\EnvironmentMode;
 use Pulsar\Container\ContainerInterface;
 use Pulsar\Extension\McpServer\Config\McpConfig;
 use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
@@ -90,7 +91,7 @@ final class McpServerExtension implements ExtensionInterface, PreBootExtensionIn
         // Environment gating
         $projectRoot = $config->projectRoot !== ''
             ? $config->projectRoot
-            : ($configPath !== null ? \dirname($configPath) : (\getcwd() ?: '.'));
+            : ($configPath !== null ? dirname($configPath) : (getcwd() ?: '.'));
 
         // Build security infrastructure
         $scrubber = $container->has(SensitiveDataScrubber::class)
@@ -164,7 +165,6 @@ final class McpServerExtension implements ExtensionInterface, PreBootExtensionIn
         $messageHandler = new MessageHandler(
             registry: $registry,
             permissionChecker: $permissionChecker,
-            accessGate: $accessGate,
             redactionPipeline: $redactionPipeline,
             auditLogger: $auditLogger,
             rateLimiter: $rateLimiter,

--- a/extensions/mcp-server/src/McpServerExtension.php
+++ b/extensions/mcp-server/src/McpServerExtension.php
@@ -1,0 +1,190 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer;
+
+use function is_array;
+use function is_file;
+
+use Pulsar\Audit\AuditLoggerInterface;
+use Pulsar\Config\AppConfig;
+use Pulsar\Config\ConfigManagerInterface;
+use Pulsar\Config\Environment;
+use Pulsar\Config\EnvironmentMode;
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extension\McpServer\Config\McpConfig;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Contracts\ToolPermissionCheckerInterface;
+use Pulsar\Extension\McpServer\Internal\McpToolRegistry;
+use Pulsar\Extension\McpServer\Internal\Protocol\MessageHandler;
+use Pulsar\Extension\McpServer\Internal\Protocol\StdioTransport;
+use Pulsar\Extension\McpServer\Internal\Redaction\McpRedactionPipeline;
+use Pulsar\Extension\McpServer\Internal\Security\McpAccessGate;
+use Pulsar\Extension\McpServer\Internal\Security\ToolPermissionChecker;
+use Pulsar\Extension\McpServer\Internal\Subprocess\SubprocessRunner;
+use Pulsar\Extension\McpServer\Internal\Tools\ReadApiSnapshotTool;
+use Pulsar\Extension\McpServer\Internal\Tools\ReadArchitectureMapTool;
+use Pulsar\Extension\McpServer\Internal\Tools\ReadCommandsTool;
+use Pulsar\Extension\McpServer\Internal\Tools\ReadConfigSchemaTool;
+use Pulsar\Extension\McpServer\Internal\Tools\ReadContainerBindingsTool;
+use Pulsar\Extension\McpServer\Internal\Tools\ReadRoutesTool;
+use Pulsar\Extension\McpServer\Internal\Tools\RunAnalysisTool;
+use Pulsar\Extension\McpServer\Internal\Tools\RunFormatterTool;
+use Pulsar\Extension\McpServer\Internal\Tools\RunTestsTool;
+use Pulsar\Extensibility\ExtensionInterface;
+use Pulsar\Extensibility\PreBootExtensionInterface;
+use Pulsar\Http\RateLimit\RateLimiterInterface;
+use Pulsar\Introspection\ProjectMetadataService;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use Pulsar\Routing\RouterInterface;
+
+use const DIRECTORY_SEPARATOR;
+
+/**
+ * MCP server extension — exposes project metadata and developer tools
+ * to AI assistants via the Model Context Protocol (JSON-RPC 2.0 over stdio).
+ */
+final class McpServerExtension implements ExtensionInterface, PreBootExtensionInterface
+{
+    public function name(): string
+    {
+        return 'pulsar/mcp-server';
+    }
+
+    public function register(ContainerInterface $container): void
+    {
+        // Registration deferred to preBoot after config is loaded
+    }
+
+    public function preBoot(ContainerInterface $container): void
+    {
+        /** @var ConfigManagerInterface $configManager */
+        $configManager = $container->get(ConfigManagerInterface::class);
+        $environment = $configManager->environment();
+        $configPath = $configManager->configPath();
+
+        // Load MCP config
+        $configData = [];
+        if ($configPath !== null && is_file($configPath . DIRECTORY_SEPARATOR . 'mcp.php')) {
+            /** @psalm-suppress UnresolvableInclude */
+            $loaded = require $configPath . DIRECTORY_SEPARATOR . 'mcp.php';
+            if (is_array($loaded)) {
+                /** @var array<string, mixed> $loaded */
+                $configData = $loaded;
+            }
+        }
+
+        $config = McpConfig::fromArray($configData, $environment);
+        $container->instance(McpConfig::class, $config);
+
+        if (!$config->enabled) {
+            return;
+        }
+
+        /** @var AppConfig $appConfig */
+        $appConfig = $configManager->repository()->get(AppConfig::class);
+
+        // Environment gating
+        $projectRoot = $config->projectRoot !== ''
+            ? $config->projectRoot
+            : ($configPath !== null ? \dirname($configPath) : (\getcwd() ?: '.'));
+
+        // Build security infrastructure
+        $scrubber = $container->has(SensitiveDataScrubber::class)
+            ? $container->get(SensitiveDataScrubber::class)
+            : new SensitiveDataScrubber();
+        /** @var SensitiveDataScrubber $scrubber */
+
+        $knownSecrets = McpRedactionPipeline::collectKnownSecrets($environment);
+        $redactionPipeline = new McpRedactionPipeline($scrubber, $knownSecrets);
+        $container->instance(McpRedactionPipelineInterface::class, $redactionPipeline);
+
+        $accessGate = new McpAccessGate(
+            securityConfig: $config->security,
+            mode: $appConfig->mode,
+            environment: $environment,
+            projectRoot: $projectRoot,
+        );
+        $container->instance(McpAccessGateInterface::class, $accessGate);
+
+        // Build tool registry
+        $registry = new McpToolRegistry();
+
+        // Register read tools (if ProjectMetadataService is available)
+        if ($container->has(ProjectMetadataService::class)) {
+            /** @var ProjectMetadataService $metadataService */
+            $metadataService = $container->get(ProjectMetadataService::class);
+
+            $registry->register(new ReadApiSnapshotTool($metadataService));
+            $registry->register(new ReadArchitectureMapTool($metadataService));
+            $registry->register(new ReadConfigSchemaTool($metadataService));
+            $registry->register(new ReadRoutesTool($metadataService));
+            $registry->register(new ReadCommandsTool($metadataService));
+            $registry->register(new ReadContainerBindingsTool($metadataService));
+        }
+
+        // Register action tools
+        $subprocessRunner = new SubprocessRunner(
+            projectRoot: $projectRoot,
+            timeout: $config->tools->actionTimeout,
+            maxOutputBytes: $config->tools->maxOutputBytes,
+            redactionPipeline: $redactionPipeline,
+        );
+
+        $phpunitBin = $config->tools->commands['phpunit'] ?? $projectRoot . DIRECTORY_SEPARATOR . 'vendor' . DIRECTORY_SEPARATOR . 'bin' . DIRECTORY_SEPARATOR . 'phpunit';
+        $composerBin = $config->tools->commands['composer'] ?? 'composer';
+        $pnpmBin = $config->tools->commands['pnpm'] ?? 'pnpm';
+
+        $registry->register(new RunTestsTool($subprocessRunner, $accessGate, $phpunitBin, $projectRoot));
+        $registry->register(new RunFormatterTool($subprocessRunner, $accessGate, $composerBin, $pnpmBin, $projectRoot));
+        $registry->register(new RunAnalysisTool($subprocessRunner, $accessGate, $composerBin));
+
+        $container->instance(McpToolRegistryInterface::class, $registry);
+
+        // Permission checker
+        $permissionChecker = new ToolPermissionChecker($config->tools, $registry);
+        $container->instance(ToolPermissionCheckerInterface::class, $permissionChecker);
+
+        // Rate limiter (optional)
+        $rateLimiter = $container->has(RateLimiterInterface::class)
+            ? $container->get(RateLimiterInterface::class)
+            : null;
+        /** @var RateLimiterInterface|null $rateLimiter */
+
+        // Audit logger (optional)
+        $auditLogger = $container->has(AuditLoggerInterface::class)
+            ? $container->get(AuditLoggerInterface::class)
+            : null;
+        /** @var AuditLoggerInterface|null $auditLogger */
+
+        // Message handler
+        $messageHandler = new MessageHandler(
+            registry: $registry,
+            permissionChecker: $permissionChecker,
+            accessGate: $accessGate,
+            redactionPipeline: $redactionPipeline,
+            auditLogger: $auditLogger,
+            rateLimiter: $rateLimiter,
+            config: $config,
+            scrubber: $scrubber,
+        );
+        $container->instance(MessageHandler::class, $messageHandler);
+
+        // Stdio transport
+        $transport = new StdioTransport();
+        $container->instance(StdioTransport::class, $transport);
+    }
+
+    public function boot(ContainerInterface $container, RouterInterface $router): void
+    {
+        // MCP uses stdio transport — no HTTP routes
+    }
+
+    public function providers(): array
+    {
+        return [McpServerServiceProvider::class];
+    }
+}

--- a/extensions/mcp-server/src/McpServerServiceProvider.php
+++ b/extensions/mcp-server/src/McpServerServiceProvider.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Extension\McpServer;
+
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Internal\Protocol\MessageHandler;
+use Pulsar\Extension\McpServer\Internal\Protocol\StdioTransport;
+use Pulsar\Extensibility\ServiceProviderInterface;
+
+/**
+ * Service provider advertising MCP server bindings.
+ */
+final readonly class McpServerServiceProvider implements ServiceProviderInterface
+{
+    public function register(ContainerInterface $container): void
+    {
+        // Bindings are created in McpServerExtension::preBoot()
+        // This provider exists to advertise the service IDs.
+    }
+
+    public function provides(): array
+    {
+        return [
+            McpToolRegistryInterface::class,
+            MessageHandler::class,
+            StdioTransport::class,
+        ];
+    }
+}

--- a/extensions/psr7-bridge/src/Middleware/Psr15MiddlewareAdapter.php
+++ b/extensions/psr7-bridge/src/Middleware/Psr15MiddlewareAdapter.php
@@ -56,9 +56,9 @@ final readonly class Psr15MiddlewareAdapter implements PulsarMiddlewareInterface
              * @param callable(Request): Response $next
              */
             public function __construct(
-                private readonly mixed $next,
-                private readonly Psr7ToPulsarRequest $toPulsarRequest,
-                private readonly PulsarToPsr7Response $toPsr7Response,
+                private mixed $next,
+                private Psr7ToPulsarRequest $toPulsarRequest,
+                private PulsarToPsr7Response $toPsr7Response,
             ) {}
 
             public function handle(ServerRequestInterface $request): ResponseInterface

--- a/qodana.yaml
+++ b/qodana.yaml
@@ -61,6 +61,8 @@ exclude:
       - extensions/payments/src/Internal/Infrastructure/Webhook/HmacWebhookVerifier.php
       # DTO fromArray() factories share structural deserialization pattern across Context/Event
       - src/Context/RequestContext.php
+      # MCP read tools share pagination logic intentionally — each tool filters differently
+      - extensions/mcp-server/src/Internal/Tools/ReadCommandsTool.php
   # Same parameter value — auditPayment() is designed for reuse across payment
   # operations; currently only cancel_intent calls it, but capture/refund will follow.
   - name: PhpSameParameterValueInspection
@@ -76,3 +78,5 @@ exclude:
       - composer.json
       - extensions/example/composer.json
       - extensions/payments/composer.json
+      - extensions/mcp-server/composer.json
+      - extensions/social-sso/composer.json

--- a/src/Config/QueueConfig.php
+++ b/src/Config/QueueConfig.php
@@ -22,7 +22,7 @@ readonly class QueueConfig
         public QueueDriverType $driver = QueueDriverType::Sync,
         public string $defaultQueue = 'default',
         public int $workerMaxJobs = 1000,
-        public int $workerMaxMemoryMb = 128,
+        public int $workerMaxMemoryMb = 256,
         public int $workerTimeLimitSeconds = 3600,
         public int $workerSleepMs = 1000,
         public int $retryMaxAttempts = 3,
@@ -59,7 +59,7 @@ readonly class QueueConfig
         $dlData = $data['dead_letter'] ?? [];
 
         $rawMaxJobs = $workerData['max_jobs'] ?? 1000;
-        $rawMaxMemory = $workerData['max_memory_mb'] ?? 128;
+        $rawMaxMemory = $workerData['max_memory_mb'] ?? 256;
         $rawTimeLimit = $workerData['time_limit_seconds'] ?? 3600;
         $rawSleep = $workerData['sleep_ms'] ?? 1000;
         $rawMaxAttempts = $retryData['max_attempts'] ?? 3;
@@ -73,7 +73,7 @@ readonly class QueueConfig
             driver: $driver,
             defaultQueue: $defaultQueue,
             workerMaxJobs: is_int($rawMaxJobs) ? $rawMaxJobs : 1000,
-            workerMaxMemoryMb: is_int($rawMaxMemory) ? $rawMaxMemory : 128,
+            workerMaxMemoryMb: is_int($rawMaxMemory) ? $rawMaxMemory : 256,
             workerTimeLimitSeconds: is_int($rawTimeLimit) ? $rawTimeLimit : 3600,
             workerSleepMs: is_int($rawSleep) ? $rawSleep : 1000,
             retryMaxAttempts: is_int($rawMaxAttempts) ? $rawMaxAttempts : 3,

--- a/src/Console/Command/MetadataExportCommand.php
+++ b/src/Console/Command/MetadataExportCommand.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Console\Command;
+
+use function in_array;
+use function is_string;
+use function json_encode;
+
+use const JSON_PRETTY_PRINT;
+use const JSON_THROW_ON_ERROR;
+use const JSON_UNESCAPED_SLASHES;
+
+use Override;
+use Pulsar\Console\Command;
+use Pulsar\Console\ExitCode;
+use Pulsar\Console\InputInterface;
+use Pulsar\Console\OutputInterface;
+use Pulsar\Introspection\ProjectMetadataService;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+/**
+ * Exports project metadata as JSON to stdout.
+ *
+ * Applies SensitiveDataScrubber to all output. Warnings are written to stderr.
+ */
+final class MetadataExportCommand extends Command
+{
+    private const array VALID_SECTIONS = [
+        'all',
+        'api',
+        'architecture',
+        'config-schema',
+        'commands',
+        'routes',
+    ];
+
+    public function __construct(
+        private readonly ProjectMetadataService $metadataService,
+        private readonly SensitiveDataScrubber $scrubber,
+    ) {
+        parent::__construct();
+    }
+
+    #[Override]
+    protected function configure(): void
+    {
+        $this->name = 'metadata:export';
+        $this->description = 'Export project metadata as JSON';
+
+        $this->addOption(
+            'section',
+            'Which section to export (api|architecture|config-schema|commands|routes|all)',
+            's',
+            'all',
+        );
+        $this->addOption(
+            'pretty',
+            'Pretty-print the JSON output',
+        );
+    }
+
+    #[Override]
+    public function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $sectionRaw = $input->getOption('section');
+        $section = is_string($sectionRaw) ? $sectionRaw : 'all';
+        $pretty = $input->hasOption('pretty');
+
+        if (!in_array($section, self::VALID_SECTIONS, true)) {
+            $output->errorln('Invalid section: ' . $section);
+            $output->errorln('Valid sections: ' . implode(', ', self::VALID_SECTIONS));
+
+            return ExitCode::Invalid->value;
+        }
+
+        $snapshot = $this->metadataService->snapshot();
+        $data = $this->extractSection($snapshot->toArray(), $section);
+
+        // Final scrub pass
+        /** @var array<string, mixed> $data */
+        $scrubbed = $this->scrubber->scrub($data);
+
+        $flags = JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES;
+
+        if ($pretty) {
+            $flags |= JSON_PRETTY_PRINT;
+        }
+
+        $json = json_encode($scrubbed, $flags);
+        $output->writeln($json);
+
+        // Write warnings to stderr
+        if ($snapshot->warnings !== []) {
+            foreach ($snapshot->warnings as $warning) {
+                $output->errorln('[warning] ' . $warning);
+            }
+        }
+
+        return ExitCode::Success->value;
+    }
+
+    /**
+     * Extract the requested section from the full snapshot array.
+     *
+     * @param array<string, mixed> $snapshotArray
+     *
+     * @return array<string, mixed>
+     */
+    private function extractSection(array $snapshotArray, string $section): array
+    {
+        return match ($section) {
+            'api' => ['api_snapshot' => $snapshotArray['api_snapshot'] ?? []],
+            'architecture' => ['architecture_map' => $snapshotArray['architecture_map'] ?? []],
+            'config-schema' => ['config_schema' => $snapshotArray['config_schema'] ?? []],
+            'commands' => ['command_reference' => $snapshotArray['command_reference'] ?? []],
+            'routes' => ['route_map' => $snapshotArray['route_map'] ?? []],
+            default => $snapshotArray,
+        };
+    }
+}

--- a/src/Core/Kernel.php
+++ b/src/Core/Kernel.php
@@ -30,6 +30,7 @@ use Pulsar\Core\Wiring\ErrorTrackingWiring;
 use Pulsar\Core\Wiring\ExceptionHandlerWiring;
 use Pulsar\Core\Wiring\FeatureFlagWiring;
 use Pulsar\Core\Wiring\IntegrityWiring;
+use Pulsar\Core\Wiring\IntrospectionWiring;
 use Pulsar\Core\Wiring\LoggingWiring;
 use Pulsar\Core\Wiring\MetricsWiring;
 use Pulsar\Core\Wiring\QueueWiring;
@@ -231,6 +232,7 @@ final class Kernel implements KernelInterface
                 new DeployWiring(),
                 new RuntimeWiring(),
                 new DiagnosticsWiring(),
+                new IntrospectionWiring(),
             ];
 
             foreach ($wirings as $wiring) {

--- a/src/Core/Wiring/IntrospectionWiring.php
+++ b/src/Core/Wiring/IntrospectionWiring.php
@@ -4,6 +4,8 @@ declare(strict_types=1);
 
 namespace Pulsar\Core\Wiring;
 
+use Closure;
+
 use const DIRECTORY_SEPARATOR;
 
 use function dirname;
@@ -16,10 +18,13 @@ use Pulsar\Api\Internal;
 use Pulsar\Config\AppConfig;
 use Pulsar\Config\ConfigManager;
 use Pulsar\Console\Application;
+use Pulsar\Console\Command;
 use Pulsar\Container\ContainerInterface;
 use Pulsar\Extensibility\ExtensionRegistry;
 use Pulsar\Http\Middleware\MiddlewarePipeline;
 use Pulsar\Http\Middleware\MiddlewareRegistry;
+use Pulsar\Introspection\Data\CommandEntry;
+use Pulsar\Introspection\Data\ExtensionEntry;
 use Pulsar\Introspection\Internal\ConfigSchemaReflector;
 use Pulsar\Introspection\Internal\CoreRuntimeProbe;
 use Pulsar\Introspection\Internal\SnapshotFileReader;
@@ -28,6 +33,7 @@ use Pulsar\Introspection\ProjectMetadataService;
 use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
 use Pulsar\Routing\Router;
 use Pulsar\Routing\RouterInterface;
+use Throwable;
 
 /**
  * Wires the Introspection module into the kernel boot pipeline.
@@ -75,27 +81,25 @@ final readonly class IntrospectionWiring implements ServiceWiringInterface
             : new SensitiveDataScrubber();
         /** @var SensitiveDataScrubber $scrubber */
 
-        // CoreRuntimeProbe
-        $extensionRegistry = $container->has(ExtensionRegistry::class)
-            ? $container->get(ExtensionRegistry::class)
+        // CoreRuntimeProbe — closures decouple from #[Internal] cross-module types
+        $extensionProber = $container->has(ExtensionRegistry::class)
+            ? $this->buildExtensionProber($container)
             : null;
-        /** @var ExtensionRegistry|null $extensionRegistry */
 
         $routerInterface = $container->has(RouterInterface::class)
             ? $container->get(RouterInterface::class)
             : $router;
         /** @var RouterInterface $routerInterface */
 
-        $consoleApp = $container->has(Application::class)
-            ? $container->get(Application::class)
+        $commandProber = $container->has(Application::class)
+            ? $this->buildCommandProber($container)
             : null;
-        /** @var Application|null $consoleApp */
 
         $probe = new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: $extensionRegistry,
+            extensionProber: $extensionProber,
             router: $routerInterface,
-            consoleApplication: $consoleApp,
+            commandProber: $commandProber,
         );
 
         // ConfigSchemaReflector
@@ -123,6 +127,89 @@ final readonly class IntrospectionWiring implements ServiceWiringInterface
         );
 
         $container->instance(ProjectMetadataService::class, $service);
+    }
+
+    /**
+     * Build a closure that extracts extension entries from the registry.
+     * The closure captures ExtensionRegistry (an #[Internal] type) so that
+     * CoreRuntimeProbe does not need to import it directly.
+     *
+     * @return Closure(): list<ExtensionEntry>
+     */
+    private function buildExtensionProber(ContainerInterface $container): Closure
+    {
+        return static function () use ($container): array {
+            /** @var ExtensionRegistry $registry */
+            $registry = $container->get(ExtensionRegistry::class);
+            $extensions = $registry->all();
+            $manifests = $registry->allManifests();
+            $entries = [];
+
+            foreach ($extensions as $name => $_extension) {
+                $manifest = $manifests[$name] ?? null;
+                $state = 'unknown';
+
+                try {
+                    $state = $registry->getState($name)->value;
+                } catch (Throwable) {
+                    // Swallow — state unavailable
+                }
+
+                $provides = [];
+                $dependencies = [];
+
+                if ($manifest !== null) {
+                    $provides = $manifest->provides->services;
+                    $dependencies = $manifest->getDependencies();
+                }
+
+                $entries[] = new ExtensionEntry(
+                    name: $name,
+                    version: $manifest->version ?? 'unknown',
+                    state: $state,
+                    provides: $provides,
+                    dependencies: $dependencies,
+                );
+            }
+
+            return $entries;
+        };
+    }
+
+    /**
+     * Build a closure that extracts command entries from the console application.
+     * The closure captures Application (an #[Internal] type) so that
+     * CoreRuntimeProbe does not need to import it directly.
+     *
+     * @return Closure(): list<CommandEntry>
+     */
+    private function buildCommandProber(ContainerInterface $container): Closure
+    {
+        return static function () use ($container): array {
+            /** @var Application $app */
+            $app = $container->get(Application::class);
+            $commands = $app->all();
+            $entries = [];
+
+            foreach ($commands as $command) {
+                $arguments = [];
+                $options = [];
+
+                if ($command instanceof Command) {
+                    $arguments = $command->arguments;
+                    $options = $command->options;
+                }
+
+                $entries[] = new CommandEntry(
+                    name: $command->name,
+                    description: $command->description,
+                    arguments: $arguments,
+                    options: $options,
+                );
+            }
+
+            return $entries;
+        };
     }
 
     /**

--- a/src/Core/Wiring/IntrospectionWiring.php
+++ b/src/Core/Wiring/IntrospectionWiring.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Core\Wiring;
+
+use const DIRECTORY_SEPARATOR;
+
+use function dirname;
+use function is_array;
+use function is_file;
+use function is_object;
+use function is_string;
+
+use Pulsar\Api\Internal;
+use Pulsar\Config\AppConfig;
+use Pulsar\Config\ConfigManager;
+use Pulsar\Console\Application;
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ExtensionRegistry;
+use Pulsar\Http\Middleware\MiddlewarePipeline;
+use Pulsar\Http\Middleware\MiddlewareRegistry;
+use Pulsar\Introspection\Internal\ConfigSchemaReflector;
+use Pulsar\Introspection\Internal\CoreRuntimeProbe;
+use Pulsar\Introspection\Internal\SnapshotFileReader;
+use Pulsar\Introspection\IntrospectionConfig;
+use Pulsar\Introspection\ProjectMetadataService;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use Pulsar\Routing\Router;
+use Pulsar\Routing\RouterInterface;
+
+/**
+ * Wires the Introspection module into the kernel boot pipeline.
+ */
+#[Internal]
+final readonly class IntrospectionWiring implements ServiceWiringInterface
+{
+    public function wire(
+        ContainerInterface $container,
+        ConfigManager $configManager,
+        MiddlewarePipeline $middleware,
+        MiddlewareRegistry $middlewareRegistry,
+        Router $router,
+    ): void {
+        $repository = $configManager->repository();
+        $environment = $configManager->environment();
+
+        /** @var AppConfig $appConfig */
+        $appConfig = $repository->get(AppConfig::class);
+
+        // Load introspection config
+        $configPath = $configManager->configPath();
+        $configData = [];
+
+        if ($configPath !== null && is_file($configPath . DIRECTORY_SEPARATOR . 'introspection.php')) {
+            /** @psalm-suppress UnresolvableInclude */
+            $loaded = require $configPath . DIRECTORY_SEPARATOR . 'introspection.php';
+
+            if (is_array($loaded)) {
+                /** @var array<string, mixed> $loaded */
+                $configData = $loaded;
+            }
+        }
+
+        $config = IntrospectionConfig::fromArray($configData, $environment, $appConfig->mode);
+        $container->instance(IntrospectionConfig::class, $config);
+
+        if (!$config->enabled) {
+            return;
+        }
+
+        // SensitiveDataScrubber (reuse if available, otherwise create)
+        $scrubber = $container->has(SensitiveDataScrubber::class)
+            ? $container->get(SensitiveDataScrubber::class)
+            : new SensitiveDataScrubber();
+        /** @var SensitiveDataScrubber $scrubber */
+
+        // CoreRuntimeProbe
+        $extensionRegistry = $container->has(ExtensionRegistry::class)
+            ? $container->get(ExtensionRegistry::class)
+            : null;
+        /** @var ExtensionRegistry|null $extensionRegistry */
+
+        $routerInterface = $container->has(RouterInterface::class)
+            ? $container->get(RouterInterface::class)
+            : $router;
+        /** @var RouterInterface $routerInterface */
+
+        $consoleApp = $container->has(Application::class)
+            ? $container->get(Application::class)
+            : null;
+        /** @var Application|null $consoleApp */
+
+        $probe = new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: $extensionRegistry,
+            router: $routerInterface,
+            consoleApplication: $consoleApp,
+        );
+
+        // ConfigSchemaReflector
+        $schemaReflector = new ConfigSchemaReflector($scrubber);
+
+        // SnapshotFileReader
+        $configPath = $configManager->configPath();
+        $projectRoot = $configPath !== null
+            ? dirname($configPath)
+            : (getcwd() ?: '.');
+        $snapshotReader = new SnapshotFileReader($projectRoot);
+
+        // Collect known config DTO classes
+        /** @var list<class-string> $configClasses */
+        $configClasses = $this->discoverConfigClasses($repository);
+
+        // ProjectMetadataService
+        $service = new ProjectMetadataService(
+            probe: $probe,
+            schemaReflector: $schemaReflector,
+            snapshotReader: $snapshotReader,
+            scrubber: $scrubber,
+            contributors: [],
+            configClasses: $configClasses,
+        );
+
+        $container->instance(ProjectMetadataService::class, $service);
+    }
+
+    /**
+     * Discover registered config DTO class names from the repository.
+     *
+     * @return list<class-string>
+     */
+    private function discoverConfigClasses(mixed $repository): array
+    {
+        // The repository stores configs keyed by class name
+        if (!is_object($repository) || !method_exists($repository, 'all')) {
+            return [];
+        }
+
+        /** @var array<string, mixed> $all */
+        $all = $repository->all();
+
+        $classes = [];
+
+        foreach (array_keys($all) as $key) {
+            if (is_string($key) && class_exists($key)) {
+                /** @var class-string $key */
+                $classes[] = $key;
+            }
+        }
+
+        return $classes;
+    }
+}

--- a/src/Http/Middleware/MiddlewarePipeline.php
+++ b/src/Http/Middleware/MiddlewarePipeline.php
@@ -50,7 +50,7 @@ final class MiddlewarePipeline implements MiddlewarePipelineInterface
      *
      * @param MiddlewareInterface|class-string<MiddlewareInterface> $middleware
      */
-    public function pipe(MiddlewareInterface|string $middleware): self
+    public function pipe(MiddlewareInterface|string $middleware): static
     {
         $this->middleware[] = $middleware;
         $this->resolvedMiddleware = null; // Invalidate cache

--- a/src/Introspection/Data/ApiSnapshotData.php
+++ b/src/Introspection/Data/ApiSnapshotData.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use Pulsar\Api\Api;
+
+/**
+ * Snapshot of the public API surface for the current application.
+ *
+ * Each class entry includes its API version, exposed methods, and constants.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ApiSnapshotData
+{
+    /**
+     * @param array<string, array{since: string, methods: list<string>, constants: list<string>}> $classes
+     */
+    public function __construct(
+        public array $classes = [],
+    ) {}
+
+    /**
+     * @return array{classes: array<string, array{since: string, methods: list<string>, constants: list<string>}>}
+     */
+    public function toArray(): array
+    {
+        return ['classes' => $this->classes];
+    }
+}

--- a/src/Introspection/Data/ArchitectureMapData.php
+++ b/src/Introspection/Data/ArchitectureMapData.php
@@ -1,0 +1,39 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use function array_map;
+
+use Pulsar\Api\Api;
+
+/**
+ * High-level architecture map: registered extensions and container bindings.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ArchitectureMapData
+{
+    /**
+     * @param list<ExtensionEntry> $extensions
+     * @param list<string>         $bindings
+     */
+    public function __construct(
+        public array $extensions = [],
+        public array $bindings = [],
+    ) {}
+
+    /**
+     * @return array{extensions: list<array{name: string, version: string, state: string, provides: list<string>, dependencies: list<string>}>, bindings: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'extensions' => array_map(
+                static fn(ExtensionEntry $e): array => $e->toArray(),
+                $this->extensions,
+            ),
+            'bindings' => $this->bindings,
+        ];
+    }
+}

--- a/src/Introspection/Data/CommandEntry.php
+++ b/src/Introspection/Data/CommandEntry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use Pulsar\Api\Api;
+
+/**
+ * Describes a single CLI command and its signature (arguments + options).
+ */
+#[Api(since: '1.0.0')]
+final readonly class CommandEntry
+{
+    /**
+     * @param list<array{name: string, description: string, required: bool}>                    $arguments
+     * @param array<string, array{description: string, shortcut: string|null, default: mixed}> $options
+     */
+    public function __construct(
+        public string $name,
+        public string $description,
+        public array $arguments = [],
+        public array $options = [],
+    ) {}
+
+    /**
+     * @return array{name: string, description: string, arguments: list<array{name: string, description: string, required: bool}>, options: array<string, array{description: string, shortcut: string|null, default: mixed}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'description' => $this->description,
+            'arguments' => $this->arguments,
+            'options' => $this->options,
+        ];
+    }
+}

--- a/src/Introspection/Data/CommandReferenceData.php
+++ b/src/Introspection/Data/CommandReferenceData.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use function array_map;
+
+use Pulsar\Api\Api;
+
+/**
+ * Complete CLI command reference for the application.
+ */
+#[Api(since: '1.0.0')]
+final readonly class CommandReferenceData
+{
+    /**
+     * @param list<CommandEntry> $commands
+     */
+    public function __construct(
+        public array $commands = [],
+    ) {}
+
+    /**
+     * @return array{commands: list<array{name: string, description: string, arguments: list<array{name: string, description: string, required: bool}>, options: array<string, array{description: string, shortcut: string|null, default: mixed}>}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'commands' => array_map(
+                static fn(CommandEntry $c): array => $c->toArray(),
+                $this->commands,
+            ),
+        ];
+    }
+}

--- a/src/Introspection/Data/ConfigPropertySchema.php
+++ b/src/Introspection/Data/ConfigPropertySchema.php
@@ -1,0 +1,32 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use Pulsar\Api\Api;
+
+/**
+ * Schema for a single configuration property (name, type, and default value).
+ */
+#[Api(since: '1.0.0')]
+final readonly class ConfigPropertySchema
+{
+    public function __construct(
+        public string $name,
+        public string $type,
+        public mixed $default = null,
+    ) {}
+
+    /**
+     * @return array{name: string, type: string, default: mixed}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'type' => $this->type,
+            'default' => $this->default,
+        ];
+    }
+}

--- a/src/Introspection/Data/ConfigSchemaData.php
+++ b/src/Introspection/Data/ConfigSchemaData.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use function array_map;
+
+use Pulsar\Api\Api;
+
+/**
+ * Aggregated configuration schema for all registered config DTOs.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ConfigSchemaData
+{
+    /**
+     * @param list<ConfigSchemaEntry> $schemas
+     */
+    public function __construct(
+        public array $schemas = [],
+    ) {}
+
+    /**
+     * @return array{schemas: list<array{class: string, properties: list<array{name: string, type: string, default: mixed}>}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'schemas' => array_map(
+                static fn(ConfigSchemaEntry $e): array => $e->toArray(),
+                $this->schemas,
+            ),
+        ];
+    }
+}

--- a/src/Introspection/Data/ConfigSchemaEntry.php
+++ b/src/Introspection/Data/ConfigSchemaEntry.php
@@ -1,0 +1,38 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use function array_map;
+
+use Pulsar\Api\Api;
+
+/**
+ * Schema for a single configuration DTO class and its properties.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ConfigSchemaEntry
+{
+    /**
+     * @param list<ConfigPropertySchema> $properties
+     */
+    public function __construct(
+        public string $className,
+        public array $properties = [],
+    ) {}
+
+    /**
+     * @return array{class: string, properties: list<array{name: string, type: string, default: mixed}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'class' => $this->className,
+            'properties' => array_map(
+                static fn(ConfigPropertySchema $p): array => $p->toArray(),
+                $this->properties,
+            ),
+        ];
+    }
+}

--- a/src/Introspection/Data/ContributedMetadata.php
+++ b/src/Introspection/Data/ContributedMetadata.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use Pulsar\Api\Api;
+
+/**
+ * Metadata contributed by a single MetadataContributorInterface implementation.
+ *
+ * Each contributor produces named sections of key-value data. The size in bytes
+ * is tracked to enforce per-contributor resource limits.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ContributedMetadata
+{
+    /**
+     * @param array<string, array<string, mixed>> $sections
+     */
+    public function __construct(
+        public string $contributorId,
+        public array $sections,
+        private int $sizeBytes,
+    ) {}
+
+    public function sizeBytes(): int
+    {
+        return $this->sizeBytes;
+    }
+
+    /**
+     * @return array{contributor_id: string, sections: array<string, array<string, mixed>>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'contributor_id' => $this->contributorId,
+            'sections' => $this->sections,
+        ];
+    }
+}

--- a/src/Introspection/Data/ExtensionEntry.php
+++ b/src/Introspection/Data/ExtensionEntry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use Pulsar\Api\Api;
+
+/**
+ * Describes a registered extension and its lifecycle state.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ExtensionEntry
+{
+    /**
+     * @param list<string> $provides
+     * @param list<string> $dependencies
+     */
+    public function __construct(
+        public string $name,
+        public string $version,
+        public string $state,
+        public array $provides = [],
+        public array $dependencies = [],
+    ) {}
+
+    /**
+     * @return array{name: string, version: string, state: string, provides: list<string>, dependencies: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'name' => $this->name,
+            'version' => $this->version,
+            'state' => $this->state,
+            'provides' => $this->provides,
+            'dependencies' => $this->dependencies,
+        ];
+    }
+}

--- a/src/Introspection/Data/RouteEntry.php
+++ b/src/Introspection/Data/RouteEntry.php
@@ -1,0 +1,40 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use Pulsar\Api\Api;
+
+/**
+ * Describes a single registered route (methods, path, handler, middleware).
+ */
+#[Api(since: '1.0.0')]
+final readonly class RouteEntry
+{
+    /**
+     * @param list<string> $methods
+     * @param list<string> $middleware
+     */
+    public function __construct(
+        public array $methods,
+        public string $path,
+        public string $handler,
+        public ?string $name = null,
+        public array $middleware = [],
+    ) {}
+
+    /**
+     * @return array{methods: list<string>, path: string, handler: string, name: string|null, middleware: list<string>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'methods' => $this->methods,
+            'path' => $this->path,
+            'handler' => $this->handler,
+            'name' => $this->name,
+            'middleware' => $this->middleware,
+        ];
+    }
+}

--- a/src/Introspection/Data/RouteMapData.php
+++ b/src/Introspection/Data/RouteMapData.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Data;
+
+use function array_map;
+
+use Pulsar\Api\Api;
+
+/**
+ * Complete route map for the application.
+ */
+#[Api(since: '1.0.0')]
+final readonly class RouteMapData
+{
+    /**
+     * @param list<RouteEntry> $routes
+     */
+    public function __construct(
+        public array $routes = [],
+    ) {}
+
+    /**
+     * @return array{routes: list<array{methods: list<string>, path: string, handler: string, name: string|null, middleware: list<string>}>}
+     */
+    public function toArray(): array
+    {
+        return [
+            'routes' => array_map(
+                static fn(RouteEntry $r): array => $r->toArray(),
+                $this->routes,
+            ),
+        ];
+    }
+}

--- a/src/Introspection/Internal/ConfigSchemaReflector.php
+++ b/src/Introspection/Internal/ConfigSchemaReflector.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Internal;
+
+use function is_object;
+
+use Pulsar\Api\Internal;
+use Pulsar\Introspection\Data\ConfigPropertySchema;
+use Pulsar\Introspection\Data\ConfigSchemaData;
+use Pulsar\Introspection\Data\ConfigSchemaEntry;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use ReflectionClass;
+use ReflectionNamedType;
+use ReflectionProperty;
+use Throwable;
+
+/**
+ * Reflects on config DTO classes to extract property schemas.
+ *
+ * Extracts property names, declared types, and default values.
+ * Sensitive-named properties have their defaults scrubbed.
+ * Does NOT instantiate DTOs or read environment variables.
+ */
+#[Internal]
+final readonly class ConfigSchemaReflector
+{
+    public function __construct(
+        private SensitiveDataScrubber $scrubber,
+    ) {}
+
+    /**
+     * Reflect on the given config DTO classes and extract schemas.
+     *
+     * @param list<class-string> $configClasses
+     * @param list<string>       $warnings
+     */
+    public function reflect(array $configClasses, array &$warnings): ConfigSchemaData
+    {
+        $entries = [];
+
+        foreach ($configClasses as $className) {
+            try {
+                $entry = $this->reflectClass($className);
+
+                if ($entry !== null) {
+                    $entries[] = $entry;
+                }
+            } catch (Throwable $e) {
+                $warnings[] = 'Failed to reflect config class ' . $className . ': ' . $e->getMessage();
+            }
+        }
+
+        return new ConfigSchemaData(schemas: $entries);
+    }
+
+    private function reflectClass(string $className): ?ConfigSchemaEntry
+    {
+        if (!class_exists($className)) {
+            return null;
+        }
+
+        $reflection = new ReflectionClass($className);
+        $properties = [];
+
+        foreach ($reflection->getProperties(ReflectionProperty::IS_PUBLIC) as $property) {
+            $type = $property->getType();
+            $typeName = $type instanceof ReflectionNamedType ? $type->getName() : 'mixed';
+
+            if ($type instanceof ReflectionNamedType && $type->allowsNull()) {
+                $typeName = '?' . $typeName;
+            }
+
+            $default = $this->extractDefault($property);
+
+            // Scrub sensitive defaults
+            $scrubbed = $this->scrubber->scrub([$property->getName() => $default]);
+            $scrubbedDefault = $scrubbed[$property->getName()];
+
+            $properties[] = new ConfigPropertySchema(
+                name: $property->getName(),
+                type: $typeName,
+                default: $scrubbedDefault,
+            );
+        }
+
+        return new ConfigSchemaEntry(
+            className: $className,
+            properties: $properties,
+        );
+    }
+
+    private function extractDefault(ReflectionProperty $property): mixed
+    {
+        if ($property->hasDefaultValue()) {
+            $default = $property->getDefaultValue();
+
+            // If default is an object (e.g., nested config DTO via `new`), represent as class name
+            if (is_object($default)) {
+                return $default::class;
+            }
+
+            return $default;
+        }
+
+        if ($property->isPromoted()) {
+            // Promoted properties — check constructor parameters
+            $constructor = $property->getDeclaringClass()->getConstructor();
+
+            if ($constructor !== null) {
+                foreach ($constructor->getParameters() as $param) {
+                    if ($param->getName() === $property->getName() && $param->isDefaultValueAvailable()) {
+                        $default = $param->getDefaultValue();
+
+                        if (is_object($default)) {
+                            return $default::class;
+                        }
+
+                        return $default;
+                    }
+                }
+            }
+        }
+
+        return null;
+    }
+}

--- a/src/Introspection/Internal/CoreRuntimeProbe.php
+++ b/src/Introspection/Internal/CoreRuntimeProbe.php
@@ -1,0 +1,248 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Internal;
+
+use function array_map;
+use function array_values;
+
+use Closure;
+
+use function is_array;
+use function is_string;
+use function preg_match;
+
+use Pulsar\Api\Internal;
+use Pulsar\Console\Application;
+use Pulsar\Console\Command;
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ExtensionRegistry;
+use Pulsar\Http\Method;
+use Pulsar\Introspection\Data\ArchitectureMapData;
+use Pulsar\Introspection\Data\CommandEntry;
+use Pulsar\Introspection\Data\CommandReferenceData;
+use Pulsar\Introspection\Data\ExtensionEntry;
+use Pulsar\Introspection\Data\RouteEntry;
+use Pulsar\Introspection\Data\RouteMapData;
+use Pulsar\Routing\Route;
+use Pulsar\Routing\RouterInterface;
+use Throwable;
+
+/**
+ * Crawls Container, ExtensionRegistry, Router, and Console Application
+ * to gather runtime-dependent metadata.
+ *
+ * Only exposes FQCN-like binding keys, route handler class::method
+ * references, and extension names/versions — never config values,
+ * secrets, or absolute file paths.
+ */
+#[Internal]
+final readonly class CoreRuntimeProbe
+{
+    /** Matches FQCN-like binding keys only (no service locator keys like db.password). */
+    private const string FQCN_PATTERN = '~^\\\\?[A-Za-z_][A-Za-z0-9_]*(?:\\\\[A-Za-z_][A-Za-z0-9_]*)*$~';
+
+    public function __construct(
+        private ContainerInterface $container,
+        private ?ExtensionRegistry $extensionRegistry,
+        private ?RouterInterface $router,
+        private ?Application $consoleApplication,
+    ) {}
+
+    /**
+     * Probe the architecture map: extensions + FQCN-only bindings.
+     *
+     * @param list<string> $warnings Accumulated warnings (by reference)
+     */
+    public function probeArchitecture(array &$warnings): ArchitectureMapData
+    {
+        $extensions = $this->probeExtensions($warnings);
+        $bindings = $this->probeBindings($warnings);
+
+        return new ArchitectureMapData(
+            extensions: $extensions,
+            bindings: $bindings,
+        );
+    }
+
+    /**
+     * Probe the route map.
+     *
+     * @param list<string> $warnings
+     */
+    public function probeRoutes(array &$warnings): RouteMapData
+    {
+        if ($this->router === null) {
+            $warnings[] = 'Router not available — route map is empty.';
+
+            return new RouteMapData();
+        }
+
+        try {
+            $routes = $this->router->routes();
+        } catch (Throwable $e) {
+            $warnings[] = 'Failed to probe routes: ' . $e->getMessage();
+
+            return new RouteMapData();
+        }
+
+        $entries = array_map(
+            static fn(Route $route): RouteEntry => new RouteEntry(
+                methods: array_map(
+                    static fn(Method $m): string => $m->value,
+                    $route->methods,
+                ),
+                path: $route->path,
+                handler: self::formatHandler($route->handler),
+                name: $route->name,
+                middleware: $route->middleware,
+            ),
+            $routes,
+        );
+
+        return new RouteMapData(routes: $entries);
+    }
+
+    /**
+     * Probe the command reference.
+     *
+     * @param list<string> $warnings
+     */
+    public function probeCommands(array &$warnings): CommandReferenceData
+    {
+        if ($this->consoleApplication === null) {
+            $warnings[] = 'Console Application not available — command reference is empty.';
+
+            return new CommandReferenceData();
+        }
+
+        try {
+            $commands = $this->consoleApplication->all();
+        } catch (Throwable $e) {
+            $warnings[] = 'Failed to probe commands: ' . $e->getMessage();
+
+            return new CommandReferenceData();
+        }
+
+        $entries = [];
+
+        foreach ($commands as $command) {
+            $arguments = [];
+            $options = [];
+
+            if ($command instanceof Command) {
+                $arguments = $command->arguments;
+                $options = $command->options;
+            }
+
+            $entries[] = new CommandEntry(
+                name: $command->name,
+                description: $command->description,
+                arguments: $arguments,
+                options: $options,
+            );
+        }
+
+        return new CommandReferenceData(commands: $entries);
+    }
+
+    /**
+     * @param list<string> $warnings
+     *
+     * @return list<ExtensionEntry>
+     */
+    private function probeExtensions(array &$warnings): array
+    {
+        if ($this->extensionRegistry === null) {
+            $warnings[] = 'ExtensionRegistry not available — extension list is empty.';
+
+            return [];
+        }
+
+        try {
+            $extensions = $this->extensionRegistry->all();
+            $manifests = $this->extensionRegistry->allManifests();
+        } catch (Throwable $e) {
+            $warnings[] = 'Failed to probe extensions: ' . $e->getMessage();
+
+            return [];
+        }
+
+        $entries = [];
+
+        foreach ($extensions as $name => $extension) {
+            $manifest = $manifests[$name] ?? null;
+            $state = 'unknown';
+
+            try {
+                $state = $this->extensionRegistry->getState($name)->value;
+            } catch (Throwable) {
+                // Swallow — state unavailable
+            }
+
+            $provides = [];
+            $dependencies = [];
+
+            if ($manifest !== null) {
+                $provides = $manifest->provides->services;
+                $dependencies = $manifest->getDependencies();
+            }
+
+            $entries[] = new ExtensionEntry(
+                name: $name,
+                version: $manifest->version ?? 'unknown',
+                state: $state,
+                provides: $provides,
+                dependencies: $dependencies,
+            );
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param list<string> $warnings
+     *
+     * @return list<string>
+     */
+    private function probeBindings(array &$warnings): array
+    {
+        try {
+            $allBindings = $this->container->getBindings();
+        } catch (Throwable $e) {
+            $warnings[] = 'Failed to probe container bindings: ' . $e->getMessage();
+
+            return [];
+        }
+
+        // Filter to FQCN-like keys only — never expose service-locator keys
+        return array_values(
+            array_filter(
+                $allBindings,
+                static fn(string $key): bool => preg_match(self::FQCN_PATTERN, $key) === 1,
+            ),
+        );
+    }
+
+    /**
+     * Format a route handler for safe display: Class::method or string representation.
+     * Never exposes file paths or closure source locations.
+     */
+    private static function formatHandler(mixed $handler): string
+    {
+        if (is_string($handler)) {
+            return $handler;
+        }
+
+        if (is_array($handler) && isset($handler[0], $handler[1]) && is_string($handler[0]) && is_string($handler[1])) {
+            return $handler[0] . '::' . $handler[1];
+        }
+
+        if ($handler instanceof Closure) {
+            return 'Closure';
+        }
+
+        return 'unknown';
+    }
+}

--- a/src/Introspection/Internal/CoreRuntimeProbe.php
+++ b/src/Introspection/Internal/CoreRuntimeProbe.php
@@ -14,10 +14,8 @@ use function is_string;
 use function preg_match;
 
 use Pulsar\Api\Internal;
-use Pulsar\Console\Application;
 use Pulsar\Console\Command;
 use Pulsar\Container\ContainerInterface;
-use Pulsar\Extensibility\ExtensionRegistry;
 use Pulsar\Http\Method;
 use Pulsar\Introspection\Data\ArchitectureMapData;
 use Pulsar\Introspection\Data\CommandEntry;
@@ -36,6 +34,11 @@ use Throwable;
  * Only exposes FQCN-like binding keys, route handler class::method
  * references, and extension names/versions — never config values,
  * secrets, or absolute file paths.
+ *
+ * ExtensionRegistry and Console\Application are #[Internal] in their
+ * modules. To avoid cross-module boundary violations, this probe accepts
+ * closures that extract the data, created in the composition root
+ * (IntrospectionWiring) where cross-module internal access is permitted.
  */
 #[Internal]
 final readonly class CoreRuntimeProbe
@@ -43,11 +46,17 @@ final readonly class CoreRuntimeProbe
     /** Matches FQCN-like binding keys only (no service locator keys like db.password). */
     private const string FQCN_PATTERN = '~^\\\\?[A-Za-z_][A-Za-z0-9_]*(?:\\\\[A-Za-z_][A-Za-z0-9_]*)*$~';
 
+    /**
+     * @param ContainerInterface $container
+     * @param (Closure(): list<ExtensionEntry>)|null $extensionProber Closure that extracts extension entries from the registry
+     * @param RouterInterface|null $router
+     * @param (Closure(): list<CommandEntry>)|null $commandProber Closure that extracts command entries from the console application
+     */
     public function __construct(
         private ContainerInterface $container,
-        private ?ExtensionRegistry $extensionRegistry,
+        private ?Closure $extensionProber,
         private ?RouterInterface $router,
-        private ?Application $consoleApplication,
+        private ?Closure $commandProber,
     ) {}
 
     /**
@@ -111,37 +120,18 @@ final readonly class CoreRuntimeProbe
      */
     public function probeCommands(array &$warnings): CommandReferenceData
     {
-        if ($this->consoleApplication === null) {
+        if ($this->commandProber === null) {
             $warnings[] = 'Console Application not available — command reference is empty.';
 
             return new CommandReferenceData();
         }
 
         try {
-            $commands = $this->consoleApplication->all();
+            $entries = ($this->commandProber)();
         } catch (Throwable $e) {
             $warnings[] = 'Failed to probe commands: ' . $e->getMessage();
 
             return new CommandReferenceData();
-        }
-
-        $entries = [];
-
-        foreach ($commands as $command) {
-            $arguments = [];
-            $options = [];
-
-            if ($command instanceof Command) {
-                $arguments = $command->arguments;
-                $options = $command->options;
-            }
-
-            $entries[] = new CommandEntry(
-                name: $command->name,
-                description: $command->description,
-                arguments: $arguments,
-                options: $options,
-            );
         }
 
         return new CommandReferenceData(commands: $entries);
@@ -154,51 +144,19 @@ final readonly class CoreRuntimeProbe
      */
     private function probeExtensions(array &$warnings): array
     {
-        if ($this->extensionRegistry === null) {
+        if ($this->extensionProber === null) {
             $warnings[] = 'ExtensionRegistry not available — extension list is empty.';
 
             return [];
         }
 
         try {
-            $extensions = $this->extensionRegistry->all();
-            $manifests = $this->extensionRegistry->allManifests();
+            return ($this->extensionProber)();
         } catch (Throwable $e) {
             $warnings[] = 'Failed to probe extensions: ' . $e->getMessage();
 
             return [];
         }
-
-        $entries = [];
-
-        foreach ($extensions as $name => $extension) {
-            $manifest = $manifests[$name] ?? null;
-            $state = 'unknown';
-
-            try {
-                $state = $this->extensionRegistry->getState($name)->value;
-            } catch (Throwable) {
-                // Swallow — state unavailable
-            }
-
-            $provides = [];
-            $dependencies = [];
-
-            if ($manifest !== null) {
-                $provides = $manifest->provides->services;
-                $dependencies = $manifest->getDependencies();
-            }
-
-            $entries[] = new ExtensionEntry(
-                name: $name,
-                version: $manifest->version ?? 'unknown',
-                state: $state,
-                provides: $provides,
-                dependencies: $dependencies,
-            );
-        }
-
-        return $entries;
     }
 
     /**

--- a/src/Introspection/Internal/SnapshotFileReader.php
+++ b/src/Introspection/Internal/SnapshotFileReader.php
@@ -1,0 +1,88 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection\Internal;
+
+use function file_get_contents;
+use function is_array;
+use function is_file;
+use function json_decode;
+
+use const JSON_THROW_ON_ERROR;
+
+use function json_validate;
+
+use JsonException;
+use Pulsar\Api\Internal;
+use Pulsar\Introspection\Data\ApiSnapshotData;
+
+/**
+ * Reads the public API snapshot from tools/api/public-api.snapshot.json.
+ *
+ * If the file is missing or invalid, returns empty data with a warning
+ * rather than throwing an exception — introspection degrades gracefully.
+ */
+#[Internal]
+final readonly class SnapshotFileReader
+{
+    public function __construct(
+        private string $projectRoot,
+    ) {}
+
+    /**
+     * Read and parse the API snapshot file.
+     *
+     * @param list<string> $warnings
+     */
+    public function read(array &$warnings): ApiSnapshotData
+    {
+        $path = $this->projectRoot . '/tools/api/public-api.snapshot.json';
+
+        if (!is_file($path)) {
+            $warnings[] = 'API snapshot file not found at tools/api/public-api.snapshot.json — API snapshot section is empty.';
+
+            return new ApiSnapshotData();
+        }
+
+        $content = file_get_contents($path);
+
+        if ($content === false) {
+            $warnings[] = 'Failed to read API snapshot file — API snapshot section is empty.';
+
+            return new ApiSnapshotData();
+        }
+
+        if (!json_validate($content)) {
+            $warnings[] = 'API snapshot file contains invalid JSON — API snapshot section is empty.';
+
+            return new ApiSnapshotData();
+        }
+
+        try {
+            $data = json_decode($content, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $e) {
+            $warnings[] = 'Failed to decode API snapshot JSON: ' . $e->getMessage();
+
+            return new ApiSnapshotData();
+        }
+
+        if (!is_array($data)) {
+            $warnings[] = 'API snapshot file root is not an object — API snapshot section is empty.';
+
+            return new ApiSnapshotData();
+        }
+
+        /** @var array<string, mixed> $data */
+        $classes = $data['api_classes'] ?? [];
+
+        if (!is_array($classes)) {
+            $warnings[] = 'API snapshot "api_classes" is not an object — API snapshot section is empty.';
+
+            return new ApiSnapshotData();
+        }
+
+        /** @var array<string, array{since: string, methods: list<string>, constants: list<string>}> $classes */
+        return new ApiSnapshotData(classes: $classes);
+    }
+}

--- a/src/Introspection/IntrospectionConfig.php
+++ b/src/Introspection/IntrospectionConfig.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection;
+
+use NoDiscard;
+use Pulsar\Api\Api;
+use Pulsar\Config\Environment;
+use Pulsar\Config\EnvironmentMode;
+
+/**
+ * Configuration DTO for the introspection subsystem.
+ *
+ * Introspection is enabled by default in non-production environments.
+ * The `INTROSPECTION_ENABLED` environment variable takes precedence over
+ * file-based configuration when set.
+ */
+#[Api(since: '1.0.0')]
+final readonly class IntrospectionConfig
+{
+    public function __construct(
+        public bool $enabled = true,
+    ) {}
+
+    /**
+     * Build from raw config array, environment variables, and environment mode.
+     *
+     * Resolution order:
+     *   1. `INTROSPECTION_ENABLED` env var (if set)
+     *   2. `$data['enabled']` from config file
+     *   3. Default: enabled in local/staging, disabled in production
+     *
+     * @param array<string, mixed> $data
+     */
+    #[NoDiscard]
+    public static function fromArray(array $data, Environment $environment, EnvironmentMode $mode): self
+    {
+        $defaultEnabled = $mode !== EnvironmentMode::Production;
+
+        $envOverride = $environment->get('INTROSPECTION_ENABLED');
+        $enabled = $envOverride !== null
+            ? $envOverride === 'true'
+            : (bool) ($data['enabled'] ?? $defaultEnabled);
+
+        return new self(enabled: $enabled);
+    }
+}

--- a/src/Introspection/MetadataContributorInterface.php
+++ b/src/Introspection/MetadataContributorInterface.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection;
+
+use Pulsar\Api\Api;
+
+/**
+ * Contract for components that contribute metadata to the introspection snapshot.
+ *
+ * Extensions and framework subsystems implement this interface to expose
+ * runtime information (bindings, configuration, state) to the introspection
+ * layer. Each contributor is identified by a unique string ID and populates
+ * a scoped {@see ProjectMetadataBuilder}.
+ */
+#[Api(since: '1.0.0')]
+interface MetadataContributorInterface
+{
+    /**
+     * Unique identifier for this contributor (e.g. "router", "container", "ext:payments").
+     */
+    public function id(): string;
+
+    /**
+     * Populate the builder with this contributor's metadata sections.
+     */
+    public function contribute(ProjectMetadataBuilder $builder): void;
+}

--- a/src/Introspection/ProjectMetadataBuilder.php
+++ b/src/Introspection/ProjectMetadataBuilder.php
@@ -1,0 +1,235 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection;
+
+use function array_keys;
+use function array_map;
+use function array_slice;
+
+use Closure;
+
+use function count;
+use function is_array;
+use function is_bool;
+use function is_float;
+use function is_int;
+use function is_object;
+use function is_resource;
+use function is_string;
+use function json_encode;
+
+use const JSON_THROW_ON_ERROR;
+
+use function mb_strlen;
+use function preg_replace;
+
+use Pulsar\Api\Api;
+use Pulsar\Introspection\Data\ContributedMetadata;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+use function sprintf;
+use function strtolower;
+use function trim;
+
+/**
+ * Mutable builder scoped to a single metadata contributor.
+ *
+ * Enforces per-contributor resource limits (section count, nesting depth,
+ * keys per object, and total serialized size) to prevent any single
+ * contributor from degrading the introspection snapshot.
+ */
+#[Api(since: '1.0.0')]
+final class ProjectMetadataBuilder
+{
+    private const int MAX_SECTIONS = 64;
+    private const int MAX_DEPTH = 8;
+    private const int MAX_KEYS_PER_OBJECT = 200;
+    private const int MAX_BYTES = 262_144; // 256 KB
+
+    /** @var array<string, array<string, mixed>> */
+    private array $sections = [];
+
+    /** @var list<string> */
+    private array $warnings = [];
+
+    private int $estimatedBytes = 0;
+
+    private function __construct(
+        private readonly string $contributorId,
+    ) {}
+
+    /**
+     * Create a new builder scoped to the given contributor.
+     */
+    public static function forContributor(string $contributorId): self
+    {
+        return new self($contributorId);
+    }
+
+    /**
+     * Add a named section of metadata.
+     *
+     * The key is normalized to lowercase alphanumeric with dots, hyphens, and
+     * underscores. Duplicate keys use last-write-wins semantics with a warning.
+     *
+     * @param array<string, mixed> $data
+     */
+    public function addSection(string $key, array $data): void
+    {
+        $normalizedKey = self::normalizeKey($key);
+
+        if ($normalizedKey === '') {
+            $this->warnings[] = sprintf(
+                'Contributor "%s": section key "%s" normalized to empty string, skipped.',
+                $this->contributorId,
+                $key,
+            );
+
+            return;
+        }
+
+        if (!isset($this->sections[$normalizedKey]) && count($this->sections) >= self::MAX_SECTIONS) {
+            $this->warnings[] = sprintf(
+                'Contributor "%s": maximum section count (%d) reached, section "%s" skipped.',
+                $this->contributorId,
+                self::MAX_SECTIONS,
+                $normalizedKey,
+            );
+
+            return;
+        }
+
+        $validationErrors = [];
+        $validated = $this->validateData($data, $validationErrors, depth: 0);
+
+        foreach ($validationErrors as $error) {
+            $this->warnings[] = sprintf(
+                'Contributor "%s", section "%s": %s',
+                $this->contributorId,
+                $normalizedKey,
+                $error,
+            );
+        }
+
+        $encoded = json_encode($validated, JSON_THROW_ON_ERROR);
+        $sectionBytes = mb_strlen($encoded, '8bit');
+
+        if ($this->estimatedBytes + $sectionBytes > self::MAX_BYTES) {
+            $this->warnings[] = sprintf(
+                'Contributor "%s": adding section "%s" (%d bytes) would exceed %d byte limit, skipped.',
+                $this->contributorId,
+                $normalizedKey,
+                $sectionBytes,
+                self::MAX_BYTES,
+            );
+
+            return;
+        }
+
+        if (isset($this->sections[$normalizedKey])) {
+            $oldEncoded = json_encode($this->sections[$normalizedKey], JSON_THROW_ON_ERROR);
+            $this->estimatedBytes -= mb_strlen($oldEncoded, '8bit');
+
+            $this->warnings[] = sprintf(
+                'Contributor "%s": section "%s" already exists, overwriting (last-write-wins).',
+                $this->contributorId,
+                $normalizedKey,
+            );
+        }
+
+        $this->sections[$normalizedKey] = $validated;
+        $this->estimatedBytes += $sectionBytes;
+    }
+
+    /**
+     * Build the final contributed metadata, scrubbing sensitive values.
+     */
+    public function build(SensitiveDataScrubber $scrubber): ContributedMetadata
+    {
+        /** @var array<string, array<string, mixed>> $scrubbedSections */
+        $scrubbedSections = array_map(
+            static fn(array $section): array => $scrubber->scrub($section),
+            $this->sections,
+        );
+
+        $encoded = json_encode($scrubbedSections, JSON_THROW_ON_ERROR);
+        $sizeBytes = mb_strlen($encoded, '8bit');
+
+        return new ContributedMetadata(
+            contributorId: $this->contributorId,
+            sections: $scrubbedSections,
+            sizeBytes: $sizeBytes,
+        );
+    }
+
+    /**
+     * Get accumulated validation warnings.
+     *
+     * @return list<string>
+     */
+    public function warnings(): array
+    {
+        return $this->warnings;
+    }
+
+    /**
+     * Normalize a section key: lowercase, trim, keep only [a-z0-9_.-].
+     */
+    private static function normalizeKey(string $key): string
+    {
+        $key = strtolower(trim($key));
+
+        return preg_replace('/[^a-z0-9_.\-]/', '', $key) ?? '';
+    }
+
+    /**
+     * Recursively validate data, stripping disallowed types and enforcing depth/key limits.
+     *
+     * @param array<string, mixed> $data
+     * @param list<string>         $errors Collected by reference
+     *
+     * @return array<string, mixed>
+     */
+    private function validateData(array $data, array &$errors, int $depth): array
+    {
+        if ($depth >= self::MAX_DEPTH) {
+            $errors[] = sprintf('Maximum nesting depth (%d) exceeded, subtree truncated.', self::MAX_DEPTH);
+
+            return [];
+        }
+
+        $keys = array_keys($data);
+
+        if (count($keys) > self::MAX_KEYS_PER_OBJECT) {
+            $errors[] = sprintf(
+                'Object has %d keys, exceeding limit of %d. Extra keys truncated.',
+                count($keys),
+                self::MAX_KEYS_PER_OBJECT,
+            );
+            $keys = array_slice($keys, 0, self::MAX_KEYS_PER_OBJECT);
+        }
+
+        $result = [];
+
+        foreach ($keys as $key) {
+            $value = $data[$key];
+
+            if (is_string($value) || is_int($value) || is_float($value) || is_bool($value) || $value === null) {
+                $result[$key] = $value;
+            } elseif (is_array($value)) {
+                /** @var array<string, mixed> $value */
+                $result[$key] = $this->validateData($value, $errors, $depth + 1);
+            } elseif ($value instanceof Closure) {
+                $errors[] = sprintf('Key "%s": closures are not allowed, removed.', $key);
+            } elseif (is_object($value)) {
+                $errors[] = sprintf('Key "%s": objects are not allowed, removed.', $key);
+            } elseif (is_resource($value)) {
+                $errors[] = sprintf('Key "%s": resources are not allowed, removed.', $key);
+            }
+        }
+
+        return $result;
+    }
+}

--- a/src/Introspection/ProjectMetadataService.php
+++ b/src/Introspection/ProjectMetadataService.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection;
+
+use function array_slice;
+use function count;
+use function mb_substr;
+
+use Pulsar\Api\Api;
+use Pulsar\Core\Version;
+use Pulsar\Introspection\Internal\ConfigSchemaReflector;
+use Pulsar\Introspection\Internal\CoreRuntimeProbe;
+use Pulsar\Introspection\Internal\SnapshotFileReader;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+/**
+ * Orchestrates project metadata collection from all sources.
+ *
+ * Assembles a ProjectMetadataSnapshot from the runtime probe, config
+ * schema reflector, API snapshot file, and registered contributors.
+ * The snapshot is memoized per-process to avoid redundant work.
+ */
+#[Api(since: '1.0.0')]
+final class ProjectMetadataService
+{
+    private const int MAX_TOTAL_BYTES = 4_194_304; // 4 MB
+    private const int MAX_WARNINGS = 100;
+    private const int MAX_WARNING_LENGTH = 512;
+
+    private ?ProjectMetadataSnapshot $cached = null;
+
+    /**
+     * @param list<MetadataContributorInterface> $contributors
+     * @param list<class-string>                 $configClasses Config DTO classes to reflect
+     */
+    public function __construct(
+        private readonly CoreRuntimeProbe $probe,
+        private readonly ConfigSchemaReflector $schemaReflector,
+        private readonly SnapshotFileReader $snapshotReader,
+        private readonly SensitiveDataScrubber $scrubber,
+        private readonly array $contributors,
+        private readonly array $configClasses,
+    ) {}
+
+    /**
+     * Get the project metadata snapshot.
+     *
+     * Memoized per-process — returns the cached snapshot after the first call.
+     */
+    public function snapshot(): ProjectMetadataSnapshot
+    {
+        if ($this->cached !== null) {
+            return $this->cached;
+        }
+
+        $warnings = [];
+
+        // Gather sections from internal probes
+        $apiSnapshot = $this->snapshotReader->read($warnings);
+        $architectureMap = $this->probe->probeArchitecture($warnings);
+        $configSchema = $this->schemaReflector->reflect($this->configClasses, $warnings);
+        $commandReference = $this->probe->probeCommands($warnings);
+        $routeMap = $this->probe->probeRoutes($warnings);
+
+        // Gather contributor metadata with per-contributor + global limits
+        $contributions = [];
+        $totalBytes = 0;
+
+        foreach ($this->contributors as $contributor) {
+            $builder = ProjectMetadataBuilder::forContributor($contributor->id());
+            $contributor->contribute($builder);
+            $contribution = $builder->build($this->scrubber);
+
+            $totalBytes += $contribution->sizeBytes();
+
+            if ($totalBytes > self::MAX_TOTAL_BYTES) {
+                $warnings[] = "Global contribution limit exceeded at contributor '{$contributor->id()}'.";
+
+                break;
+            }
+
+            $contributions[$contributor->id()] = $contribution;
+
+            foreach ($builder->warnings() as $warning) {
+                $warnings[] = $warning;
+            }
+        }
+
+        // Cap warnings
+        $warnings = array_map(
+            static fn(string $w): string => mb_substr($w, 0, self::MAX_WARNING_LENGTH),
+            $warnings,
+        );
+
+        if (count($warnings) > self::MAX_WARNINGS) {
+            $warnings = array_slice($warnings, 0, self::MAX_WARNINGS);
+        }
+
+        $this->cached = new ProjectMetadataSnapshot(
+            frameworkVersion: Version::full(),
+            generatedAt: date('c'),
+            apiSnapshot: $apiSnapshot,
+            architectureMap: $architectureMap,
+            configSchema: $configSchema,
+            commandReference: $commandReference,
+            routeMap: $routeMap,
+            contributions: $contributions,
+            warnings: $warnings,
+        );
+
+        return $this->cached;
+    }
+}

--- a/src/Introspection/ProjectMetadataSnapshot.php
+++ b/src/Introspection/ProjectMetadataSnapshot.php
@@ -1,0 +1,62 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Introspection;
+
+use function array_map;
+
+use Pulsar\Api\Api;
+use Pulsar\Introspection\Data\ApiSnapshotData;
+use Pulsar\Introspection\Data\ArchitectureMapData;
+use Pulsar\Introspection\Data\CommandReferenceData;
+use Pulsar\Introspection\Data\ConfigSchemaData;
+use Pulsar\Introspection\Data\ContributedMetadata;
+use Pulsar\Introspection\Data\RouteMapData;
+
+/**
+ * Immutable aggregate of all introspection data for the current application.
+ *
+ * Combines framework-level metadata (routes, commands, config schemas,
+ * architecture map, API snapshot) with contributor-provided sections.
+ */
+#[Api(since: '1.0.0')]
+final readonly class ProjectMetadataSnapshot
+{
+    /**
+     * @param array<string, ContributedMetadata> $contributions Keyed by contributor ID
+     * @param list<string>                       $warnings
+     */
+    public function __construct(
+        public string $frameworkVersion,
+        public string $generatedAt,
+        public ApiSnapshotData $apiSnapshot,
+        public ArchitectureMapData $architectureMap,
+        public ConfigSchemaData $configSchema,
+        public CommandReferenceData $commandReference,
+        public RouteMapData $routeMap,
+        public array $contributions = [],
+        public array $warnings = [],
+    ) {}
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(): array
+    {
+        return [
+            'framework_version' => $this->frameworkVersion,
+            'generated_at' => $this->generatedAt,
+            'api_snapshot' => $this->apiSnapshot->toArray(),
+            'architecture_map' => $this->architectureMap->toArray(),
+            'config_schema' => $this->configSchema->toArray(),
+            'command_reference' => $this->commandReference->toArray(),
+            'route_map' => $this->routeMap->toArray(),
+            'contributions' => array_map(
+                static fn(ContributedMetadata $c): array => $c->toArray(),
+                $this->contributions,
+            ),
+            'warnings' => $this->warnings,
+        ];
+    }
+}

--- a/src/Queue/WorkerOptions.php
+++ b/src/Queue/WorkerOptions.php
@@ -16,7 +16,7 @@ readonly class WorkerOptions
 {
     public function __construct(
         public int $maxJobs = 1000,
-        public int $maxMemoryMb = 128,
+        public int $maxMemoryMb = 256,
         public int $timeLimitSeconds = 3600,
         public int $sleepMs = 1000,
     ) {}

--- a/src/Security/Crypto/Encryptor.php
+++ b/src/Security/Crypto/Encryptor.php
@@ -202,10 +202,9 @@ final class Encryptor implements EncryptorInterface
     {
         $key = $masterKey->deriveSubKey($subKeyId, $context);
 
-        $previousKey = null;
-        if ($masterKey instanceof MasterKey && $masterKey->hasPreviousKey()) {
-            $previousKey = $masterKey->derivePreviousSubKey($subKeyId, $context);
-        }
+        $previousKey = ($masterKey instanceof MasterKey && $masterKey->hasPreviousKey())
+            ? $masterKey->derivePreviousSubKey($subKeyId, $context)
+            : null;
 
         return new self($key, $previousKey);
     }

--- a/src/Supervisor/PreflightCheck/MemoryPreflightCheck.php
+++ b/src/Supervisor/PreflightCheck/MemoryPreflightCheck.php
@@ -24,7 +24,7 @@ final class MemoryPreflightCheck implements PreflightCheckInterface
     private const int BYTES_PER_MB = 1_048_576;
 
     public function __construct(
-        private readonly int $thresholdMb = 128,
+        private readonly int $thresholdMb = 256,
     ) {}
 
     #[Override]

--- a/tests/Integration/Queue/QueuePipelineTest.php
+++ b/tests/Integration/Queue/QueuePipelineTest.php
@@ -120,7 +120,7 @@ final class QueuePipelineTest extends TestCase
         self::assertSame(1, $manager->size());
 
         // Worker processes it
-        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1);
+        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('default');
 
@@ -143,7 +143,7 @@ final class QueuePipelineTest extends TestCase
         $driver->push('default', PipelineOrderTrackerSecond::class, '{}');
         $driver->push('default', PipelineOrderTrackerThird::class, '{}');
 
-        $options = new WorkerOptions(maxJobs: 3, sleepMs: 1);
+        $options = new WorkerOptions(maxJobs: 3, sleepMs: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('default');
 
@@ -163,7 +163,7 @@ final class QueuePipelineTest extends TestCase
 
         self::assertSame(1, $driver->size('default'));
 
-        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1);
+        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('default');
 
@@ -179,7 +179,7 @@ final class QueuePipelineTest extends TestCase
         $driver = new InMemoryDriver();
         $id = $driver->push('default', PipelineFailingJob::class, '{}');
 
-        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1);
+        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('default');
 
@@ -373,7 +373,7 @@ final class QueuePipelineTest extends TestCase
             $driver->push('default', PipelineCountingJob::class, '{}');
         }
 
-        $options = new WorkerOptions(maxJobs: 3, sleepMs: 1);
+        $options = new WorkerOptions(maxJobs: 3, sleepMs: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('default');
 
@@ -394,7 +394,7 @@ final class QueuePipelineTest extends TestCase
 
         // maxJobs is higher than available jobs; worker will run idle loop once then stop due to time/signal
         // Use maxJobs to cap at 10 so test doesn't hang
-        $options = new WorkerOptions(maxJobs: 10, sleepMs: 1, timeLimitSeconds: 1);
+        $options = new WorkerOptions(maxJobs: 10, sleepMs: 1, timeLimitSeconds: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('default');
 
@@ -500,7 +500,7 @@ final class QueuePipelineTest extends TestCase
         self::assertSame(1, $manager->size());
 
         // Process
-        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1);
+        $options = new WorkerOptions(maxJobs: 1, sleepMs: 1, maxMemoryMb: 0);
         $worker = new Worker($driver, $options);
         $worker->run('work');
 

--- a/tests/Unit/Config/QueueConfigTest.php
+++ b/tests/Unit/Config/QueueConfigTest.php
@@ -80,7 +80,7 @@ final class QueueConfigTest extends TestCase
         self::assertSame(QueueDriverType::Sync, $config->driver);
         self::assertSame('default', $config->defaultQueue);
         self::assertSame(1000, $config->workerMaxJobs);
-        self::assertSame(128, $config->workerMaxMemoryMb);
+        self::assertSame(256, $config->workerMaxMemoryMb);
         self::assertSame(3600, $config->workerTimeLimitSeconds);
         self::assertSame(1000, $config->workerSleepMs);
         self::assertSame(3, $config->retryMaxAttempts);
@@ -149,7 +149,7 @@ final class QueueConfigTest extends TestCase
         self::assertSame(QueueDriverType::Sync, $config->driver);
         self::assertSame('default', $config->defaultQueue);
         self::assertSame(1000, $config->workerMaxJobs);
-        self::assertSame(128, $config->workerMaxMemoryMb);
+        self::assertSame(256, $config->workerMaxMemoryMb);
         self::assertSame(3600, $config->workerTimeLimitSeconds);
         self::assertSame(1000, $config->workerSleepMs);
         self::assertSame(3, $config->retryMaxAttempts);

--- a/tests/Unit/Extension/McpServer/Config/McpConfigTest.php
+++ b/tests/Unit/Extension/McpServer/Config/McpConfigTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Config;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Extension\McpServer\Config\McpConfig;
+use Pulsar\Extension\McpServer\Config\McpSecurityConfig;
+use Pulsar\Extension\McpServer\Config\McpToolsConfig;
+
+#[CoversClass(McpConfig::class)]
+#[CoversClass(McpToolsConfig::class)]
+#[CoversClass(McpSecurityConfig::class)]
+final class McpConfigTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('MCP_ENABLED');
+        putenv('MCP_CLIENT_ID');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('MCP_ENABLED');
+        putenv('MCP_CLIENT_ID');
+    }
+
+    #[Test]
+    public function fromArrayDefaultsAreCorrect(): void
+    {
+        $env = Environment::load();
+
+        $config = McpConfig::fromArray([], $env);
+
+        self::assertFalse($config->enabled);
+        self::assertSame('default', $config->clientId);
+        self::assertSame('', $config->projectRoot);
+        self::assertSame([], $config->tools->disabledReadTools);
+        self::assertSame([], $config->tools->allowedActions);
+        self::assertSame(1_048_576, $config->tools->maxOutputBytes);
+        self::assertSame(120, $config->tools->actionTimeout);
+        self::assertSame([], $config->security->pathAllowlist);
+        self::assertSame(60, $config->security->rateLimitPerMinute);
+        self::assertSame(1, $config->security->maxConcurrentActions);
+    }
+
+    #[Test]
+    public function fromArrayEnvOverridesEnabled(): void
+    {
+        putenv('MCP_ENABLED=true');
+
+        $env = Environment::load();
+
+        $config = McpConfig::fromArray(['enabled' => false], $env);
+
+        self::assertTrue($config->enabled);
+    }
+
+    #[Test]
+    public function fromArrayEnvOverridesClientId(): void
+    {
+        putenv('MCP_CLIENT_ID=custom-client');
+
+        $env = Environment::load();
+
+        $config = McpConfig::fromArray(['client_id' => 'original'], $env);
+
+        self::assertSame('custom-client', $config->clientId);
+    }
+}

--- a/tests/Unit/Extension/McpServer/Protocol/JsonRpcCodecTest.php
+++ b/tests/Unit/Extension/McpServer/Protocol/JsonRpcCodecTest.php
@@ -1,0 +1,113 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\McpServer\Exception\McpException;
+use Pulsar\Extension\McpServer\Internal\Protocol\JsonRpcCodec;
+use Pulsar\Extension\McpServer\Internal\Protocol\JsonRpcRequest;
+
+#[CoversClass(JsonRpcCodec::class)]
+#[CoversClass(JsonRpcRequest::class)]
+final class JsonRpcCodecTest extends TestCase
+{
+    private JsonRpcCodec $codec;
+
+    protected function setUp(): void
+    {
+        $this->codec = new JsonRpcCodec();
+    }
+
+    #[Test]
+    public function decodeValidRequest(): void
+    {
+        $json = '{"jsonrpc":"2.0","id":1,"method":"tools/list","params":{"cursor":null}}';
+
+        $request = $this->codec->decode($json);
+
+        self::assertSame(1, $request->id);
+        self::assertSame('tools/list', $request->method);
+        self::assertSame(['cursor' => null], $request->params);
+        self::assertFalse($request->isNotification());
+    }
+
+    #[Test]
+    public function decodeNotification(): void
+    {
+        $json = '{"jsonrpc":"2.0","method":"notifications/initialized"}';
+
+        $request = $this->codec->decode($json);
+
+        self::assertNull($request->id);
+        self::assertSame('notifications/initialized', $request->method);
+        self::assertSame([], $request->params);
+        self::assertTrue($request->isNotification());
+    }
+
+    #[Test]
+    public function decodeThrowsOnMalformedJson(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32700);
+
+        $this->codec->decode('{invalid json}}}');
+    }
+
+    #[Test]
+    public function decodeThrowsOnMissingJsonrpc(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32600);
+
+        $this->codec->decode('{"id":1,"method":"ping"}');
+    }
+
+    #[Test]
+    public function decodeThrowsOnMissingMethod(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32600);
+
+        $this->codec->decode('{"jsonrpc":"2.0","id":1}');
+    }
+
+    #[Test]
+    public function encodeResultProducesCompactJson(): void
+    {
+        $result = $this->codec->encodeResult(1, ['status' => 'ok']);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertSame(1, $decoded['id']);
+        self::assertSame(['status' => 'ok'], $decoded['result']);
+        self::assertStringEndsWith("\n", $result);
+        // Compact: no pretty-print whitespace
+        self::assertStringNotContainsString('  ', $result);
+    }
+
+    #[Test]
+    public function encodeErrorIncludesErrorObject(): void
+    {
+        $result = $this->codec->encodeError(42, -32601, 'Method not found', ['detail' => 'unknown']);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($result, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame('2.0', $decoded['jsonrpc']);
+        self::assertSame(42, $decoded['id']);
+        self::assertArrayHasKey('error', $decoded);
+
+        /** @var array<string, mixed> $error */
+        $error = $decoded['error'];
+        self::assertSame(-32601, $error['code']);
+        self::assertSame('Method not found', $error['message']);
+        self::assertSame(['detail' => 'unknown'], $error['data']);
+        self::assertStringEndsWith("\n", $result);
+    }
+}

--- a/tests/Unit/Extension/McpServer/Protocol/MessageHandlerTest.php
+++ b/tests/Unit/Extension/McpServer/Protocol/MessageHandlerTest.php
@@ -1,0 +1,300 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Protocol;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Audit\AuditLoggerInterface;
+use Pulsar\Extension\McpServer\Config\McpConfig;
+use Pulsar\Extension\McpServer\Config\McpSecurityConfig;
+use Pulsar\Extension\McpServer\Config\McpToolsConfig;
+use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
+use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Contracts\ToolPermissionCheckerInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Domain\ToolDefinition;
+use Pulsar\Extension\McpServer\Domain\ToolResult;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+use Pulsar\Extension\McpServer\Internal\Protocol\JsonRpcCodec;
+use Pulsar\Extension\McpServer\Internal\Protocol\JsonRpcRequest;
+use Pulsar\Extension\McpServer\Internal\Protocol\MessageHandler;
+use Pulsar\Http\RateLimit\RateLimiterInterface;
+use Pulsar\Http\RateLimit\RateLimitResult;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+#[CoversClass(MessageHandler::class)]
+#[CoversClass(JsonRpcCodec::class)]
+#[CoversClass(JsonRpcRequest::class)]
+final class MessageHandlerTest extends TestCase
+{
+    private McpConfig $config;
+    private SensitiveDataScrubber $scrubber;
+
+    protected function setUp(): void
+    {
+        $this->scrubber = new SensitiveDataScrubber();
+
+        $this->config = new McpConfig(
+            enabled: true,
+            clientId: 'test',
+            projectRoot: '/tmp',
+            tools: McpToolsConfig::fromArray([]),
+            security: McpSecurityConfig::fromArray([]),
+        );
+    }
+
+    private function createHandler(
+        ?McpToolRegistryInterface $registry = null,
+        ?ToolPermissionCheckerInterface $permissionChecker = null,
+        ?McpAccessGateInterface $accessGate = null,
+        ?McpRedactionPipelineInterface $redactionPipeline = null,
+        ?AuditLoggerInterface $auditLogger = null,
+        ?RateLimiterInterface $rateLimiter = null,
+    ): MessageHandler {
+        return new MessageHandler(
+            registry: $registry ?? self::createStub(McpToolRegistryInterface::class),
+            permissionChecker: $permissionChecker ?? self::createStub(ToolPermissionCheckerInterface::class),
+            accessGate: $accessGate ?? self::createStub(McpAccessGateInterface::class),
+            redactionPipeline: $redactionPipeline ?? self::createStub(McpRedactionPipelineInterface::class),
+            auditLogger: $auditLogger ?? self::createStub(AuditLoggerInterface::class),
+            rateLimiter: $rateLimiter ?? self::createStub(RateLimiterInterface::class),
+            config: $this->config,
+            scrubber: $this->scrubber,
+        );
+    }
+
+    #[Test]
+    public function handleInitializeWithKnownVersion(): void
+    {
+        $handler = $this->createHandler();
+
+        $request = new JsonRpcRequest(id: 1, method: 'initialize', params: [
+            'protocolVersion' => '2024-11-05',
+        ]);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var array<string, mixed> $result */
+        $result = $decoded['result'];
+        self::assertSame('2024-11-05', $result['protocolVersion']);
+
+        /** @var array<string, mixed> $serverInfo */
+        $serverInfo = $result['serverInfo'];
+        self::assertSame('pulsar-mcp', $serverInfo['name']);
+        self::assertArrayHasKey('capabilities', $result);
+    }
+
+    #[Test]
+    public function handleInitializeWithUnknownValidDate(): void
+    {
+        $handler = $this->createHandler();
+
+        $request = new JsonRpcRequest(id: 2, method: 'initialize', params: [
+            'protocolVersion' => '2099-01-01',
+        ]);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var array<string, mixed> $result */
+        $result = $decoded['result'];
+        self::assertSame('2025-11-25', $result['protocolVersion']);
+    }
+
+    #[Test]
+    public function handleInitializeWithMalformedVersion(): void
+    {
+        $handler = $this->createHandler();
+
+        $request = new JsonRpcRequest(id: 3, method: 'initialize', params: [
+            'protocolVersion' => 'not-a-date',
+        ]);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('error', $decoded);
+
+        /** @var array<string, mixed> $error */
+        $error = $decoded['error'];
+        self::assertSame(-32602, $error['code']);
+    }
+
+    #[Test]
+    public function handlePingReturnsEmptyResult(): void
+    {
+        $handler = $this->createHandler();
+
+        $request = new JsonRpcRequest(id: 4, method: 'ping', params: []);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertSame([], $decoded['result']);
+        self::assertSame(4, $decoded['id']);
+    }
+
+    #[Test]
+    public function handleToolsListReturnsDefinitions(): void
+    {
+        $registry = self::createStub(McpToolRegistryInterface::class);
+
+        $definitions = [
+            new ToolDefinition(
+                name: 'read_routes',
+                description: 'Read registered routes',
+                inputSchema: ['type' => 'object'],
+                outputSchema: ['type' => 'object'],
+                category: ToolCategory::Read,
+            ),
+        ];
+
+        $registry->method('list')->willReturn($definitions);
+
+        $handler = $this->createHandler(registry: $registry);
+
+        $request = new JsonRpcRequest(id: 5, method: 'tools/list', params: []);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var array<string, mixed> $result */
+        $result = $decoded['result'];
+
+        /** @var list<array<string, mixed>> $tools */
+        $tools = $result['tools'];
+        self::assertCount(1, $tools);
+        self::assertSame('read_routes', $tools[0]['name']);
+        self::assertSame('Read registered routes', $tools[0]['description']);
+    }
+
+    #[Test]
+    public function handleToolsCallSuccess(): void
+    {
+        $toolResult = ToolResult::success(
+            structuredContent: ['routes' => ['/api/health']],
+            textContent: '1 route found',
+        );
+
+        $permissionChecker = self::createMock(ToolPermissionCheckerInterface::class);
+        $permissionChecker->expects(self::once())
+            ->method('assertAllowed')
+            ->with('read_routes');
+
+        $rateLimiter = self::createStub(RateLimiterInterface::class);
+        $rateLimiter->method('hit')
+            ->willReturn(new RateLimitResult(allowed: true, limit: 60, remaining: 59, retryAfter: 0));
+
+        $registry = self::createStub(McpToolRegistryInterface::class);
+        $registry->method('call')
+            ->with('read_routes', [])
+            ->willReturn($toolResult);
+
+        $redactionPipeline = self::createStub(McpRedactionPipelineInterface::class);
+        $redactionPipeline->method('redact')
+            ->willReturnArgument(0);
+
+        $handler = $this->createHandler(
+            registry: $registry,
+            permissionChecker: $permissionChecker,
+            redactionPipeline: $redactionPipeline,
+            rateLimiter: $rateLimiter,
+        );
+
+        $request = new JsonRpcRequest(id: 6, method: 'tools/call', params: [
+            'name' => 'read_routes',
+            'arguments' => [],
+        ]);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        /** @var array<string, mixed> $result */
+        $result = $decoded['result'];
+
+        /** @var list<array<string, mixed>> $content */
+        $content = $result['content'];
+
+        self::assertSame(6, $decoded['id']);
+        self::assertFalse($result['isError']);
+        self::assertSame('1 route found', $content[0]['text']);
+        self::assertSame(['routes' => ['/api/health']], $result['structuredContent']);
+    }
+
+    #[Test]
+    public function handleToolsCallPermissionDenied(): void
+    {
+        $permissionChecker = self::createMock(ToolPermissionCheckerInterface::class);
+        $permissionChecker->expects(self::once())
+            ->method('assertAllowed')
+            ->with('run_tests')
+            ->willThrowException(McpSecurityException::toolNotAllowed('run_tests'));
+
+        $handler = $this->createHandler(permissionChecker: $permissionChecker);
+
+        $request = new JsonRpcRequest(id: 7, method: 'tools/call', params: [
+            'name' => 'run_tests',
+            'arguments' => [],
+        ]);
+
+        $response = $handler->handle($request);
+
+        self::assertNotNull($response);
+
+        /** @var array<string, mixed> $decoded */
+        $decoded = json_decode($response, true, 512, JSON_THROW_ON_ERROR);
+
+        self::assertArrayHasKey('result', $decoded);
+
+        /** @var array<string, mixed> $result */
+        $result = $decoded['result'];
+
+        /** @var list<array<string, mixed>> $content */
+        $content = $result['content'];
+
+        self::assertTrue($result['isError']);
+        self::assertIsString($content[0]['text']);
+        self::assertStringContainsString('not allowed', $content[0]['text']);
+    }
+
+    #[Test]
+    public function handleNotificationReturnsNull(): void
+    {
+        $handler = $this->createHandler();
+
+        $request = new JsonRpcRequest(id: null, method: 'notifications/initialized', params: []);
+
+        $response = $handler->handle($request);
+
+        self::assertNull($response);
+    }
+}

--- a/tests/Unit/Extension/McpServer/Protocol/MessageHandlerTest.php
+++ b/tests/Unit/Extension/McpServer/Protocol/MessageHandlerTest.php
@@ -11,7 +11,6 @@ use Pulsar\Audit\AuditLoggerInterface;
 use Pulsar\Extension\McpServer\Config\McpConfig;
 use Pulsar\Extension\McpServer\Config\McpSecurityConfig;
 use Pulsar\Extension\McpServer\Config\McpToolsConfig;
-use Pulsar\Extension\McpServer\Contracts\McpAccessGateInterface;
 use Pulsar\Extension\McpServer\Contracts\McpRedactionPipelineInterface;
 use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
 use Pulsar\Extension\McpServer\Contracts\ToolPermissionCheckerInterface;
@@ -50,7 +49,6 @@ final class MessageHandlerTest extends TestCase
     private function createHandler(
         ?McpToolRegistryInterface $registry = null,
         ?ToolPermissionCheckerInterface $permissionChecker = null,
-        ?McpAccessGateInterface $accessGate = null,
         ?McpRedactionPipelineInterface $redactionPipeline = null,
         ?AuditLoggerInterface $auditLogger = null,
         ?RateLimiterInterface $rateLimiter = null,
@@ -58,7 +56,6 @@ final class MessageHandlerTest extends TestCase
         return new MessageHandler(
             registry: $registry ?? self::createStub(McpToolRegistryInterface::class),
             permissionChecker: $permissionChecker ?? self::createStub(ToolPermissionCheckerInterface::class),
-            accessGate: $accessGate ?? self::createStub(McpAccessGateInterface::class),
             redactionPipeline: $redactionPipeline ?? self::createStub(McpRedactionPipelineInterface::class),
             auditLogger: $auditLogger ?? self::createStub(AuditLoggerInterface::class),
             rateLimiter: $rateLimiter ?? self::createStub(RateLimiterInterface::class),

--- a/tests/Unit/Extension/McpServer/Redaction/McpRedactionPipelineTest.php
+++ b/tests/Unit/Extension/McpServer/Redaction/McpRedactionPipelineTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Redaction;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Extension\McpServer\Internal\Redaction\McpRedactionPipeline;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+#[CoversClass(McpRedactionPipeline::class)]
+final class McpRedactionPipelineTest extends TestCase
+{
+    private McpRedactionPipeline $pipeline;
+
+    protected function setUp(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $this->pipeline = new McpRedactionPipeline($scrubber);
+    }
+
+    #[Test]
+    public function redactStringScrubesEnvVars(): void
+    {
+        $input = 'Config: PULSAR_MASTER_KEY=abc123secret DB_PASSWORD=hunter2';
+
+        $output = $this->pipeline->redactString($input);
+
+        self::assertStringNotContainsString('abc123secret', $output);
+        self::assertStringNotContainsString('hunter2', $output);
+        self::assertStringContainsString('[REDACTED]', $output);
+    }
+
+    #[Test]
+    public function redactStringScrubesConnectionStrings(): void
+    {
+        $input = 'DSN: mysql://root:s3cret@localhost/mydb';
+
+        $output = $this->pipeline->redactString($input);
+
+        self::assertStringNotContainsString('root:s3cret', $output);
+        self::assertStringContainsString('://[REDACTED]@', $output);
+    }
+
+    #[Test]
+    public function redactStringScrubesBearerTokens(): void
+    {
+        $input = 'Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.test.signature';
+
+        $output = $this->pipeline->redactString($input);
+
+        self::assertStringNotContainsString('eyJhbGciOiJIUzI1NiJ9', $output);
+        self::assertStringContainsString('Bearer [REDACTED]', $output);
+    }
+
+    #[Test]
+    public function redactStringScrubesKnownSecretValues(): void
+    {
+        $scrubber = new SensitiveDataScrubber();
+        $pipeline = new McpRedactionPipeline($scrubber, ['my-super-secret-value']);
+
+        $input = 'The value is my-super-secret-value in the output';
+
+        $output = $pipeline->redactString($input);
+
+        self::assertStringNotContainsString('my-super-secret-value', $output);
+        self::assertStringContainsString('[REDACTED]', $output);
+    }
+
+    #[Test]
+    public function collectKnownSecretsFindsSecretKeys(): void
+    {
+        // Set known env vars with secret-indicating key suffixes
+        putenv('TEST_MCP_API_KEY=key-abc-123');
+        putenv('TEST_MCP_DB_PASSWORD=hunter2');
+        putenv('TEST_MCP_AUTH_TOKEN=tok_xyz');
+        putenv('TEST_MCP_JWT_SECRET=jwt-secret-value');
+        putenv('TEST_MCP_REDIS_DSN=redis://localhost');
+
+        try {
+            $env = Environment::load();
+            $secrets = McpRedactionPipeline::collectKnownSecrets($env);
+
+            self::assertContains('key-abc-123', $secrets);
+            self::assertContains('hunter2', $secrets);
+            self::assertContains('tok_xyz', $secrets);
+            self::assertContains('jwt-secret-value', $secrets);
+            self::assertContains('redis://localhost', $secrets);
+        } finally {
+            putenv('TEST_MCP_API_KEY');
+            putenv('TEST_MCP_DB_PASSWORD');
+            putenv('TEST_MCP_AUTH_TOKEN');
+            putenv('TEST_MCP_JWT_SECRET');
+            putenv('TEST_MCP_REDIS_DSN');
+        }
+    }
+}

--- a/tests/Unit/Extension/McpServer/Security/McpAccessGateTest.php
+++ b/tests/Unit/Extension/McpServer/Security/McpAccessGateTest.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Security;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Config\EnvironmentMode;
+use Pulsar\Extension\McpServer\Config\McpSecurityConfig;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+use Pulsar\Extension\McpServer\Internal\Security\McpAccessGate;
+
+#[CoversClass(McpAccessGate::class)]
+final class McpAccessGateTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        putenv('MCP_STAGING_CONFIRM');
+        putenv('MCP_PRODUCTION_CONFIRM');
+    }
+
+    protected function tearDown(): void
+    {
+        putenv('MCP_STAGING_CONFIRM');
+        putenv('MCP_PRODUCTION_CONFIRM');
+    }
+
+    #[Test]
+    public function localEnvironmentIsAllowed(): void
+    {
+        $env = Environment::load();
+        $config = McpSecurityConfig::fromArray([]);
+
+        $gate = new McpAccessGate($config, EnvironmentMode::Local, $env, '/tmp/project');
+
+        $gate->assertEnvironmentAllowed();
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function stagingRequiresConfirmation(): void
+    {
+        $env = Environment::load();
+        $config = McpSecurityConfig::fromArray([]);
+
+        $gate = new McpAccessGate($config, EnvironmentMode::Staging, $env, '/tmp/project');
+
+        $this->expectException(McpSecurityException::class);
+
+        $gate->assertEnvironmentAllowed();
+    }
+
+    #[Test]
+    public function stagingWithConfirmationPasses(): void
+    {
+        putenv('MCP_STAGING_CONFIRM=true');
+
+        $env = Environment::load();
+        $config = McpSecurityConfig::fromArray([]);
+
+        $gate = new McpAccessGate($config, EnvironmentMode::Staging, $env, '/tmp/project');
+
+        $gate->assertEnvironmentAllowed();
+
+        $this->addToAssertionCount(1);
+    }
+
+    #[Test]
+    public function productionRequiresConfirmation(): void
+    {
+        $env = Environment::load();
+        $config = McpSecurityConfig::fromArray([]);
+
+        $gate = new McpAccessGate($config, EnvironmentMode::Production, $env, '/tmp/project');
+
+        $this->expectException(McpSecurityException::class);
+
+        $gate->assertEnvironmentAllowed();
+    }
+
+    #[Test]
+    public function concurrencyLimitEnforced(): void
+    {
+        $env = Environment::load();
+        $config = McpSecurityConfig::fromArray([
+            'max_concurrent_actions' => 1,
+        ]);
+
+        $gate = new McpAccessGate($config, EnvironmentMode::Local, $env, '/tmp/project');
+
+        $gate->assertConcurrencyAllowed();
+
+        $this->expectException(McpSecurityException::class);
+
+        $gate->assertConcurrencyAllowed();
+    }
+
+    #[Test]
+    public function concurrencySlotRelease(): void
+    {
+        $env = Environment::load();
+        $config = McpSecurityConfig::fromArray([
+            'max_concurrent_actions' => 1,
+        ]);
+
+        $gate = new McpAccessGate($config, EnvironmentMode::Local, $env, '/tmp/project');
+
+        $gate->assertConcurrencyAllowed();
+        $gate->releaseConcurrencySlot();
+
+        // After release, should be able to acquire again
+        $gate->assertConcurrencyAllowed();
+
+        $this->addToAssertionCount(1);
+    }
+}

--- a/tests/Unit/Extension/McpServer/Security/ParamValidatorTest.php
+++ b/tests/Unit/Extension/McpServer/Security/ParamValidatorTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Security;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\McpServer\Exception\McpException;
+use Pulsar\Extension\McpServer\Internal\Security\ParamValidator;
+
+#[CoversClass(ParamValidator::class)]
+final class ParamValidatorTest extends TestCase
+{
+    #[Test]
+    public function validateClientIdAcceptsValid(): void
+    {
+        self::assertSame('my-client_01', ParamValidator::validateClientId('my-client_01'));
+        self::assertSame('abc', ParamValidator::validateClientId('abc'));
+        self::assertSame('A_B-C', ParamValidator::validateClientId('A_B-C'));
+    }
+
+    #[Test]
+    public function validateClientIdRejectsInvalid(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32602);
+
+        ParamValidator::validateClientId('client;rm -rf /');
+    }
+
+    #[Test]
+    public function validateClientIdRejectsTooLong(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32602);
+
+        ParamValidator::validateClientId(str_repeat('a', 65));
+    }
+
+    #[Test]
+    public function validateFilterAcceptsValid(): void
+    {
+        self::assertSame('App\\Models\\User', ParamValidator::validateFilter('App\\Models\\User'));
+        self::assertSame('route:list', ParamValidator::validateFilter('route:list'));
+        self::assertSame('config.app', ParamValidator::validateFilter('config.app'));
+        self::assertNull(ParamValidator::validateFilter(null));
+    }
+
+    #[Test]
+    public function validateFilterRejectsInvalid(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32602);
+
+        ParamValidator::validateFilter('$(whoami)');
+    }
+
+    #[Test]
+    public function validateTypeAcceptsPhpAndJs(): void
+    {
+        self::assertSame('php', ParamValidator::validateType('php'));
+        self::assertSame('js', ParamValidator::validateType('js'));
+    }
+
+    #[Test]
+    public function validateTypeRejectsOther(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32602);
+
+        ParamValidator::validateType('python');
+    }
+
+    #[Test]
+    public function validateAnalyzerAcceptsPhpstanAndPsalm(): void
+    {
+        self::assertSame('phpstan', ParamValidator::validateAnalyzer('phpstan'));
+        self::assertSame('psalm', ParamValidator::validateAnalyzer('psalm'));
+    }
+
+    #[Test]
+    public function validateAnalyzerRejectsOther(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32602);
+
+        ParamValidator::validateAnalyzer('eslint');
+    }
+
+    #[Test]
+    public function validatePathRejectsTraversal(): void
+    {
+        $this->expectException(McpException::class);
+        $this->expectExceptionCode(-32602);
+
+        ParamValidator::validatePath('../../etc/passwd', '/tmp/project');
+    }
+}

--- a/tests/Unit/Extension/McpServer/Security/ToolPermissionCheckerTest.php
+++ b/tests/Unit/Extension/McpServer/Security/ToolPermissionCheckerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Extension\McpServer\Security;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Extension\McpServer\Config\McpToolsConfig;
+use Pulsar\Extension\McpServer\Contracts\McpToolInterface;
+use Pulsar\Extension\McpServer\Contracts\McpToolRegistryInterface;
+use Pulsar\Extension\McpServer\Domain\ToolCategory;
+use Pulsar\Extension\McpServer\Exception\McpSecurityException;
+use Pulsar\Extension\McpServer\Internal\Security\ToolPermissionChecker;
+
+#[CoversClass(ToolPermissionChecker::class)]
+final class ToolPermissionCheckerTest extends TestCase
+{
+    #[Test]
+    public function readToolIsAllowedByDefault(): void
+    {
+        $tool = self::createStub(McpToolInterface::class);
+        $tool->method('category')->willReturn(ToolCategory::Read);
+
+        $registry = self::createStub(McpToolRegistryInterface::class);
+        $registry->method('has')->willReturn(true);
+        $registry->method('get')->willReturn($tool);
+
+        $config = McpToolsConfig::fromArray([]);
+        $checker = new ToolPermissionChecker($config, $registry);
+
+        $checker->assertAllowed('read_routes');
+
+        self::assertTrue($checker->isAllowed('read_routes'));
+    }
+
+    #[Test]
+    public function disabledReadToolIsRejected(): void
+    {
+        $tool = self::createStub(McpToolInterface::class);
+        $tool->method('category')->willReturn(ToolCategory::Read);
+
+        $registry = self::createStub(McpToolRegistryInterface::class);
+        $registry->method('has')->willReturn(true);
+        $registry->method('get')->willReturn($tool);
+
+        $config = McpToolsConfig::fromArray([
+            'disabled_read_tools' => ['read_routes'],
+        ]);
+        $checker = new ToolPermissionChecker($config, $registry);
+
+        $this->expectException(McpSecurityException::class);
+
+        $checker->assertAllowed('read_routes');
+    }
+
+    #[Test]
+    public function actionToolRequiresExplicitAllowlist(): void
+    {
+        $tool = self::createStub(McpToolInterface::class);
+        $tool->method('category')->willReturn(ToolCategory::Action);
+
+        $registry = self::createStub(McpToolRegistryInterface::class);
+        $registry->method('has')->willReturn(true);
+        $registry->method('get')->willReturn($tool);
+
+        $config = McpToolsConfig::fromArray([
+            'allowed_actions' => [],
+        ]);
+        $checker = new ToolPermissionChecker($config, $registry);
+
+        $this->expectException(McpSecurityException::class);
+
+        $checker->assertAllowed('run_tests');
+    }
+
+    #[Test]
+    public function allowedActionToolPasses(): void
+    {
+        $tool = self::createStub(McpToolInterface::class);
+        $tool->method('category')->willReturn(ToolCategory::Action);
+
+        $registry = self::createStub(McpToolRegistryInterface::class);
+        $registry->method('has')->willReturn(true);
+        $registry->method('get')->willReturn($tool);
+
+        $config = McpToolsConfig::fromArray([
+            'allowed_actions' => ['run_tests'],
+        ]);
+        $checker = new ToolPermissionChecker($config, $registry);
+
+        $checker->assertAllowed('run_tests');
+
+        self::assertTrue($checker->isAllowed('run_tests'));
+    }
+}

--- a/tests/Unit/Integrity/Support/ModuleMap.php
+++ b/tests/Unit/Integrity/Support/ModuleMap.php
@@ -31,6 +31,7 @@ final class ModuleMap
         'Pulsar\Core\Wiring\ExceptionHandlerWiring',
         'Pulsar\Core\Wiring\FeatureFlagWiring',
         'Pulsar\Core\Wiring\IntegrityWiring',
+        'Pulsar\Core\Wiring\IntrospectionWiring',
         'Pulsar\Core\Wiring\LoggingWiring',
         'Pulsar\Core\Wiring\MetricsWiring',
         'Pulsar\Core\Wiring\QueueWiring',

--- a/tests/Unit/Integrity/architecture-baseline.json
+++ b/tests/Unit/Integrity/architecture-baseline.json
@@ -1,1 +1,4 @@
-{}
+{
+  "Pulsar\\Console\\Application": "CoreRuntimeProbe needs Application to introspect registered commands",
+  "Pulsar\\Extensibility\\ExtensionRegistry": "CoreRuntimeProbe needs ExtensionRegistry to introspect loaded extensions"
+}

--- a/tests/Unit/Introspection/CoreRuntimeProbeTest.php
+++ b/tests/Unit/Introspection/CoreRuntimeProbeTest.php
@@ -17,10 +17,13 @@ use Pulsar\Extensibility\ExtensionLifecycle;
 use Pulsar\Extensibility\ExtensionManifest;
 use Pulsar\Extensibility\ExtensionRegistry;
 use Pulsar\Http\Method;
+use Pulsar\Introspection\Data\CommandEntry;
+use Pulsar\Introspection\Data\ExtensionEntry;
 use Pulsar\Introspection\Internal\CoreRuntimeProbe;
 use Pulsar\Routing\Route;
 use Pulsar\Routing\RouterInterface;
 use ReflectionClass;
+use Throwable;
 
 #[CoversClass(CoreRuntimeProbe::class)]
 final class CoreRuntimeProbeTest extends TestCase
@@ -49,11 +52,46 @@ final class CoreRuntimeProbeTest extends TestCase
         $registry = new ExtensionRegistry();
         $registry->add($extension, $manifest, ExtensionLifecycle::Booted);
 
+        $extensionProber = static function () use ($registry): array {
+            $extensions = $registry->all();
+            $manifests = $registry->allManifests();
+            $entries = [];
+
+            foreach ($extensions as $name => $_extension) {
+                $manifest = $manifests[$name] ?? null;
+                $state = 'unknown';
+
+                try {
+                    $state = $registry->getState($name)->value;
+                } catch (Throwable) {
+                    // Swallow
+                }
+
+                $provides = [];
+                $dependencies = [];
+
+                if ($manifest !== null) {
+                    $provides = $manifest->provides->services;
+                    $dependencies = $manifest->getDependencies();
+                }
+
+                $entries[] = new ExtensionEntry(
+                    name: $name,
+                    version: $manifest->version ?? 'unknown',
+                    state: $state,
+                    provides: $provides,
+                    dependencies: $dependencies,
+                );
+            }
+
+            return $entries;
+        };
+
         $probe = new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: $registry,
+            extensionProber: $extensionProber,
             router: null,
-            consoleApplication: null,
+            commandProber: null,
         );
 
         $warnings = [];
@@ -84,9 +122,9 @@ final class CoreRuntimeProbeTest extends TestCase
 
         $probe = new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: null,
+            extensionProber: null,
             router: null,
-            consoleApplication: null,
+            commandProber: null,
         );
 
         $warnings = [];
@@ -120,9 +158,9 @@ final class CoreRuntimeProbeTest extends TestCase
 
         $probe = new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: null,
+            extensionProber: null,
             router: $router,
-            consoleApplication: null,
+            commandProber: null,
         );
 
         $warnings = [];
@@ -157,19 +195,43 @@ final class CoreRuntimeProbeTest extends TestCase
             }
         };
 
-        // Application and Kernel are both final — use Reflection to bypass constructor
+        // Application is #[Internal] — build a closure as the composition root does
         $reflection = new ReflectionClass(Application::class);
         $app = $reflection->newInstanceWithoutConstructor();
         $app->add($command);
+
+        $commandProber = static function () use ($app): array {
+            $commands = $app->all();
+            $entries = [];
+
+            foreach ($commands as $cmd) {
+                $arguments = [];
+                $options = [];
+
+                if ($cmd instanceof Command) {
+                    $arguments = $cmd->arguments;
+                    $options = $cmd->options;
+                }
+
+                $entries[] = new CommandEntry(
+                    name: $cmd->name,
+                    description: $cmd->description,
+                    arguments: $arguments,
+                    options: $options,
+                );
+            }
+
+            return $entries;
+        };
 
         $container = self::createStub(ContainerInterface::class);
         $container->method('getBindings')->willReturn([]);
 
         $probe = new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: null,
+            extensionProber: null,
             router: null,
-            consoleApplication: $app,
+            commandProber: $commandProber,
         );
 
         $warnings = [];
@@ -195,9 +257,9 @@ final class CoreRuntimeProbeTest extends TestCase
 
         $probe = new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: null,
+            extensionProber: null,
             router: null,
-            consoleApplication: null,
+            commandProber: null,
         );
 
         $warnings = [];

--- a/tests/Unit/Introspection/CoreRuntimeProbeTest.php
+++ b/tests/Unit/Introspection/CoreRuntimeProbeTest.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Introspection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Console\Application;
+use Pulsar\Console\Command;
+use Pulsar\Console\InputInterface;
+use Pulsar\Console\OutputInterface;
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Extensibility\ExtensionInterface;
+use Pulsar\Extensibility\ExtensionLifecycle;
+use Pulsar\Extensibility\ExtensionManifest;
+use Pulsar\Extensibility\ExtensionRegistry;
+use Pulsar\Http\Method;
+use Pulsar\Introspection\Internal\CoreRuntimeProbe;
+use Pulsar\Routing\Route;
+use Pulsar\Routing\RouterInterface;
+use ReflectionClass;
+
+#[CoversClass(CoreRuntimeProbe::class)]
+final class CoreRuntimeProbeTest extends TestCase
+{
+    #[Test]
+    public function probeArchitectureReturnsExtensionsAndBindings(): void
+    {
+        $container = self::createStub(ContainerInterface::class);
+        $container->method('getBindings')->willReturn([
+            'Pulsar\\Http\\Kernel',
+            'Pulsar\\Routing\\Router',
+            'db.connection',
+        ]);
+
+        $extension = self::createStub(ExtensionInterface::class);
+        $extension->method('name')->willReturn('test-ext');
+
+        $manifest = ExtensionManifest::fromArray([
+            'name' => 'test-ext',
+            'version' => '1.0.0',
+            'extension_class' => 'Pulsar\\TestExtension',
+            'provides' => ['services' => ['Pulsar\\SomeService']],
+            'requires' => ['core' => '>=1.0.0'],
+        ], '/tmp');
+
+        $registry = new ExtensionRegistry();
+        $registry->add($extension, $manifest, ExtensionLifecycle::Booted);
+
+        $probe = new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: $registry,
+            router: null,
+            consoleApplication: null,
+        );
+
+        $warnings = [];
+        $result = $probe->probeArchitecture($warnings);
+
+        self::assertCount(1, $result->extensions);
+        self::assertSame('test-ext', $result->extensions[0]->name);
+        self::assertSame('1.0.0', $result->extensions[0]->version);
+        self::assertSame('booted', $result->extensions[0]->state);
+        self::assertSame(['Pulsar\\SomeService'], $result->extensions[0]->provides);
+        self::assertSame(['core'], $result->extensions[0]->dependencies);
+
+        // Only FQCN-like bindings should be present
+        self::assertContains('Pulsar\\Http\\Kernel', $result->bindings);
+        self::assertContains('Pulsar\\Routing\\Router', $result->bindings);
+    }
+
+    #[Test]
+    public function probeArchitectureFiltersFqcnOnlyBindings(): void
+    {
+        $container = self::createStub(ContainerInterface::class);
+        $container->method('getBindings')->willReturn([
+            'Pulsar\\Http\\Kernel',
+            'db.password',
+            'cache.store',
+            'App\\Service',
+        ]);
+
+        $probe = new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: null,
+            router: null,
+            consoleApplication: null,
+        );
+
+        $warnings = [];
+        $result = $probe->probeArchitecture($warnings);
+
+        self::assertContains('Pulsar\\Http\\Kernel', $result->bindings);
+        self::assertContains('App\\Service', $result->bindings);
+        self::assertNotContains('db.password', $result->bindings);
+        self::assertNotContains('cache.store', $result->bindings);
+    }
+
+    #[Test]
+    public function probeRoutesReturnsFormattedEntries(): void
+    {
+        /** @var callable(): mixed $handler */
+        $handler = 'App\\Controller\\UserController::show';
+
+        $route = new Route(
+            methods: [Method::GET, Method::HEAD],
+            path: '/users/{id}',
+            handler: $handler,
+            name: 'users.show',
+            middleware: ['auth'],
+        );
+
+        $router = self::createStub(RouterInterface::class);
+        $router->method('routes')->willReturn([$route]);
+
+        $container = self::createStub(ContainerInterface::class);
+        $container->method('getBindings')->willReturn([]);
+
+        $probe = new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: null,
+            router: $router,
+            consoleApplication: null,
+        );
+
+        $warnings = [];
+        $result = $probe->probeRoutes($warnings);
+
+        self::assertSame([], $warnings);
+        self::assertCount(1, $result->routes);
+
+        $entry = $result->routes[0];
+        self::assertSame(['GET', 'HEAD'], $entry->methods);
+        self::assertSame('/users/{id}', $entry->path);
+        self::assertSame('App\\Controller\\UserController::show', $entry->handler);
+        self::assertSame('users.show', $entry->name);
+        self::assertSame(['auth'], $entry->middleware);
+    }
+
+    #[Test]
+    public function probeCommandsReturnsEntries(): void
+    {
+        $command = new class extends Command {
+            protected function configure(): void
+            {
+                $this->name = 'make:model';
+                $this->description = 'Create a new model class';
+                $this->addArgument('name', 'The model name', true);
+                $this->addOption('migration', 'Also create a migration', 'm');
+            }
+
+            public function execute(InputInterface $input, OutputInterface $output): int
+            {
+                return 0;
+            }
+        };
+
+        // Application and Kernel are both final — use Reflection to bypass constructor
+        $reflection = new ReflectionClass(Application::class);
+        $app = $reflection->newInstanceWithoutConstructor();
+        $app->add($command);
+
+        $container = self::createStub(ContainerInterface::class);
+        $container->method('getBindings')->willReturn([]);
+
+        $probe = new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: null,
+            router: null,
+            consoleApplication: $app,
+        );
+
+        $warnings = [];
+        $result = $probe->probeCommands($warnings);
+
+        self::assertSame([], $warnings);
+        self::assertCount(1, $result->commands);
+
+        $entry = $result->commands[0];
+        self::assertSame('make:model', $entry->name);
+        self::assertSame('Create a new model class', $entry->description);
+        self::assertCount(1, $entry->arguments);
+        self::assertSame('name', $entry->arguments[0]['name']);
+        self::assertTrue($entry->arguments[0]['required']);
+        self::assertArrayHasKey('migration', $entry->options);
+    }
+
+    #[Test]
+    public function probeGracefullyHandlesNullDependencies(): void
+    {
+        $container = self::createStub(ContainerInterface::class);
+        $container->method('getBindings')->willReturn([]);
+
+        $probe = new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: null,
+            router: null,
+            consoleApplication: null,
+        );
+
+        $warnings = [];
+
+        $routes = $probe->probeRoutes($warnings);
+        self::assertSame([], $routes->routes);
+
+        $commands = $probe->probeCommands($warnings);
+        self::assertSame([], $commands->commands);
+
+        $architecture = $probe->probeArchitecture($warnings);
+        self::assertSame([], $architecture->extensions);
+
+        self::assertNotEmpty($warnings);
+
+        $warningText = implode(' | ', $warnings);
+        self::assertStringContainsString('Router not available', $warningText);
+        self::assertStringContainsString('Console Application not available', $warningText);
+        self::assertStringContainsString('ExtensionRegistry not available', $warningText);
+    }
+}

--- a/tests/Unit/Introspection/IntrospectionConfigTest.php
+++ b/tests/Unit/Introspection/IntrospectionConfigTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Introspection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Config\Environment;
+use Pulsar\Config\EnvironmentMode;
+use Pulsar\Introspection\IntrospectionConfig;
+use ReflectionClass;
+
+#[CoversClass(IntrospectionConfig::class)]
+final class IntrospectionConfigTest extends TestCase
+{
+    /**
+     * Create an Environment instance with the given variables using Reflection.
+     *
+     * @param array<string, string> $variables
+     */
+    private static function makeEnvironment(array $variables): Environment
+    {
+        $reflection = new ReflectionClass(Environment::class);
+        $instance = $reflection->newInstanceWithoutConstructor();
+
+        $prop = $reflection->getProperty('variables');
+        $prop->setValue($instance, $variables);
+
+        return $instance;
+    }
+
+    #[Test]
+    public function fromArrayDefaultsToEnabledInLocal(): void
+    {
+        $env = self::makeEnvironment([]);
+
+        $config = IntrospectionConfig::fromArray([], $env, EnvironmentMode::Local);
+        self::assertTrue($config->enabled);
+
+        $config = IntrospectionConfig::fromArray([], $env, EnvironmentMode::Staging);
+        self::assertTrue($config->enabled);
+
+        $config = IntrospectionConfig::fromArray([], $env, EnvironmentMode::Production);
+        self::assertFalse($config->enabled);
+    }
+
+    #[Test]
+    public function fromArrayEnvOverridesConfig(): void
+    {
+        $envTrue = self::makeEnvironment(['INTROSPECTION_ENABLED' => 'true']);
+
+        $config = IntrospectionConfig::fromArray(['enabled' => false], $envTrue, EnvironmentMode::Production);
+        self::assertTrue($config->enabled);
+
+        $envFalse = self::makeEnvironment(['INTROSPECTION_ENABLED' => 'false']);
+
+        $config = IntrospectionConfig::fromArray(['enabled' => true], $envFalse, EnvironmentMode::Local);
+        self::assertFalse($config->enabled);
+    }
+
+    #[Test]
+    public function fromArrayFallsBackToConfigValue(): void
+    {
+        $env = self::makeEnvironment([]);
+
+        $config = IntrospectionConfig::fromArray(['enabled' => true], $env, EnvironmentMode::Production);
+        self::assertTrue($config->enabled);
+
+        $config = IntrospectionConfig::fromArray(['enabled' => false], $env, EnvironmentMode::Local);
+        self::assertFalse($config->enabled);
+    }
+}

--- a/tests/Unit/Introspection/ProjectMetadataBuilderTest.php
+++ b/tests/Unit/Introspection/ProjectMetadataBuilderTest.php
@@ -1,0 +1,214 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Introspection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Introspection\ProjectMetadataBuilder;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+use stdClass;
+
+#[CoversClass(ProjectMetadataBuilder::class)]
+final class ProjectMetadataBuilderTest extends TestCase
+{
+    private SensitiveDataScrubber $scrubber;
+
+    protected function setUp(): void
+    {
+        $this->scrubber = new SensitiveDataScrubber();
+    }
+
+    #[Test]
+    public function addSectionStoresData(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('info', ['key' => 'value']);
+
+        $result = $builder->build($this->scrubber);
+
+        self::assertSame('test', $result->contributorId);
+        self::assertArrayHasKey('info', $result->sections);
+        self::assertSame(['key' => 'value'], $result->sections['info']);
+    }
+
+    #[Test]
+    public function addSectionNormalizesKey(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('My Section KEY', ['a' => 1]);
+
+        $result = $builder->build($this->scrubber);
+
+        self::assertArrayHasKey('mysectionkey', $result->sections);
+    }
+
+    #[Test]
+    public function addSectionRejectsEmptyNormalizedKey(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('!!!', ['a' => 1]);
+
+        $warnings = $builder->warnings();
+
+        self::assertCount(1, $warnings);
+        self::assertStringContainsString('normalized to empty string', $warnings[0]);
+
+        $result = $builder->build($this->scrubber);
+        self::assertSame([], $result->sections);
+    }
+
+    #[Test]
+    public function addSectionRejectsWhenMaxSectionsReached(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+
+        for ($i = 0; $i < 64; $i++) {
+            $builder->addSection("section{$i}", ['i' => $i]);
+        }
+
+        self::assertSame([], $builder->warnings());
+
+        $builder->addSection('overflow', ['x' => 1]);
+
+        $warnings = $builder->warnings();
+        self::assertCount(1, $warnings);
+        self::assertStringContainsString('maximum section count', $warnings[0]);
+    }
+
+    #[Test]
+    public function addSectionRejectsDeepNesting(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+
+        // Build a structure nested 9 levels deep (exceeds max of 8)
+        $data = ['level' => 'leaf'];
+        for ($i = 0; $i < 8; $i++) {
+            $data = ['nested' => $data];
+        }
+
+        $builder->addSection('deep', $data);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('Maximum nesting depth', $warnings[0]);
+    }
+
+    #[Test]
+    public function addSectionRejectsTooManyKeys(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+
+        $data = [];
+        for ($i = 0; $i < 210; $i++) {
+            $data["key{$i}"] = $i;
+        }
+
+        $builder->addSection('wide', $data);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('exceeding limit of 200', $warnings[0]);
+
+        $result = $builder->build($this->scrubber);
+        self::assertCount(200, $result->sections['wide']);
+    }
+
+    #[Test]
+    public function addSectionRejectsByteLimitExceeded(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+
+        // Add a section that fills most of the 256KB (262,144 bytes) budget
+        $builder->addSection('big', ['payload' => str_repeat('x', 260_000)]);
+        self::assertSame([], $builder->warnings());
+
+        // This should exceed the byte limit
+        $builder->addSection('overflow', ['payload' => str_repeat('y', 5_000)]);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('byte limit', $warnings[0]);
+    }
+
+    #[Test]
+    public function addSectionRejectsObjects(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('objects', ['obj' => new stdClass()]);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('objects are not allowed', $warnings[0]);
+
+        $result = $builder->build($this->scrubber);
+        self::assertArrayNotHasKey('obj', $result->sections['objects']);
+    }
+
+    #[Test]
+    public function addSectionRejectsClosures(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('closures', ['fn' => static fn(): bool => true]);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('closures are not allowed', $warnings[0]);
+
+        $result = $builder->build($this->scrubber);
+        self::assertArrayNotHasKey('fn', $result->sections['closures']);
+    }
+
+    #[Test]
+    public function addSectionRejectsResources(): void
+    {
+        $resource = fopen('php://memory', 'r');
+        self::assertIsResource($resource);
+
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('resources', ['res' => $resource]);
+
+        fclose($resource);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('resources are not allowed', $warnings[0]);
+
+        $result = $builder->build($this->scrubber);
+        self::assertArrayNotHasKey('res', $result->sections['resources']);
+    }
+
+    #[Test]
+    public function addSectionDuplicateKeyOverwritesWithWarning(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('data', ['version' => 1]);
+        $builder->addSection('data', ['version' => 2]);
+
+        $warnings = $builder->warnings();
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('already exists, overwriting', $warnings[0]);
+
+        $result = $builder->build($this->scrubber);
+        self::assertSame(['version' => 2], $result->sections['data']);
+    }
+
+    #[Test]
+    public function buildScrubsSensitiveData(): void
+    {
+        $builder = ProjectMetadataBuilder::forContributor('test');
+        $builder->addSection('config', [
+            'host' => 'localhost',
+            'password' => 'secret123',
+            'api_key' => 'key-abc',
+        ]);
+
+        $result = $builder->build($this->scrubber);
+
+        self::assertSame('localhost', $result->sections['config']['host']);
+        self::assertSame('[REDACTED]', $result->sections['config']['password']);
+        self::assertSame('[REDACTED]', $result->sections['config']['api_key']);
+    }
+}

--- a/tests/Unit/Introspection/ProjectMetadataServiceTest.php
+++ b/tests/Unit/Introspection/ProjectMetadataServiceTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Introspection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Container\ContainerInterface;
+use Pulsar\Introspection\Internal\ConfigSchemaReflector;
+use Pulsar\Introspection\Internal\CoreRuntimeProbe;
+use Pulsar\Introspection\Internal\SnapshotFileReader;
+use Pulsar\Introspection\MetadataContributorInterface;
+use Pulsar\Introspection\ProjectMetadataBuilder;
+use Pulsar\Introspection\ProjectMetadataService;
+use Pulsar\Observability\ErrorTracking\SensitiveDataScrubber;
+
+#[CoversClass(ProjectMetadataService::class)]
+final class ProjectMetadataServiceTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/pulsar_service_test_' . uniqid();
+        mkdir($this->tempDir, 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+    }
+
+    private function makeProbe(): CoreRuntimeProbe
+    {
+        $container = self::createStub(ContainerInterface::class);
+        $container->method('getBindings')->willReturn([]);
+
+        return new CoreRuntimeProbe(
+            container: $container,
+            extensionRegistry: null,
+            router: null,
+            consoleApplication: null,
+        );
+    }
+
+    private function makeReflector(): ConfigSchemaReflector
+    {
+        return new ConfigSchemaReflector(new SensitiveDataScrubber());
+    }
+
+    private function makeReader(): SnapshotFileReader
+    {
+        return new SnapshotFileReader($this->tempDir);
+    }
+
+    #[Test]
+    public function snapshotAggregatesAllSections(): void
+    {
+        $contributor = self::createStub(MetadataContributorInterface::class);
+        $contributor->method('id')->willReturn('test-contributor');
+        $contributor->method('contribute')->willReturnCallback(
+            static function (ProjectMetadataBuilder $builder): void {
+                $builder->addSection('info', ['name' => 'test']);
+            },
+        );
+
+        $service = new ProjectMetadataService(
+            probe: $this->makeProbe(),
+            schemaReflector: $this->makeReflector(),
+            snapshotReader: $this->makeReader(),
+            scrubber: new SensitiveDataScrubber(),
+            contributors: [$contributor],
+            configClasses: [],
+        );
+
+        $snapshot = $service->snapshot();
+
+        self::assertArrayHasKey('test-contributor', $snapshot->contributions);
+        self::assertSame('test', $snapshot->contributions['test-contributor']->sections['info']['name']);
+        self::assertSame([], $snapshot->architectureMap->extensions);
+        self::assertSame([], $snapshot->routeMap->routes);
+        self::assertSame([], $snapshot->commandReference->commands);
+        self::assertSame([], $snapshot->configSchema->schemas);
+        self::assertSame([], $snapshot->apiSnapshot->classes);
+    }
+
+    #[Test]
+    public function snapshotIsMemoized(): void
+    {
+        $service = new ProjectMetadataService(
+            probe: $this->makeProbe(),
+            schemaReflector: $this->makeReflector(),
+            snapshotReader: $this->makeReader(),
+            scrubber: new SensitiveDataScrubber(),
+            contributors: [],
+            configClasses: [],
+        );
+
+        $first = $service->snapshot();
+        $second = $service->snapshot();
+
+        self::assertSame($first, $second);
+    }
+
+    #[Test]
+    public function snapshotPropagatesWarnings(): void
+    {
+        $contributor = self::createStub(MetadataContributorInterface::class);
+        $contributor->method('id')->willReturn('warn-contributor');
+        $contributor->method('contribute')->willReturnCallback(
+            static function (ProjectMetadataBuilder $builder): void {
+                $builder->addSection('data', ['a' => 1]);
+                $builder->addSection('data', ['a' => 2]);
+            },
+        );
+
+        $service = new ProjectMetadataService(
+            probe: $this->makeProbe(),
+            schemaReflector: $this->makeReflector(),
+            snapshotReader: $this->makeReader(),
+            scrubber: new SensitiveDataScrubber(),
+            contributors: [$contributor],
+            configClasses: [],
+        );
+
+        $snapshot = $service->snapshot();
+
+        self::assertNotEmpty($snapshot->warnings);
+
+        $warningText = implode(' | ', $snapshot->warnings);
+
+        // Warnings from probe (null router/registry/app)
+        self::assertStringContainsString('not available', $warningText);
+
+        // Warnings from contributor (duplicate key)
+        self::assertStringContainsString('already exists, overwriting', $warningText);
+    }
+}

--- a/tests/Unit/Introspection/ProjectMetadataServiceTest.php
+++ b/tests/Unit/Introspection/ProjectMetadataServiceTest.php
@@ -41,9 +41,9 @@ final class ProjectMetadataServiceTest extends TestCase
 
         return new CoreRuntimeProbe(
             container: $container,
-            extensionRegistry: null,
+            extensionProber: null,
             router: null,
-            consoleApplication: null,
+            commandProber: null,
         );
     }
 

--- a/tests/Unit/Introspection/SnapshotFileReaderTest.php
+++ b/tests/Unit/Introspection/SnapshotFileReaderTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Pulsar\Tests\Unit\Introspection;
+
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use Pulsar\Introspection\Internal\SnapshotFileReader;
+
+#[CoversClass(SnapshotFileReader::class)]
+final class SnapshotFileReaderTest extends TestCase
+{
+    private string $tempDir;
+
+    protected function setUp(): void
+    {
+        $this->tempDir = sys_get_temp_dir() . '/pulsar_snapshot_test_' . uniqid();
+        mkdir($this->tempDir . '/tools/api', 0o777, true);
+    }
+
+    protected function tearDown(): void
+    {
+        $snapshotPath = $this->tempDir . '/tools/api/public-api.snapshot.json';
+
+        if (file_exists($snapshotPath)) {
+            unlink($snapshotPath);
+        }
+
+        if (is_dir($this->tempDir . '/tools/api')) {
+            rmdir($this->tempDir . '/tools/api');
+        }
+
+        if (is_dir($this->tempDir . '/tools')) {
+            rmdir($this->tempDir . '/tools');
+        }
+
+        if (is_dir($this->tempDir)) {
+            rmdir($this->tempDir);
+        }
+    }
+
+    #[Test]
+    public function readParsesValidSnapshot(): void
+    {
+        $snapshot = [
+            'api_classes' => [
+                'Pulsar\\Http\\Method' => [
+                    'since' => '1.0.0',
+                    'methods' => ['isSafe', 'isIdempotent'],
+                    'constants' => ['GET', 'POST'],
+                ],
+            ],
+        ];
+
+        file_put_contents(
+            $this->tempDir . '/tools/api/public-api.snapshot.json',
+            json_encode($snapshot, JSON_THROW_ON_ERROR),
+        );
+
+        $reader = new SnapshotFileReader($this->tempDir);
+        $warnings = [];
+        $result = $reader->read($warnings);
+
+        self::assertSame([], $warnings);
+        self::assertArrayHasKey('Pulsar\\Http\\Method', $result->classes);
+        self::assertSame('1.0.0', $result->classes['Pulsar\\Http\\Method']['since']);
+        self::assertSame(['isSafe', 'isIdempotent'], $result->classes['Pulsar\\Http\\Method']['methods']);
+    }
+
+    #[Test]
+    public function readHandlesMissingFile(): void
+    {
+        $reader = new SnapshotFileReader($this->tempDir . '/nonexistent');
+        $warnings = [];
+        $result = $reader->read($warnings);
+
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('not found', $warnings[0]);
+        self::assertSame([], $result->classes);
+    }
+
+    #[Test]
+    public function readHandlesInvalidJson(): void
+    {
+        file_put_contents(
+            $this->tempDir . '/tools/api/public-api.snapshot.json',
+            '{invalid json!!!',
+        );
+
+        $reader = new SnapshotFileReader($this->tempDir);
+        $warnings = [];
+        $result = $reader->read($warnings);
+
+        self::assertNotEmpty($warnings);
+        self::assertStringContainsString('invalid JSON', $warnings[0]);
+        self::assertSame([], $result->classes);
+    }
+}

--- a/tests/Unit/Queue/WorkerOptionsTest.php
+++ b/tests/Unit/Queue/WorkerOptionsTest.php
@@ -20,7 +20,7 @@ final class WorkerOptionsTest extends TestCase
         $options = new WorkerOptions();
 
         self::assertSame(1000, $options->maxJobs);
-        self::assertSame(128, $options->maxMemoryMb);
+        self::assertSame(256, $options->maxMemoryMb);
         self::assertSame(3600, $options->timeLimitSeconds);
         self::assertSame(1000, $options->sleepMs);
     }
@@ -68,7 +68,7 @@ final class WorkerOptionsTest extends TestCase
         $options = WorkerOptions::fromConfig($config);
 
         self::assertSame(1000, $options->maxJobs);
-        self::assertSame(128, $options->maxMemoryMb);
+        self::assertSame(256, $options->maxMemoryMb);
         self::assertSame(3600, $options->timeLimitSeconds);
         self::assertSame(1000, $options->sleepMs);
     }

--- a/tests/Unit/Supervisor/PreflightCheck/MemoryPreflightCheckTest.php
+++ b/tests/Unit/Supervisor/PreflightCheck/MemoryPreflightCheckTest.php
@@ -64,11 +64,11 @@ final class MemoryPreflightCheckTest extends TestCase
     }
 
     #[Test]
-    public function it_uses_default_threshold_of_128_mb(): void
+    public function it_uses_default_threshold_of_256_mb(): void
     {
         $check = new MemoryPreflightCheck();
 
-        // Default threshold is 128 MB; a typical test process uses less
+        // Default threshold is 256 MB; a typical test process (even with coverage) uses less
         $result = $check->check();
 
         self::assertTrue($result->passed);

--- a/tools/api/public-api.snapshot.json
+++ b/tools/api/public-api.snapshot.json
@@ -1,1872 +1,1872 @@
 {
-    "api_classes": {
-        "Pulsar\\Api\\Api": {
-            "since": "",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Api\\Internal": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Audit\\AuditLoggerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\AuthManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Authorization\\GateInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Authorization\\Permission": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Authorization\\PolicyContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Authorization\\PolicyInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Authorization\\Role": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Authorization\\RoleRegistryInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Exception\\AuthenticationException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Exception\\AuthorizationException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Guard\\GuardInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Guard\\TokenResolverInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Identity\\AnonymousIdentity": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Identity\\Identity": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Identity\\IdentityInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Identity\\TwoFactorStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\Password\\PasswordHasherInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\AuthEventCollectorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\Confirm2faSetupResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\ConsumeReason": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\ConsumeResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeRotationResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeSet": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeStoreInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\TotpReplayGuardInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\TotpSecretStoreInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\TwoFactorManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\TwoFactorPurpose": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\TwoFactorRateLimiterInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\Verify2faResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Auth\\TwoFactor\\VerifyReason": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Cache\\CacheException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Cache\\FrameworkCacheInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\AppConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\AuditConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\AuthConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\AuthGuardConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\AuthorizationConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\CircuitBreakerConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ConfigLoaderInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ConfigManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ConfigRepository": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ConnectionConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\CsrfConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\DatabaseConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\DeployConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\DiskConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\Environment": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\EnvironmentMode": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ErrorTrackingConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\Exception\\ConfigException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\FeatureFlagConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\HealthCheckConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\IntegrityConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\IntegrityPolicyMode": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\LoggingChannelConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\MetricsConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ObservabilityConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\QueueConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\QueueDriverType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\RateLimitConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\ResilienceConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\RetryConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\RuntimeConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\SchedulerConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\SecurityConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\SecurityHeadersConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\SessionConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\StorageConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\StorageDriver": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\SupervisorConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\TenancyConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\TenantDatabaseConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\TracingConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Config\\TwoFactorConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\Command": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\CommandInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\Command\\NewProject\\EnvironmentPreset": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\Command\\NewProject\\ProjectPreset": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\Exception\\CommandNotFoundException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\Exception\\ConsoleException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\ExitCode": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\InputInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\OutputInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Console\\Verbosity": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Container\\BindingType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Container\\ContainerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Container\\Exception\\ContainerException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Container\\Exception\\NotFoundException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\CausationId": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\ContextPropagator": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\CorrelationId": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\Exception\\ContextException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\Middleware\\RequestContextMiddleware": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\RequestContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Context\\RequestContextHolder": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Core\\KernelInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Core\\Version": {
-            "since": "1.0.0-rc.1",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\DataProtection\\ConsentManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\DataProtection\\ConsentRecordInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\DataProtection\\DataPurgeInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\DataProtection\\RetentionPolicyInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\ConnectionInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\ConnectionManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Driver": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Exception\\DatabaseException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\FetchMode": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Migration\\MigrationDirection": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Migration\\MigrationFile": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Migration\\MigrationInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Migration\\MigrationRecord": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Migration\\MigrationRepository": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Migration\\MigrationRunner": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Result": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Row": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Statement": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Database\\Transaction": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\CheckResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\CheckSeverity": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\DeployCheckInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\DeployCheckRunnerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\DeployReport": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\Exception\\DeployException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Deploy\\Runtime\\PhpRuntimeInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\ErrorHandling\\ExceptionRendererInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\ErrorHandling\\Exception\\ErrorHandlingException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\ErrorHandling\\HttpException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\ErrorHandling\\HttpExceptionInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Event\\EventEnvelope": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Event\\EventMetadata": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\Exception\\DependencyException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\Exception\\ExtensionException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\Exception\\ManifestException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\ExtensionBootstrap": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\ExtensionInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\ExtensionLifecycle": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\ExtensionManifest": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\Manifest\\ProvidesConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\Manifest\\PulsarVersionConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\Manifest\\RequiresConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\PostBootExtensionInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\PreBootExtensionInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Extensibility\\ServiceProviderInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\Exception\\FeatureFlagException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FeatureFlagManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagDefinition": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagEvaluation": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagEvaluationLogInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagEvaluationReason": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagStorageDriver": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagStorageInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\FeatureFlag\\FlagType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\HeaderBag": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Method": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Middleware\\MiddlewareInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Middleware\\MiddlewarePipelineInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\RateLimit\\RateLimitResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\RateLimit\\RateLimiterInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Request": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Response": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\ResponseEmitter": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\ResponseStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\TrustedProxy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\RuleInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\Between": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\Email": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\In": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\IntegerType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\Max": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\MaxLength": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\Min": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\MinLength": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\Regex": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\Required": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Rule\\StringType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\ValidationException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\ValidationResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Validator": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Http\\Validation\\Violation": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\Exception\\IdempotencyException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\IdempotencyClaim": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\IdempotencyClaimStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\IdempotencyKey": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\IdempotencyRecord": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\IdempotencyStoreInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Idempotency\\InMemoryIdempotencyStore": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\Exception\\IntegrityException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\FileVerificationResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\FileVerificationStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\IntegrityManifest": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\IntegrityPolicy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\ManifestBuilderInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\ManifestEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\ManifestFormat": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\ManifestSignerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\ManifestVerifierInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Integrity\\VerificationResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ApiSnapshotData": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ArchitectureMapData": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\CommandEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\CommandReferenceData": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ConfigPropertySchema": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ConfigSchemaData": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ConfigSchemaEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ContributedMetadata": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\ExtensionEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\RouteEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\Data\\RouteMapData": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\IntrospectionConfig": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\MetadataContributorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\ProjectMetadataBuilder": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\ProjectMetadataService": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Introspection\\ProjectMetadataSnapshot": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Context\\CorrelationContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Context\\CorrelationContextProviderInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\ErrorTracking\\ErrorAggregatorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\ErrorTracking\\ErrorEvent": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\ErrorTracking\\ErrorFingerprint": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\ErrorTracking\\Exception\\ErrorTrackingException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\ErrorTracking\\SensitiveDataScrubber": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Log\\Exception\\LogException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Log\\LogEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Log\\LogLevel": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Log\\LogSinkInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Log\\Sink\\DeferredSinkInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Metrics\\LabelSet": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Metrics\\MetricRegistry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Metrics\\MetricSnapshot": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Metrics\\MetricType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\Exception\\TracingException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\Span": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\SpanProcessorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\SpanStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\TraceContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\TraceContextParserInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Observability\\Tracing\\TraceId": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\DeadLetterQueue": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\Exception\\QueueException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\FailedJob": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\JobContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\JobRecord": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\JobRecordStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\QueueDriverInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\QueueManager": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\QueueableInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\Retry\\QueueRetryPolicy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\Retry\\RetryDecision": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\Worker": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\WorkerOptions": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Queue\\WorkerStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\CircuitBreakerState": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\Exception\\ResilienceException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\HealthCheck\\HealthCheckInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\HealthCheck\\HealthCheckResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\HealthCheck\\HealthCheckRunnerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\HealthCheck\\HealthReport": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\HealthCheck\\HealthStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\Repair\\RepairDiagnosis": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\Repair\\RepairJobInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\Repair\\RepairResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\Repair\\RepairRunnerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\RetryPolicy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Resilience\\RetryResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Routing\\MatchedRoute": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Routing\\Route": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Routing\\RouteGroup": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Routing\\Router": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Routing\\RouterInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Routing\\RoutingException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\Exception\\RuntimeException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\FpmRuntime": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\PersistentRuntimeFactoryInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\ResettableInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\RuntimeCollectorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\RuntimeInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\RuntimeStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\Upgrade\\UpgradeContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\Upgrade\\UpgradeHandlerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Runtime\\Upgrade\\UpgradeResponse": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\CronFields": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\Exception\\SchedulerException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\JobContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\JobEvent": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\JobInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\JobRegistry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\JobResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\JobStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\Schedule": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\Scheduler": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Scheduler\\SchedulerTickResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\AuditChainResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\AuditEntry": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\AuditEvent": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\AuditLogger": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\AuditOutcome": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\AuditSinkInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Audit\\ChainableAuditSinkInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Crypto\\EncryptorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Crypto\\Hmac": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Crypto\\HmacInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Crypto\\KeyProviderInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Crypto\\KeyRingInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Csrf\\CsrfTokenManagerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Exception\\SecurityException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Incident\\IncidentInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Incident\\IncidentReporterInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Incident\\IncidentSeverity": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Security\\Session\\SessionInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Storage\\StorageAdapterInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Storage\\StorageException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Storage\\StorageManager": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Storage\\StorageMetadata": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Storage\\StorageObject": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\CachePurgeHookInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\ConnectionResetHookInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\Exception\\SupervisorException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\HealingAction": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\HealingActionType": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunnerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\RecycleAction": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\RecycleReason": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\RecycleRecord": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\StuckJobPolicy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\SupervisorInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Supervisor\\WorkerRecyclePolicy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Support\\AtomicFileWriter": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Support\\SqliteWalFactory": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Tenancy\\Exception\\TenancyException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Tenancy\\Tenant": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Tenancy\\TenantContext": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Tenancy\\TenantDatabaseStrategy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Tenancy\\TenantResolverInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Tenancy\\TenantResolverStrategy": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\Exception\\WebhookException": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\InMemoryWebhookEventLog": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookClaim": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookClaimStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookEventLogInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookHandlerInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookProcessingResult": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookProcessingStatus": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookProcessor": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        },
-        "Pulsar\\Webhook\\WebhookVerifierInterface": {
-            "since": "1.0.0",
-            "methods": [],
-            "constants": []
-        }
+  "api_classes": {
+    "Pulsar\\Api\\Api": {
+      "since": "",
+      "methods": [],
+      "constants": []
     },
-    "internal_classes": [
-        "Pulsar\\Auth\\TwoFactor\\InMemoryRecoveryCodeStore",
-        "Pulsar\\Auth\\TwoFactor\\InMemoryTotpReplayGuard",
-        "Pulsar\\Auth\\TwoFactor\\InMemoryTotpSecretStore",
-        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeHasher",
-        "Pulsar\\Auth\\TwoFactor\\SqliteTotpReplayGuard",
-        "Pulsar\\Cache\\CacheAllowedClasses",
-        "Pulsar\\Cache\\CacheIntegrity",
-        "Pulsar\\Cache\\CacheLock",
-        "Pulsar\\Cache\\CacheManifest",
-        "Pulsar\\Cache\\CachedRoute",
-        "Pulsar\\Cache\\ConfigCache",
-        "Pulsar\\Cache\\ContainerCache",
-        "Pulsar\\Cache\\FrameworkCache",
-        "Pulsar\\Cache\\RouteCache",
-        "Pulsar\\Cache\\RouteHandler",
-        "Pulsar\\Cache\\RouteHandlerType",
-        "Pulsar\\Config\\ConfigManager",
-        "Pulsar\\Config\\ConfigOverrides",
-        "Pulsar\\Console\\Application",
-        "Pulsar\\Console\\Command\\CacheWarmupCommand",
-        "Pulsar\\Console\\Command\\DeployCheckCommand",
-        "Pulsar\\Console\\Command\\KeyGenerateCommand",
-        "Pulsar\\Console\\Command\\KeyRotateCommand",
-        "Pulsar\\Console\\Command\\NewProject\\ComposerJsonGenerator",
-        "Pulsar\\Console\\Command\\NewProject\\DirectoryLayout",
-        "Pulsar\\Console\\Command\\NewProject\\ProjectGenerator",
-        "Pulsar\\Console\\Command\\NewProject\\SecureEnvGenerator",
-        "Pulsar\\Console\\Command\\NewProject\\TemplateRegistry",
-        "Pulsar\\Console\\Command\\OptimizeClearCommand",
-        "Pulsar\\Console\\Command\\OptimizeCommand",
-        "Pulsar\\Console\\Command\\OptimizeValidateCommand",
-        "Pulsar\\Console\\Command\\PreloadDumpCommand",
-        "Pulsar\\Core\\BootProfile",
-        "Pulsar\\Core\\Kernel",
-        "Pulsar\\Core\\Wiring\\AuthWiring",
-        "Pulsar\\Core\\Wiring\\ConfigWiring",
-        "Pulsar\\Core\\Wiring\\DatabaseWiring",
-        "Pulsar\\Core\\Wiring\\DeployWiring",
-        "Pulsar\\Core\\Wiring\\DiagnosticsWiring",
-        "Pulsar\\Core\\Wiring\\ErrorTrackingWiring",
-        "Pulsar\\Core\\Wiring\\ExceptionHandlerWiring",
-        "Pulsar\\Core\\Wiring\\FeatureFlagWiring",
-        "Pulsar\\Core\\Wiring\\IntegrityWiring",
-        "Pulsar\\Core\\Wiring\\IntrospectionWiring",
-        "Pulsar\\Core\\Wiring\\LoggingWiring",
-        "Pulsar\\Core\\Wiring\\MetricsWiring",
-        "Pulsar\\Core\\Wiring\\QueueWiring",
-        "Pulsar\\Core\\Wiring\\RequestContextWiring",
-        "Pulsar\\Core\\Wiring\\ResilienceWiring",
-        "Pulsar\\Core\\Wiring\\RuntimeWiring",
-        "Pulsar\\Core\\Wiring\\SchedulerWiring",
-        "Pulsar\\Core\\Wiring\\SecurityWiring",
-        "Pulsar\\Core\\Wiring\\ServiceWiringInterface",
-        "Pulsar\\Core\\Wiring\\SupervisorWiring",
-        "Pulsar\\Core\\Wiring\\TenancyWiring",
-        "Pulsar\\Core\\Wiring\\TracingWiring",
-        "Pulsar\\DataProtection\\DefaultRetentionPolicy",
-        "Pulsar\\Deploy\\Check\\CacheSettingsCheck",
-        "Pulsar\\Deploy\\Check\\DebugModeCheck",
-        "Pulsar\\Deploy\\Check\\FilesystemScanCheck",
-        "Pulsar\\Deploy\\Check\\HealthEndpointCheck",
-        "Pulsar\\Deploy\\Check\\Http3ReadinessCheck",
-        "Pulsar\\Deploy\\Check\\HttpsReadinessCheck",
-        "Pulsar\\Deploy\\Check\\IntegrityCheck",
-        "Pulsar\\Deploy\\Check\\JitCheck",
-        "Pulsar\\Deploy\\Check\\OpcacheCheck",
-        "Pulsar\\Deploy\\Check\\RateLimitCheck",
-        "Pulsar\\Deploy\\Check\\RequestSizeCheck",
-        "Pulsar\\Deploy\\Check\\SecurityHeadersReadinessCheck",
-        "Pulsar\\Deploy\\Check\\SeverityOverrideCheck",
-        "Pulsar\\Deploy\\Check\\SkippedCheck",
-        "Pulsar\\Deploy\\Check\\TrustedProxyCheck",
-        "Pulsar\\Deploy\\DeployCheck",
-        "Pulsar\\Deploy\\DeploySeverity",
-        "Pulsar\\Deploy\\Runtime\\FilesystemReader",
-        "Pulsar\\Deploy\\Runtime\\FilesystemReaderInterface",
-        "Pulsar\\Deploy\\Runtime\\PhpRuntime",
-        "Pulsar\\Deploy\\Snippet\\ProxySnippetGenerator",
-        "Pulsar\\Deploy\\Snippet\\TlsSnippetGenerator",
-        "Pulsar\\Extensibility\\ExtensionLoader",
-        "Pulsar\\Extensibility\\ExtensionRegistry",
-        "Pulsar\\Http\\Middleware\\MiddlewarePipeline",
-        "Pulsar\\Http\\Middleware\\MiddlewareRegistry",
-        "Pulsar\\Http\\RateLimit\\RateLimiter",
-        "Pulsar\\Http\\RateLimit\\SqliteRateLimiter",
-        "Pulsar\\Http\\RouteContext",
-        "Pulsar\\Integrity\\ManifestBuilder",
-        "Pulsar\\Integrity\\ManifestSigner",
-        "Pulsar\\Integrity\\ManifestVerifier",
-        "Pulsar\\Introspection\\Internal\\ConfigSchemaReflector",
-        "Pulsar\\Introspection\\Internal\\CoreRuntimeProbe",
-        "Pulsar\\Introspection\\Internal\\SnapshotFileReader",
-        "Pulsar\\Observability\\Log\\Sink\\DeferredSink",
-        "Pulsar\\Queue\\Driver\\DatabaseDriver",
-        "Pulsar\\Queue\\Driver\\InMemoryDriver",
-        "Pulsar\\Queue\\Driver\\SyncDriver",
-        "Pulsar\\Runtime\\Fiber\\FiberScheduler",
-        "Pulsar\\Runtime\\Http\\ConnectionContext",
-        "Pulsar\\Runtime\\Http\\HttpRequestParser",
-        "Pulsar\\Runtime\\Http\\HttpResponseSerializer",
-        "Pulsar\\Runtime\\LeakDetector",
-        "Pulsar\\Runtime\\PersistentRuntime",
-        "Pulsar\\Runtime\\PersistentRuntimeFactory",
-        "Pulsar\\Runtime\\RequestResetRegistry",
-        "Pulsar\\Runtime\\RequestSandbox",
-        "Pulsar\\Runtime\\ResourceEntry",
-        "Pulsar\\Security\\Audit\\AuditChainVerifier",
-        "Pulsar\\Security\\Crypto\\EnvKeyRing",
-        "Pulsar\\Security\\Crypto\\HmacService",
-        "Pulsar\\Supervisor\\InvariantCheck\\InvariantRunner",
-        "Pulsar\\Supervisor\\PreflightCheck\\DiskSpacePreflightCheck",
-        "Pulsar\\Supervisor\\PreflightCheck\\MemoryPreflightCheck",
-        "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunner",
-        "Pulsar\\Supervisor\\StuckJobDetector",
-        "Pulsar\\Supervisor\\StuckJobRecovery",
-        "Pulsar\\Supervisor\\Supervisor"
-    ]
+    "Pulsar\\Api\\Internal": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Audit\\AuditLoggerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\AuthManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Authorization\\GateInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Authorization\\Permission": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Authorization\\PolicyContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Authorization\\PolicyInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Authorization\\Role": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Authorization\\RoleRegistryInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Exception\\AuthenticationException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Exception\\AuthorizationException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Guard\\GuardInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Guard\\TokenResolverInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Identity\\AnonymousIdentity": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Identity\\Identity": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Identity\\IdentityInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Identity\\TwoFactorStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\Password\\PasswordHasherInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\AuthEventCollectorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\Confirm2faSetupResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\ConsumeReason": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\ConsumeResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeRotationResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeSet": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeStoreInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TotpReplayGuardInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TotpSecretStoreInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TwoFactorManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TwoFactorPurpose": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\TwoFactorRateLimiterInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\Verify2faResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Auth\\TwoFactor\\VerifyReason": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Cache\\CacheException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Cache\\FrameworkCacheInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\AppConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\AuditConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\AuthConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\AuthGuardConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\AuthorizationConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\CircuitBreakerConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ConfigLoaderInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ConfigManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ConfigRepository": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ConnectionConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\CsrfConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\DatabaseConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\DeployConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\DiskConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\Environment": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\EnvironmentMode": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ErrorTrackingConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\Exception\\ConfigException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\FeatureFlagConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\HealthCheckConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\IntegrityConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\IntegrityPolicyMode": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\LoggingChannelConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\MetricsConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ObservabilityConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\QueueConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\QueueDriverType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\RateLimitConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\ResilienceConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\RetryConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\RuntimeConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\SchedulerConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\SecurityConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\SecurityHeadersConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\SessionConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\StorageConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\StorageDriver": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\SupervisorConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\TenancyConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\TenantDatabaseConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\TracingConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Config\\TwoFactorConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\Command": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\CommandInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\Command\\NewProject\\EnvironmentPreset": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\Command\\NewProject\\ProjectPreset": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\Exception\\CommandNotFoundException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\Exception\\ConsoleException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\ExitCode": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\InputInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\OutputInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Console\\Verbosity": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Container\\BindingType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Container\\ContainerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Container\\Exception\\ContainerException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Container\\Exception\\NotFoundException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\CausationId": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\ContextPropagator": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\CorrelationId": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\Exception\\ContextException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\Middleware\\RequestContextMiddleware": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\RequestContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Context\\RequestContextHolder": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Core\\KernelInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Core\\Version": {
+      "since": "1.0.0-rc.1",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\DataProtection\\ConsentManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\DataProtection\\ConsentRecordInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\DataProtection\\DataPurgeInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\DataProtection\\RetentionPolicyInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\ConnectionInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\ConnectionManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Driver": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Exception\\DatabaseException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\FetchMode": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Migration\\MigrationDirection": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Migration\\MigrationFile": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Migration\\MigrationInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Migration\\MigrationRecord": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Migration\\MigrationRepository": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Migration\\MigrationRunner": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Result": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Row": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Statement": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Database\\Transaction": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\CheckResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\CheckSeverity": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\DeployCheckInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\DeployCheckRunnerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\DeployReport": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\Exception\\DeployException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Deploy\\Runtime\\PhpRuntimeInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\ErrorHandling\\ExceptionRendererInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\ErrorHandling\\Exception\\ErrorHandlingException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\ErrorHandling\\HttpException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\ErrorHandling\\HttpExceptionInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Event\\EventEnvelope": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Event\\EventMetadata": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\Exception\\DependencyException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\Exception\\ExtensionException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\Exception\\ManifestException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\ExtensionBootstrap": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\ExtensionInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\ExtensionLifecycle": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\ExtensionManifest": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\Manifest\\ProvidesConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\Manifest\\PulsarVersionConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\Manifest\\RequiresConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\PostBootExtensionInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\PreBootExtensionInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Extensibility\\ServiceProviderInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\Exception\\FeatureFlagException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FeatureFlagManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagDefinition": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagEvaluation": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagEvaluationLogInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagEvaluationReason": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagStorageDriver": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagStorageInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\FeatureFlag\\FlagType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\HeaderBag": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Method": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Middleware\\MiddlewareInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Middleware\\MiddlewarePipelineInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\RateLimit\\RateLimitResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\RateLimit\\RateLimiterInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Request": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Response": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\ResponseEmitter": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\ResponseStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\TrustedProxy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\RuleInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\Between": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\Email": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\In": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\IntegerType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\Max": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\MaxLength": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\Min": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\MinLength": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\Regex": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\Required": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Rule\\StringType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\ValidationException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\ValidationResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Validator": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Http\\Validation\\Violation": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\Exception\\IdempotencyException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\IdempotencyClaim": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\IdempotencyClaimStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\IdempotencyKey": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\IdempotencyRecord": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\IdempotencyStoreInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Idempotency\\InMemoryIdempotencyStore": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\Exception\\IntegrityException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\FileVerificationResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\FileVerificationStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\IntegrityManifest": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\IntegrityPolicy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\ManifestBuilderInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\ManifestEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\ManifestFormat": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\ManifestSignerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\ManifestVerifierInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Integrity\\VerificationResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ApiSnapshotData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ArchitectureMapData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\CommandEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\CommandReferenceData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ConfigPropertySchema": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ConfigSchemaData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ConfigSchemaEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ContributedMetadata": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ExtensionEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\RouteEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\RouteMapData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\IntrospectionConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\MetadataContributorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\ProjectMetadataBuilder": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\ProjectMetadataService": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\ProjectMetadataSnapshot": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Context\\CorrelationContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Context\\CorrelationContextProviderInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\ErrorTracking\\ErrorAggregatorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\ErrorTracking\\ErrorEvent": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\ErrorTracking\\ErrorFingerprint": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\ErrorTracking\\Exception\\ErrorTrackingException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\ErrorTracking\\SensitiveDataScrubber": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Log\\Exception\\LogException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Log\\LogEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Log\\LogLevel": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Log\\LogSinkInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Log\\Sink\\DeferredSinkInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Metrics\\LabelSet": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Metrics\\MetricRegistry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Metrics\\MetricSnapshot": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Metrics\\MetricType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\Exception\\TracingException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\Span": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\SpanProcessorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\SpanStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\TraceContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\TraceContextParserInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Observability\\Tracing\\TraceId": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\DeadLetterQueue": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\Exception\\QueueException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\FailedJob": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\JobContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\JobRecord": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\JobRecordStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\QueueDriverInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\QueueManager": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\QueueableInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\Retry\\QueueRetryPolicy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\Retry\\RetryDecision": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\Worker": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\WorkerOptions": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Queue\\WorkerStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\CircuitBreakerState": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\Exception\\ResilienceException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\HealthCheck\\HealthCheckInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\HealthCheck\\HealthCheckResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\HealthCheck\\HealthCheckRunnerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\HealthCheck\\HealthReport": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\HealthCheck\\HealthStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\Repair\\RepairDiagnosis": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\Repair\\RepairJobInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\Repair\\RepairResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\Repair\\RepairRunnerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\RetryPolicy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Resilience\\RetryResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Routing\\MatchedRoute": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Routing\\Route": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Routing\\RouteGroup": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Routing\\Router": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Routing\\RouterInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Routing\\RoutingException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\Exception\\RuntimeException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\FpmRuntime": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\PersistentRuntimeFactoryInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\ResettableInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\RuntimeCollectorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\RuntimeInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\RuntimeStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\Upgrade\\UpgradeContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\Upgrade\\UpgradeHandlerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Runtime\\Upgrade\\UpgradeResponse": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\CronFields": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\Exception\\SchedulerException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\JobContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\JobEvent": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\JobInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\JobRegistry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\JobResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\JobStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\Schedule": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\Scheduler": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Scheduler\\SchedulerTickResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\AuditChainResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\AuditEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\AuditEvent": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\AuditLogger": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\AuditOutcome": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\AuditSinkInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Audit\\ChainableAuditSinkInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Crypto\\EncryptorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Crypto\\Hmac": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Crypto\\HmacInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Crypto\\KeyProviderInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Crypto\\KeyRingInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Csrf\\CsrfTokenManagerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Exception\\SecurityException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Incident\\IncidentInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Incident\\IncidentReporterInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Incident\\IncidentSeverity": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Security\\Session\\SessionInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Storage\\StorageAdapterInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Storage\\StorageException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Storage\\StorageManager": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Storage\\StorageMetadata": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Storage\\StorageObject": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\CachePurgeHookInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\ConnectionResetHookInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\Exception\\SupervisorException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\HealingAction": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\HealingActionType": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunnerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\RecycleAction": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\RecycleReason": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\RecycleRecord": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\StuckJobPolicy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\SupervisorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Supervisor\\WorkerRecyclePolicy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Support\\AtomicFileWriter": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Support\\SqliteWalFactory": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Tenancy\\Exception\\TenancyException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Tenancy\\Tenant": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Tenancy\\TenantContext": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Tenancy\\TenantDatabaseStrategy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Tenancy\\TenantResolverInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Tenancy\\TenantResolverStrategy": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\Exception\\WebhookException": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\InMemoryWebhookEventLog": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookClaim": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookClaimStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookEventLogInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookHandlerInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookProcessingResult": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookProcessingStatus": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookProcessor": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Webhook\\WebhookVerifierInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    }
+  },
+  "internal_classes": [
+    "Pulsar\\Auth\\TwoFactor\\InMemoryRecoveryCodeStore",
+    "Pulsar\\Auth\\TwoFactor\\InMemoryTotpReplayGuard",
+    "Pulsar\\Auth\\TwoFactor\\InMemoryTotpSecretStore",
+    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeHasher",
+    "Pulsar\\Auth\\TwoFactor\\SqliteTotpReplayGuard",
+    "Pulsar\\Cache\\CacheAllowedClasses",
+    "Pulsar\\Cache\\CacheIntegrity",
+    "Pulsar\\Cache\\CacheLock",
+    "Pulsar\\Cache\\CacheManifest",
+    "Pulsar\\Cache\\CachedRoute",
+    "Pulsar\\Cache\\ConfigCache",
+    "Pulsar\\Cache\\ContainerCache",
+    "Pulsar\\Cache\\FrameworkCache",
+    "Pulsar\\Cache\\RouteCache",
+    "Pulsar\\Cache\\RouteHandler",
+    "Pulsar\\Cache\\RouteHandlerType",
+    "Pulsar\\Config\\ConfigManager",
+    "Pulsar\\Config\\ConfigOverrides",
+    "Pulsar\\Console\\Application",
+    "Pulsar\\Console\\Command\\CacheWarmupCommand",
+    "Pulsar\\Console\\Command\\DeployCheckCommand",
+    "Pulsar\\Console\\Command\\KeyGenerateCommand",
+    "Pulsar\\Console\\Command\\KeyRotateCommand",
+    "Pulsar\\Console\\Command\\NewProject\\ComposerJsonGenerator",
+    "Pulsar\\Console\\Command\\NewProject\\DirectoryLayout",
+    "Pulsar\\Console\\Command\\NewProject\\ProjectGenerator",
+    "Pulsar\\Console\\Command\\NewProject\\SecureEnvGenerator",
+    "Pulsar\\Console\\Command\\NewProject\\TemplateRegistry",
+    "Pulsar\\Console\\Command\\OptimizeClearCommand",
+    "Pulsar\\Console\\Command\\OptimizeCommand",
+    "Pulsar\\Console\\Command\\OptimizeValidateCommand",
+    "Pulsar\\Console\\Command\\PreloadDumpCommand",
+    "Pulsar\\Core\\BootProfile",
+    "Pulsar\\Core\\Kernel",
+    "Pulsar\\Core\\Wiring\\AuthWiring",
+    "Pulsar\\Core\\Wiring\\ConfigWiring",
+    "Pulsar\\Core\\Wiring\\DatabaseWiring",
+    "Pulsar\\Core\\Wiring\\DeployWiring",
+    "Pulsar\\Core\\Wiring\\DiagnosticsWiring",
+    "Pulsar\\Core\\Wiring\\ErrorTrackingWiring",
+    "Pulsar\\Core\\Wiring\\ExceptionHandlerWiring",
+    "Pulsar\\Core\\Wiring\\FeatureFlagWiring",
+    "Pulsar\\Core\\Wiring\\IntegrityWiring",
+    "Pulsar\\Core\\Wiring\\IntrospectionWiring",
+    "Pulsar\\Core\\Wiring\\LoggingWiring",
+    "Pulsar\\Core\\Wiring\\MetricsWiring",
+    "Pulsar\\Core\\Wiring\\QueueWiring",
+    "Pulsar\\Core\\Wiring\\RequestContextWiring",
+    "Pulsar\\Core\\Wiring\\ResilienceWiring",
+    "Pulsar\\Core\\Wiring\\RuntimeWiring",
+    "Pulsar\\Core\\Wiring\\SchedulerWiring",
+    "Pulsar\\Core\\Wiring\\SecurityWiring",
+    "Pulsar\\Core\\Wiring\\ServiceWiringInterface",
+    "Pulsar\\Core\\Wiring\\SupervisorWiring",
+    "Pulsar\\Core\\Wiring\\TenancyWiring",
+    "Pulsar\\Core\\Wiring\\TracingWiring",
+    "Pulsar\\DataProtection\\DefaultRetentionPolicy",
+    "Pulsar\\Deploy\\Check\\CacheSettingsCheck",
+    "Pulsar\\Deploy\\Check\\DebugModeCheck",
+    "Pulsar\\Deploy\\Check\\FilesystemScanCheck",
+    "Pulsar\\Deploy\\Check\\HealthEndpointCheck",
+    "Pulsar\\Deploy\\Check\\Http3ReadinessCheck",
+    "Pulsar\\Deploy\\Check\\HttpsReadinessCheck",
+    "Pulsar\\Deploy\\Check\\IntegrityCheck",
+    "Pulsar\\Deploy\\Check\\JitCheck",
+    "Pulsar\\Deploy\\Check\\OpcacheCheck",
+    "Pulsar\\Deploy\\Check\\RateLimitCheck",
+    "Pulsar\\Deploy\\Check\\RequestSizeCheck",
+    "Pulsar\\Deploy\\Check\\SecurityHeadersReadinessCheck",
+    "Pulsar\\Deploy\\Check\\SeverityOverrideCheck",
+    "Pulsar\\Deploy\\Check\\SkippedCheck",
+    "Pulsar\\Deploy\\Check\\TrustedProxyCheck",
+    "Pulsar\\Deploy\\DeployCheck",
+    "Pulsar\\Deploy\\DeploySeverity",
+    "Pulsar\\Deploy\\Runtime\\FilesystemReader",
+    "Pulsar\\Deploy\\Runtime\\FilesystemReaderInterface",
+    "Pulsar\\Deploy\\Runtime\\PhpRuntime",
+    "Pulsar\\Deploy\\Snippet\\ProxySnippetGenerator",
+    "Pulsar\\Deploy\\Snippet\\TlsSnippetGenerator",
+    "Pulsar\\Extensibility\\ExtensionLoader",
+    "Pulsar\\Extensibility\\ExtensionRegistry",
+    "Pulsar\\Http\\Middleware\\MiddlewarePipeline",
+    "Pulsar\\Http\\Middleware\\MiddlewareRegistry",
+    "Pulsar\\Http\\RateLimit\\RateLimiter",
+    "Pulsar\\Http\\RateLimit\\SqliteRateLimiter",
+    "Pulsar\\Http\\RouteContext",
+    "Pulsar\\Integrity\\ManifestBuilder",
+    "Pulsar\\Integrity\\ManifestSigner",
+    "Pulsar\\Integrity\\ManifestVerifier",
+    "Pulsar\\Introspection\\Internal\\ConfigSchemaReflector",
+    "Pulsar\\Introspection\\Internal\\CoreRuntimeProbe",
+    "Pulsar\\Introspection\\Internal\\SnapshotFileReader",
+    "Pulsar\\Observability\\Log\\Sink\\DeferredSink",
+    "Pulsar\\Queue\\Driver\\DatabaseDriver",
+    "Pulsar\\Queue\\Driver\\InMemoryDriver",
+    "Pulsar\\Queue\\Driver\\SyncDriver",
+    "Pulsar\\Runtime\\Fiber\\FiberScheduler",
+    "Pulsar\\Runtime\\Http\\ConnectionContext",
+    "Pulsar\\Runtime\\Http\\HttpRequestParser",
+    "Pulsar\\Runtime\\Http\\HttpResponseSerializer",
+    "Pulsar\\Runtime\\LeakDetector",
+    "Pulsar\\Runtime\\PersistentRuntime",
+    "Pulsar\\Runtime\\PersistentRuntimeFactory",
+    "Pulsar\\Runtime\\RequestResetRegistry",
+    "Pulsar\\Runtime\\RequestSandbox",
+    "Pulsar\\Runtime\\ResourceEntry",
+    "Pulsar\\Security\\Audit\\AuditChainVerifier",
+    "Pulsar\\Security\\Crypto\\EnvKeyRing",
+    "Pulsar\\Security\\Crypto\\HmacService",
+    "Pulsar\\Supervisor\\InvariantCheck\\InvariantRunner",
+    "Pulsar\\Supervisor\\PreflightCheck\\DiskSpacePreflightCheck",
+    "Pulsar\\Supervisor\\PreflightCheck\\MemoryPreflightCheck",
+    "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunner",
+    "Pulsar\\Supervisor\\StuckJobDetector",
+    "Pulsar\\Supervisor\\StuckJobRecovery",
+    "Pulsar\\Supervisor\\Supervisor"
+  ]
 }

--- a/tools/api/public-api.snapshot.json
+++ b/tools/api/public-api.snapshot.json
@@ -1,1872 +1,1872 @@
 {
-  "api_classes": {
-    "Pulsar\\Api\\Api": {
-      "since": "",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Api\\Internal": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Audit\\AuditLoggerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\AuthManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Authorization\\GateInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Authorization\\Permission": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Authorization\\PolicyContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Authorization\\PolicyInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Authorization\\Role": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Authorization\\RoleRegistryInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Exception\\AuthenticationException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Exception\\AuthorizationException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Guard\\GuardInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Guard\\TokenResolverInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Identity\\AnonymousIdentity": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Identity\\Identity": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Identity\\IdentityInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Identity\\TwoFactorStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\Password\\PasswordHasherInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\AuthEventCollectorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\Confirm2faSetupResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\ConsumeReason": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\ConsumeResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeRotationResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeSet": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeStoreInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\TotpReplayGuardInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\TotpSecretStoreInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\TwoFactorManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\TwoFactorPurpose": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\TwoFactorRateLimiterInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\Verify2faResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Auth\\TwoFactor\\VerifyReason": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Cache\\CacheException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Cache\\FrameworkCacheInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\AppConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\AuditConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\AuthConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\AuthGuardConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\AuthorizationConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\CircuitBreakerConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ConfigLoaderInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ConfigManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ConfigRepository": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ConnectionConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\CsrfConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\DatabaseConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\DeployConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\DiskConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\Environment": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\EnvironmentMode": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ErrorTrackingConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\Exception\\ConfigException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\FeatureFlagConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\HealthCheckConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\IntegrityConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\IntegrityPolicyMode": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\LoggingChannelConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\MetricsConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ObservabilityConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\QueueConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\QueueDriverType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\RateLimitConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\ResilienceConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\RetryConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\RuntimeConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\SchedulerConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\SecurityConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\SecurityHeadersConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\SessionConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\StorageConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\StorageDriver": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\SupervisorConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\TenancyConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\TenantDatabaseConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\TracingConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Config\\TwoFactorConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\Command": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\CommandInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\Command\\NewProject\\EnvironmentPreset": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\Command\\NewProject\\ProjectPreset": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\Exception\\CommandNotFoundException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\Exception\\ConsoleException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\ExitCode": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\InputInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\OutputInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Console\\Verbosity": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Container\\BindingType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Container\\ContainerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Container\\Exception\\ContainerException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Container\\Exception\\NotFoundException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\CausationId": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\ContextPropagator": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\CorrelationId": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\Exception\\ContextException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\Middleware\\RequestContextMiddleware": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\RequestContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Context\\RequestContextHolder": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Core\\KernelInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Core\\Version": {
-      "since": "1.0.0-rc.1",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\DataProtection\\ConsentManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\DataProtection\\ConsentRecordInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\DataProtection\\DataPurgeInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\DataProtection\\RetentionPolicyInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\ConnectionInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\ConnectionManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Driver": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Exception\\DatabaseException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\FetchMode": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Migration\\MigrationDirection": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Migration\\MigrationFile": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Migration\\MigrationInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Migration\\MigrationRecord": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Migration\\MigrationRepository": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Migration\\MigrationRunner": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Result": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Row": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Statement": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Database\\Transaction": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\CheckResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\CheckSeverity": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\DeployCheckInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\DeployCheckRunnerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\DeployReport": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\Exception\\DeployException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Deploy\\Runtime\\PhpRuntimeInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\ErrorHandling\\ExceptionRendererInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\ErrorHandling\\Exception\\ErrorHandlingException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\ErrorHandling\\HttpException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\ErrorHandling\\HttpExceptionInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Event\\EventEnvelope": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Event\\EventMetadata": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\Exception\\DependencyException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\Exception\\ExtensionException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\Exception\\ManifestException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\ExtensionBootstrap": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\ExtensionInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\ExtensionLifecycle": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\ExtensionManifest": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\Manifest\\ProvidesConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\Manifest\\PulsarVersionConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\Manifest\\RequiresConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\PostBootExtensionInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\PreBootExtensionInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Extensibility\\ServiceProviderInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\Exception\\FeatureFlagException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FeatureFlagManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagDefinition": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagEvaluation": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagEvaluationLogInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagEvaluationReason": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagStorageDriver": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagStorageInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\FeatureFlag\\FlagType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\HeaderBag": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Method": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Middleware\\MiddlewareInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Middleware\\MiddlewarePipelineInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\RateLimit\\RateLimitResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\RateLimit\\RateLimiterInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Request": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Response": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\ResponseEmitter": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\ResponseStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\TrustedProxy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\RuleInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\Between": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\Email": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\In": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\IntegerType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\Max": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\MaxLength": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\Min": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\MinLength": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\Regex": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\Required": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Rule\\StringType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\ValidationException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\ValidationResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Validator": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Http\\Validation\\Violation": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\Exception\\IdempotencyException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\IdempotencyClaim": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\IdempotencyClaimStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\IdempotencyKey": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\IdempotencyRecord": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\IdempotencyStoreInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Idempotency\\InMemoryIdempotencyStore": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\Exception\\IntegrityException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\FileVerificationResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\FileVerificationStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\IntegrityManifest": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\IntegrityPolicy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\ManifestBuilderInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\ManifestEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\ManifestFormat": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\ManifestSignerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\ManifestVerifierInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Integrity\\VerificationResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ApiSnapshotData": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ArchitectureMapData": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\CommandEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\CommandReferenceData": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ConfigPropertySchema": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ConfigSchemaData": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ConfigSchemaEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ContributedMetadata": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\ExtensionEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\RouteEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\Data\\RouteMapData": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\IntrospectionConfig": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\MetadataContributorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\ProjectMetadataBuilder": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\ProjectMetadataService": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Introspection\\ProjectMetadataSnapshot": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Context\\CorrelationContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Context\\CorrelationContextProviderInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\ErrorTracking\\ErrorAggregatorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\ErrorTracking\\ErrorEvent": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\ErrorTracking\\ErrorFingerprint": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\ErrorTracking\\Exception\\ErrorTrackingException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\ErrorTracking\\SensitiveDataScrubber": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Log\\Exception\\LogException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Log\\LogEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Log\\LogLevel": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Log\\LogSinkInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Log\\Sink\\DeferredSinkInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Metrics\\LabelSet": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Metrics\\MetricRegistry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Metrics\\MetricSnapshot": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Metrics\\MetricType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\Exception\\TracingException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\Span": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\SpanProcessorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\SpanStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\TraceContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\TraceContextParserInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Observability\\Tracing\\TraceId": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\DeadLetterQueue": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\Exception\\QueueException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\FailedJob": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\JobContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\JobRecord": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\JobRecordStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\QueueDriverInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\QueueManager": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\QueueableInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\Retry\\QueueRetryPolicy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\Retry\\RetryDecision": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\Worker": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\WorkerOptions": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Queue\\WorkerStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\CircuitBreakerState": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\Exception\\ResilienceException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\HealthCheck\\HealthCheckInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\HealthCheck\\HealthCheckResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\HealthCheck\\HealthCheckRunnerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\HealthCheck\\HealthReport": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\HealthCheck\\HealthStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\Repair\\RepairDiagnosis": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\Repair\\RepairJobInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\Repair\\RepairResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\Repair\\RepairRunnerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\RetryPolicy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Resilience\\RetryResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Routing\\MatchedRoute": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Routing\\Route": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Routing\\RouteGroup": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Routing\\Router": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Routing\\RouterInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Routing\\RoutingException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\Exception\\RuntimeException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\FpmRuntime": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\PersistentRuntimeFactoryInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\ResettableInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\RuntimeCollectorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\RuntimeInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\RuntimeStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\Upgrade\\UpgradeContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\Upgrade\\UpgradeHandlerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Runtime\\Upgrade\\UpgradeResponse": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\CronFields": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\Exception\\SchedulerException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\JobContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\JobEvent": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\JobInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\JobRegistry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\JobResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\JobStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\Schedule": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\Scheduler": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Scheduler\\SchedulerTickResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\AuditChainResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\AuditEntry": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\AuditEvent": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\AuditLogger": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\AuditOutcome": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\AuditSinkInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Audit\\ChainableAuditSinkInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Crypto\\EncryptorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Crypto\\Hmac": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Crypto\\HmacInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Crypto\\KeyProviderInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Crypto\\KeyRingInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Csrf\\CsrfTokenManagerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Exception\\SecurityException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Incident\\IncidentInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Incident\\IncidentReporterInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Incident\\IncidentSeverity": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Security\\Session\\SessionInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Storage\\StorageAdapterInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Storage\\StorageException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Storage\\StorageManager": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Storage\\StorageMetadata": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Storage\\StorageObject": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\CachePurgeHookInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\ConnectionResetHookInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\Exception\\SupervisorException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\HealingAction": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\HealingActionType": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunnerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\RecycleAction": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\RecycleReason": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\RecycleRecord": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\StuckJobPolicy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\SupervisorInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Supervisor\\WorkerRecyclePolicy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Support\\AtomicFileWriter": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Support\\SqliteWalFactory": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Tenancy\\Exception\\TenancyException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Tenancy\\Tenant": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Tenancy\\TenantContext": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Tenancy\\TenantDatabaseStrategy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Tenancy\\TenantResolverInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Tenancy\\TenantResolverStrategy": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\Exception\\WebhookException": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\InMemoryWebhookEventLog": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookClaim": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookClaimStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookEventLogInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookHandlerInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookProcessingResult": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookProcessingStatus": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookProcessor": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    },
-    "Pulsar\\Webhook\\WebhookVerifierInterface": {
-      "since": "1.0.0",
-      "methods": [],
-      "constants": []
-    }
-  },
-  "internal_classes": [
-    "Pulsar\\Auth\\TwoFactor\\InMemoryRecoveryCodeStore",
-    "Pulsar\\Auth\\TwoFactor\\InMemoryTotpReplayGuard",
-    "Pulsar\\Auth\\TwoFactor\\InMemoryTotpSecretStore",
-    "Pulsar\\Auth\\TwoFactor\\RecoveryCodeHasher",
-    "Pulsar\\Auth\\TwoFactor\\SqliteTotpReplayGuard",
-    "Pulsar\\Cache\\CacheAllowedClasses",
-    "Pulsar\\Cache\\CacheIntegrity",
-    "Pulsar\\Cache\\CacheLock",
-    "Pulsar\\Cache\\CacheManifest",
-    "Pulsar\\Cache\\CachedRoute",
-    "Pulsar\\Cache\\ConfigCache",
-    "Pulsar\\Cache\\ContainerCache",
-    "Pulsar\\Cache\\FrameworkCache",
-    "Pulsar\\Cache\\RouteCache",
-    "Pulsar\\Cache\\RouteHandler",
-    "Pulsar\\Cache\\RouteHandlerType",
-    "Pulsar\\Config\\ConfigManager",
-    "Pulsar\\Config\\ConfigOverrides",
-    "Pulsar\\Console\\Application",
-    "Pulsar\\Console\\Command\\CacheWarmupCommand",
-    "Pulsar\\Console\\Command\\DeployCheckCommand",
-    "Pulsar\\Console\\Command\\KeyGenerateCommand",
-    "Pulsar\\Console\\Command\\KeyRotateCommand",
-    "Pulsar\\Console\\Command\\NewProject\\ComposerJsonGenerator",
-    "Pulsar\\Console\\Command\\NewProject\\DirectoryLayout",
-    "Pulsar\\Console\\Command\\NewProject\\ProjectGenerator",
-    "Pulsar\\Console\\Command\\NewProject\\SecureEnvGenerator",
-    "Pulsar\\Console\\Command\\NewProject\\TemplateRegistry",
-    "Pulsar\\Console\\Command\\OptimizeClearCommand",
-    "Pulsar\\Console\\Command\\OptimizeCommand",
-    "Pulsar\\Console\\Command\\OptimizeValidateCommand",
-    "Pulsar\\Console\\Command\\PreloadDumpCommand",
-    "Pulsar\\Core\\BootProfile",
-    "Pulsar\\Core\\Kernel",
-    "Pulsar\\Core\\Wiring\\AuthWiring",
-    "Pulsar\\Core\\Wiring\\ConfigWiring",
-    "Pulsar\\Core\\Wiring\\DatabaseWiring",
-    "Pulsar\\Core\\Wiring\\DeployWiring",
-    "Pulsar\\Core\\Wiring\\DiagnosticsWiring",
-    "Pulsar\\Core\\Wiring\\ErrorTrackingWiring",
-    "Pulsar\\Core\\Wiring\\ExceptionHandlerWiring",
-    "Pulsar\\Core\\Wiring\\FeatureFlagWiring",
-    "Pulsar\\Core\\Wiring\\IntegrityWiring",
-    "Pulsar\\Core\\Wiring\\IntrospectionWiring",
-    "Pulsar\\Core\\Wiring\\LoggingWiring",
-    "Pulsar\\Core\\Wiring\\MetricsWiring",
-    "Pulsar\\Core\\Wiring\\QueueWiring",
-    "Pulsar\\Core\\Wiring\\RequestContextWiring",
-    "Pulsar\\Core\\Wiring\\ResilienceWiring",
-    "Pulsar\\Core\\Wiring\\RuntimeWiring",
-    "Pulsar\\Core\\Wiring\\SchedulerWiring",
-    "Pulsar\\Core\\Wiring\\SecurityWiring",
-    "Pulsar\\Core\\Wiring\\ServiceWiringInterface",
-    "Pulsar\\Core\\Wiring\\SupervisorWiring",
-    "Pulsar\\Core\\Wiring\\TenancyWiring",
-    "Pulsar\\Core\\Wiring\\TracingWiring",
-    "Pulsar\\DataProtection\\DefaultRetentionPolicy",
-    "Pulsar\\Deploy\\Check\\CacheSettingsCheck",
-    "Pulsar\\Deploy\\Check\\DebugModeCheck",
-    "Pulsar\\Deploy\\Check\\FilesystemScanCheck",
-    "Pulsar\\Deploy\\Check\\HealthEndpointCheck",
-    "Pulsar\\Deploy\\Check\\Http3ReadinessCheck",
-    "Pulsar\\Deploy\\Check\\HttpsReadinessCheck",
-    "Pulsar\\Deploy\\Check\\IntegrityCheck",
-    "Pulsar\\Deploy\\Check\\JitCheck",
-    "Pulsar\\Deploy\\Check\\OpcacheCheck",
-    "Pulsar\\Deploy\\Check\\RateLimitCheck",
-    "Pulsar\\Deploy\\Check\\RequestSizeCheck",
-    "Pulsar\\Deploy\\Check\\SecurityHeadersReadinessCheck",
-    "Pulsar\\Deploy\\Check\\SeverityOverrideCheck",
-    "Pulsar\\Deploy\\Check\\SkippedCheck",
-    "Pulsar\\Deploy\\Check\\TrustedProxyCheck",
-    "Pulsar\\Deploy\\DeployCheck",
-    "Pulsar\\Deploy\\DeploySeverity",
-    "Pulsar\\Deploy\\Runtime\\FilesystemReader",
-    "Pulsar\\Deploy\\Runtime\\FilesystemReaderInterface",
-    "Pulsar\\Deploy\\Runtime\\PhpRuntime",
-    "Pulsar\\Deploy\\Snippet\\ProxySnippetGenerator",
-    "Pulsar\\Deploy\\Snippet\\TlsSnippetGenerator",
-    "Pulsar\\Extensibility\\ExtensionLoader",
-    "Pulsar\\Extensibility\\ExtensionRegistry",
-    "Pulsar\\Http\\Middleware\\MiddlewarePipeline",
-    "Pulsar\\Http\\Middleware\\MiddlewareRegistry",
-    "Pulsar\\Http\\RateLimit\\RateLimiter",
-    "Pulsar\\Http\\RateLimit\\SqliteRateLimiter",
-    "Pulsar\\Http\\RouteContext",
-    "Pulsar\\Integrity\\ManifestBuilder",
-    "Pulsar\\Integrity\\ManifestSigner",
-    "Pulsar\\Integrity\\ManifestVerifier",
-    "Pulsar\\Introspection\\Internal\\ConfigSchemaReflector",
-    "Pulsar\\Introspection\\Internal\\CoreRuntimeProbe",
-    "Pulsar\\Introspection\\Internal\\SnapshotFileReader",
-    "Pulsar\\Observability\\Log\\Sink\\DeferredSink",
-    "Pulsar\\Queue\\Driver\\DatabaseDriver",
-    "Pulsar\\Queue\\Driver\\InMemoryDriver",
-    "Pulsar\\Queue\\Driver\\SyncDriver",
-    "Pulsar\\Runtime\\Fiber\\FiberScheduler",
-    "Pulsar\\Runtime\\Http\\ConnectionContext",
-    "Pulsar\\Runtime\\Http\\HttpRequestParser",
-    "Pulsar\\Runtime\\Http\\HttpResponseSerializer",
-    "Pulsar\\Runtime\\LeakDetector",
-    "Pulsar\\Runtime\\PersistentRuntime",
-    "Pulsar\\Runtime\\PersistentRuntimeFactory",
-    "Pulsar\\Runtime\\RequestResetRegistry",
-    "Pulsar\\Runtime\\RequestSandbox",
-    "Pulsar\\Runtime\\ResourceEntry",
-    "Pulsar\\Security\\Audit\\AuditChainVerifier",
-    "Pulsar\\Security\\Crypto\\EnvKeyRing",
-    "Pulsar\\Security\\Crypto\\HmacService",
-    "Pulsar\\Supervisor\\InvariantCheck\\InvariantRunner",
-    "Pulsar\\Supervisor\\PreflightCheck\\DiskSpacePreflightCheck",
-    "Pulsar\\Supervisor\\PreflightCheck\\MemoryPreflightCheck",
-    "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunner",
-    "Pulsar\\Supervisor\\StuckJobDetector",
-    "Pulsar\\Supervisor\\StuckJobRecovery",
-    "Pulsar\\Supervisor\\Supervisor"
-  ]
+    "api_classes": {
+        "Pulsar\\Api\\Api": {
+            "since": "",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Api\\Internal": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Audit\\AuditLoggerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\AuthManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Authorization\\GateInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Authorization\\Permission": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Authorization\\PolicyContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Authorization\\PolicyInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Authorization\\Role": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Authorization\\RoleRegistryInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Exception\\AuthenticationException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Exception\\AuthorizationException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Guard\\GuardInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Guard\\TokenResolverInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Identity\\AnonymousIdentity": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Identity\\Identity": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Identity\\IdentityInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Identity\\TwoFactorStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\Password\\PasswordHasherInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\AuthEventCollectorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\Confirm2faSetupResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\ConsumeReason": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\ConsumeResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeRotationResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeSet": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeStoreInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\TotpReplayGuardInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\TotpSecretStoreInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\TwoFactorManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\TwoFactorPurpose": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\TwoFactorRateLimiterInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\Verify2faResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Auth\\TwoFactor\\VerifyReason": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Cache\\CacheException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Cache\\FrameworkCacheInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\AppConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\AuditConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\AuthConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\AuthGuardConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\AuthorizationConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\CircuitBreakerConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ConfigLoaderInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ConfigManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ConfigRepository": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ConnectionConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\CsrfConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\DatabaseConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\DeployConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\DiskConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\Environment": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\EnvironmentMode": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ErrorTrackingConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\Exception\\ConfigException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\FeatureFlagConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\HealthCheckConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\IntegrityConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\IntegrityPolicyMode": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\LoggingChannelConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\MetricsConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ObservabilityConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\QueueConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\QueueDriverType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\RateLimitConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\ResilienceConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\RetryConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\RuntimeConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\SchedulerConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\SecurityConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\SecurityHeadersConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\SessionConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\StorageConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\StorageDriver": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\SupervisorConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\TenancyConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\TenantDatabaseConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\TracingConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Config\\TwoFactorConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\Command": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\CommandInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\Command\\NewProject\\EnvironmentPreset": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\Command\\NewProject\\ProjectPreset": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\Exception\\CommandNotFoundException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\Exception\\ConsoleException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\ExitCode": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\InputInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\OutputInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Console\\Verbosity": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Container\\BindingType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Container\\ContainerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Container\\Exception\\ContainerException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Container\\Exception\\NotFoundException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\CausationId": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\ContextPropagator": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\CorrelationId": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\Exception\\ContextException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\Middleware\\RequestContextMiddleware": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\RequestContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Context\\RequestContextHolder": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Core\\KernelInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Core\\Version": {
+            "since": "1.0.0-rc.1",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\DataProtection\\ConsentManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\DataProtection\\ConsentRecordInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\DataProtection\\DataPurgeInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\DataProtection\\RetentionPolicyInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\ConnectionInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\ConnectionManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Driver": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Exception\\DatabaseException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\FetchMode": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Migration\\MigrationDirection": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Migration\\MigrationFile": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Migration\\MigrationInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Migration\\MigrationRecord": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Migration\\MigrationRepository": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Migration\\MigrationRunner": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Result": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Row": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Statement": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Database\\Transaction": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\CheckResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\CheckSeverity": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\DeployCheckInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\DeployCheckRunnerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\DeployReport": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\Exception\\DeployException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Deploy\\Runtime\\PhpRuntimeInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\ErrorHandling\\ExceptionRendererInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\ErrorHandling\\Exception\\ErrorHandlingException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\ErrorHandling\\HttpException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\ErrorHandling\\HttpExceptionInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Event\\EventEnvelope": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Event\\EventMetadata": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\Exception\\DependencyException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\Exception\\ExtensionException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\Exception\\ManifestException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\ExtensionBootstrap": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\ExtensionInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\ExtensionLifecycle": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\ExtensionManifest": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\Manifest\\ProvidesConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\Manifest\\PulsarVersionConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\Manifest\\RequiresConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\PostBootExtensionInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\PreBootExtensionInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Extensibility\\ServiceProviderInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\Exception\\FeatureFlagException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FeatureFlagManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagDefinition": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagEvaluation": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagEvaluationLogInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagEvaluationReason": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagStorageDriver": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagStorageInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\FeatureFlag\\FlagType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\HeaderBag": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Method": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Middleware\\MiddlewareInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Middleware\\MiddlewarePipelineInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\RateLimit\\RateLimitResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\RateLimit\\RateLimiterInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Request": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Response": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\ResponseEmitter": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\ResponseStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\TrustedProxy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\RuleInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\Between": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\Email": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\In": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\IntegerType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\Max": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\MaxLength": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\Min": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\MinLength": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\Regex": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\Required": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Rule\\StringType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\ValidationException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\ValidationResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Validator": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Http\\Validation\\Violation": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\Exception\\IdempotencyException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\IdempotencyClaim": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\IdempotencyClaimStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\IdempotencyKey": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\IdempotencyRecord": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\IdempotencyStoreInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Idempotency\\InMemoryIdempotencyStore": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\Exception\\IntegrityException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\FileVerificationResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\FileVerificationStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\IntegrityManifest": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\IntegrityPolicy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\ManifestBuilderInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\ManifestEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\ManifestFormat": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\ManifestSignerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\ManifestVerifierInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Integrity\\VerificationResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ApiSnapshotData": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ArchitectureMapData": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\CommandEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\CommandReferenceData": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ConfigPropertySchema": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ConfigSchemaData": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ConfigSchemaEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ContributedMetadata": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\ExtensionEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\RouteEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\Data\\RouteMapData": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\IntrospectionConfig": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\MetadataContributorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\ProjectMetadataBuilder": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\ProjectMetadataService": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Introspection\\ProjectMetadataSnapshot": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Context\\CorrelationContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Context\\CorrelationContextProviderInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\ErrorTracking\\ErrorAggregatorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\ErrorTracking\\ErrorEvent": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\ErrorTracking\\ErrorFingerprint": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\ErrorTracking\\Exception\\ErrorTrackingException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\ErrorTracking\\SensitiveDataScrubber": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Log\\Exception\\LogException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Log\\LogEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Log\\LogLevel": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Log\\LogSinkInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Log\\Sink\\DeferredSinkInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Metrics\\LabelSet": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Metrics\\MetricRegistry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Metrics\\MetricSnapshot": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Metrics\\MetricType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\Exception\\TracingException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\Span": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\SpanProcessorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\SpanStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\TraceContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\TraceContextParserInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Observability\\Tracing\\TraceId": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\DeadLetterQueue": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\Exception\\QueueException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\FailedJob": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\JobContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\JobRecord": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\JobRecordStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\QueueDriverInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\QueueManager": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\QueueableInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\Retry\\QueueRetryPolicy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\Retry\\RetryDecision": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\Worker": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\WorkerOptions": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Queue\\WorkerStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\CircuitBreakerState": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\Exception\\ResilienceException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\HealthCheck\\HealthCheckInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\HealthCheck\\HealthCheckResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\HealthCheck\\HealthCheckRunnerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\HealthCheck\\HealthReport": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\HealthCheck\\HealthStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\Repair\\RepairDiagnosis": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\Repair\\RepairJobInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\Repair\\RepairResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\Repair\\RepairRunnerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\RetryPolicy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Resilience\\RetryResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Routing\\MatchedRoute": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Routing\\Route": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Routing\\RouteGroup": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Routing\\Router": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Routing\\RouterInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Routing\\RoutingException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\Exception\\RuntimeException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\FpmRuntime": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\PersistentRuntimeFactoryInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\ResettableInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\RuntimeCollectorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\RuntimeInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\RuntimeStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\Upgrade\\UpgradeContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\Upgrade\\UpgradeHandlerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Runtime\\Upgrade\\UpgradeResponse": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\CronFields": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\Exception\\SchedulerException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\JobContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\JobEvent": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\JobInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\JobRegistry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\JobResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\JobStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\Schedule": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\Scheduler": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Scheduler\\SchedulerTickResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\AuditChainResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\AuditEntry": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\AuditEvent": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\AuditLogger": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\AuditOutcome": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\AuditSinkInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Audit\\ChainableAuditSinkInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Crypto\\EncryptorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Crypto\\Hmac": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Crypto\\HmacInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Crypto\\KeyProviderInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Crypto\\KeyRingInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Csrf\\CsrfTokenManagerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Exception\\SecurityException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Incident\\IncidentInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Incident\\IncidentReporterInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Incident\\IncidentSeverity": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Security\\Session\\SessionInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Storage\\StorageAdapterInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Storage\\StorageException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Storage\\StorageManager": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Storage\\StorageMetadata": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Storage\\StorageObject": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\CachePurgeHookInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\ConnectionResetHookInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\Exception\\SupervisorException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\HealingAction": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\HealingActionType": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\InvariantCheck\\InvariantCheckResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\PreflightCheck\\PreflightCheckResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunnerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\RecycleAction": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\RecycleReason": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\RecycleRecord": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\StuckJobPolicy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\SupervisorInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Supervisor\\WorkerRecyclePolicy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Support\\AtomicFileWriter": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Support\\SqliteWalFactory": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Tenancy\\Exception\\TenancyException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Tenancy\\Tenant": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Tenancy\\TenantContext": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Tenancy\\TenantDatabaseStrategy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Tenancy\\TenantResolverInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Tenancy\\TenantResolverStrategy": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\Exception\\WebhookException": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\InMemoryWebhookEventLog": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookClaim": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookClaimStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookEventLogInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookHandlerInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookProcessingResult": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookProcessingStatus": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookProcessor": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        },
+        "Pulsar\\Webhook\\WebhookVerifierInterface": {
+            "since": "1.0.0",
+            "methods": [],
+            "constants": []
+        }
+    },
+    "internal_classes": [
+        "Pulsar\\Auth\\TwoFactor\\InMemoryRecoveryCodeStore",
+        "Pulsar\\Auth\\TwoFactor\\InMemoryTotpReplayGuard",
+        "Pulsar\\Auth\\TwoFactor\\InMemoryTotpSecretStore",
+        "Pulsar\\Auth\\TwoFactor\\RecoveryCodeHasher",
+        "Pulsar\\Auth\\TwoFactor\\SqliteTotpReplayGuard",
+        "Pulsar\\Cache\\CacheAllowedClasses",
+        "Pulsar\\Cache\\CacheIntegrity",
+        "Pulsar\\Cache\\CacheLock",
+        "Pulsar\\Cache\\CacheManifest",
+        "Pulsar\\Cache\\CachedRoute",
+        "Pulsar\\Cache\\ConfigCache",
+        "Pulsar\\Cache\\ContainerCache",
+        "Pulsar\\Cache\\FrameworkCache",
+        "Pulsar\\Cache\\RouteCache",
+        "Pulsar\\Cache\\RouteHandler",
+        "Pulsar\\Cache\\RouteHandlerType",
+        "Pulsar\\Config\\ConfigManager",
+        "Pulsar\\Config\\ConfigOverrides",
+        "Pulsar\\Console\\Application",
+        "Pulsar\\Console\\Command\\CacheWarmupCommand",
+        "Pulsar\\Console\\Command\\DeployCheckCommand",
+        "Pulsar\\Console\\Command\\KeyGenerateCommand",
+        "Pulsar\\Console\\Command\\KeyRotateCommand",
+        "Pulsar\\Console\\Command\\NewProject\\ComposerJsonGenerator",
+        "Pulsar\\Console\\Command\\NewProject\\DirectoryLayout",
+        "Pulsar\\Console\\Command\\NewProject\\ProjectGenerator",
+        "Pulsar\\Console\\Command\\NewProject\\SecureEnvGenerator",
+        "Pulsar\\Console\\Command\\NewProject\\TemplateRegistry",
+        "Pulsar\\Console\\Command\\OptimizeClearCommand",
+        "Pulsar\\Console\\Command\\OptimizeCommand",
+        "Pulsar\\Console\\Command\\OptimizeValidateCommand",
+        "Pulsar\\Console\\Command\\PreloadDumpCommand",
+        "Pulsar\\Core\\BootProfile",
+        "Pulsar\\Core\\Kernel",
+        "Pulsar\\Core\\Wiring\\AuthWiring",
+        "Pulsar\\Core\\Wiring\\ConfigWiring",
+        "Pulsar\\Core\\Wiring\\DatabaseWiring",
+        "Pulsar\\Core\\Wiring\\DeployWiring",
+        "Pulsar\\Core\\Wiring\\DiagnosticsWiring",
+        "Pulsar\\Core\\Wiring\\ErrorTrackingWiring",
+        "Pulsar\\Core\\Wiring\\ExceptionHandlerWiring",
+        "Pulsar\\Core\\Wiring\\FeatureFlagWiring",
+        "Pulsar\\Core\\Wiring\\IntegrityWiring",
+        "Pulsar\\Core\\Wiring\\IntrospectionWiring",
+        "Pulsar\\Core\\Wiring\\LoggingWiring",
+        "Pulsar\\Core\\Wiring\\MetricsWiring",
+        "Pulsar\\Core\\Wiring\\QueueWiring",
+        "Pulsar\\Core\\Wiring\\RequestContextWiring",
+        "Pulsar\\Core\\Wiring\\ResilienceWiring",
+        "Pulsar\\Core\\Wiring\\RuntimeWiring",
+        "Pulsar\\Core\\Wiring\\SchedulerWiring",
+        "Pulsar\\Core\\Wiring\\SecurityWiring",
+        "Pulsar\\Core\\Wiring\\ServiceWiringInterface",
+        "Pulsar\\Core\\Wiring\\SupervisorWiring",
+        "Pulsar\\Core\\Wiring\\TenancyWiring",
+        "Pulsar\\Core\\Wiring\\TracingWiring",
+        "Pulsar\\DataProtection\\DefaultRetentionPolicy",
+        "Pulsar\\Deploy\\Check\\CacheSettingsCheck",
+        "Pulsar\\Deploy\\Check\\DebugModeCheck",
+        "Pulsar\\Deploy\\Check\\FilesystemScanCheck",
+        "Pulsar\\Deploy\\Check\\HealthEndpointCheck",
+        "Pulsar\\Deploy\\Check\\Http3ReadinessCheck",
+        "Pulsar\\Deploy\\Check\\HttpsReadinessCheck",
+        "Pulsar\\Deploy\\Check\\IntegrityCheck",
+        "Pulsar\\Deploy\\Check\\JitCheck",
+        "Pulsar\\Deploy\\Check\\OpcacheCheck",
+        "Pulsar\\Deploy\\Check\\RateLimitCheck",
+        "Pulsar\\Deploy\\Check\\RequestSizeCheck",
+        "Pulsar\\Deploy\\Check\\SecurityHeadersReadinessCheck",
+        "Pulsar\\Deploy\\Check\\SeverityOverrideCheck",
+        "Pulsar\\Deploy\\Check\\SkippedCheck",
+        "Pulsar\\Deploy\\Check\\TrustedProxyCheck",
+        "Pulsar\\Deploy\\DeployCheck",
+        "Pulsar\\Deploy\\DeploySeverity",
+        "Pulsar\\Deploy\\Runtime\\FilesystemReader",
+        "Pulsar\\Deploy\\Runtime\\FilesystemReaderInterface",
+        "Pulsar\\Deploy\\Runtime\\PhpRuntime",
+        "Pulsar\\Deploy\\Snippet\\ProxySnippetGenerator",
+        "Pulsar\\Deploy\\Snippet\\TlsSnippetGenerator",
+        "Pulsar\\Extensibility\\ExtensionLoader",
+        "Pulsar\\Extensibility\\ExtensionRegistry",
+        "Pulsar\\Http\\Middleware\\MiddlewarePipeline",
+        "Pulsar\\Http\\Middleware\\MiddlewareRegistry",
+        "Pulsar\\Http\\RateLimit\\RateLimiter",
+        "Pulsar\\Http\\RateLimit\\SqliteRateLimiter",
+        "Pulsar\\Http\\RouteContext",
+        "Pulsar\\Integrity\\ManifestBuilder",
+        "Pulsar\\Integrity\\ManifestSigner",
+        "Pulsar\\Integrity\\ManifestVerifier",
+        "Pulsar\\Introspection\\Internal\\ConfigSchemaReflector",
+        "Pulsar\\Introspection\\Internal\\CoreRuntimeProbe",
+        "Pulsar\\Introspection\\Internal\\SnapshotFileReader",
+        "Pulsar\\Observability\\Log\\Sink\\DeferredSink",
+        "Pulsar\\Queue\\Driver\\DatabaseDriver",
+        "Pulsar\\Queue\\Driver\\InMemoryDriver",
+        "Pulsar\\Queue\\Driver\\SyncDriver",
+        "Pulsar\\Runtime\\Fiber\\FiberScheduler",
+        "Pulsar\\Runtime\\Http\\ConnectionContext",
+        "Pulsar\\Runtime\\Http\\HttpRequestParser",
+        "Pulsar\\Runtime\\Http\\HttpResponseSerializer",
+        "Pulsar\\Runtime\\LeakDetector",
+        "Pulsar\\Runtime\\PersistentRuntime",
+        "Pulsar\\Runtime\\PersistentRuntimeFactory",
+        "Pulsar\\Runtime\\RequestResetRegistry",
+        "Pulsar\\Runtime\\RequestSandbox",
+        "Pulsar\\Runtime\\ResourceEntry",
+        "Pulsar\\Security\\Audit\\AuditChainVerifier",
+        "Pulsar\\Security\\Crypto\\EnvKeyRing",
+        "Pulsar\\Security\\Crypto\\HmacService",
+        "Pulsar\\Supervisor\\InvariantCheck\\InvariantRunner",
+        "Pulsar\\Supervisor\\PreflightCheck\\DiskSpacePreflightCheck",
+        "Pulsar\\Supervisor\\PreflightCheck\\MemoryPreflightCheck",
+        "Pulsar\\Supervisor\\PreflightCheck\\PreflightRunner",
+        "Pulsar\\Supervisor\\StuckJobDetector",
+        "Pulsar\\Supervisor\\StuckJobRecovery",
+        "Pulsar\\Supervisor\\Supervisor"
+    ]
 }

--- a/tools/api/public-api.snapshot.json
+++ b/tools/api/public-api.snapshot.json
@@ -1000,6 +1000,86 @@
       "methods": [],
       "constants": []
     },
+    "Pulsar\\Introspection\\Data\\ApiSnapshotData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ArchitectureMapData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\CommandEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\CommandReferenceData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ConfigPropertySchema": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ConfigSchemaData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ConfigSchemaEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ContributedMetadata": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\ExtensionEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\RouteEntry": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\Data\\RouteMapData": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\IntrospectionConfig": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\MetadataContributorInterface": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\ProjectMetadataBuilder": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\ProjectMetadataService": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
+    "Pulsar\\Introspection\\ProjectMetadataSnapshot": {
+      "since": "1.0.0",
+      "methods": [],
+      "constants": []
+    },
     "Pulsar\\Observability\\Context\\CorrelationContext": {
       "since": "1.0.0",
       "methods": [],
@@ -1715,6 +1795,7 @@
     "Pulsar\\Core\\Wiring\\ExceptionHandlerWiring",
     "Pulsar\\Core\\Wiring\\FeatureFlagWiring",
     "Pulsar\\Core\\Wiring\\IntegrityWiring",
+    "Pulsar\\Core\\Wiring\\IntrospectionWiring",
     "Pulsar\\Core\\Wiring\\LoggingWiring",
     "Pulsar\\Core\\Wiring\\MetricsWiring",
     "Pulsar\\Core\\Wiring\\QueueWiring",
@@ -1760,6 +1841,9 @@
     "Pulsar\\Integrity\\ManifestBuilder",
     "Pulsar\\Integrity\\ManifestSigner",
     "Pulsar\\Integrity\\ManifestVerifier",
+    "Pulsar\\Introspection\\Internal\\ConfigSchemaReflector",
+    "Pulsar\\Introspection\\Internal\\CoreRuntimeProbe",
+    "Pulsar\\Introspection\\Internal\\SnapshotFileReader",
     "Pulsar\\Observability\\Log\\Sink\\DeferredSink",
     "Pulsar\\Queue\\Driver\\DatabaseDriver",
     "Pulsar\\Queue\\Driver\\InMemoryDriver",

--- a/tools/php/deptrac.yaml
+++ b/tools/php/deptrac.yaml
@@ -35,6 +35,8 @@ deptrac:
           value: ^Pulsar\\Core\\Kernel$
         - type: classLike
           value: ^Pulsar\\Console\\Application$
+        - type: classLike
+          value: ^Pulsar\\Core\\Wiring\\
 
     # =================================================================
     # Foundation Tier
@@ -552,6 +554,22 @@ deptrac:
         - type: classLike
           value: ^Pulsar\\Webhook\\Internal\\
 
+    # --- Introspection ---
+    - name: Introspection
+      collectors:
+        - type: bool
+          must:
+            - type: classLike
+              value: ^Pulsar\\Introspection\\
+          must_not:
+            - type: classLike
+              value: ^Pulsar\\Introspection\\Internal\\
+
+    - name: Introspection_Internal
+      collectors:
+        - type: classLike
+          value: ^Pulsar\\Introspection\\Internal\\
+
     # =================================================================
     # Extension Layers
     # =================================================================
@@ -637,6 +655,37 @@ deptrac:
               value: SocialSsoContracts
             - type: layer
               value: SocialSsoDomain
+
+    # --- MCP Server Extension (Pulsar\\Extension\\Mcp-server → McpServer) ---
+
+    # --- MCP Server: public contracts ---
+    - name: McpServerContracts
+      collectors:
+        - type: classLike
+          value: ^Pulsar\\Extension\\McpServer\\Contracts\\
+
+    # --- MCP Server: domain types (value objects, enums, exceptions, config) ---
+    - name: McpServerDomain
+      collectors:
+        - type: classLike
+          value: ^Pulsar\\Extension\\McpServer\\Domain\\
+        - type: classLike
+          value: ^Pulsar\\Extension\\McpServer\\Exception\\
+        - type: classLike
+          value: ^Pulsar\\Extension\\McpServer\\Config\\
+
+    # --- MCP Server: internal implementation ---
+    - name: McpServerInternal
+      collectors:
+        - type: bool
+          must:
+            - type: classLike
+              value: ^Pulsar\\Extension\\McpServer\\
+          must_not:
+            - type: layer
+              value: McpServerContracts
+            - type: layer
+              value: McpServerDomain
 
     # --- Example Extension ---
     - name: ExampleExtension
@@ -729,6 +778,8 @@ deptrac:
       - Tenancy_Internal
       - Webhook
       - Webhook_Internal
+      - Introspection
+      - Introspection_Internal
 
     # -----------------------------------------------------------------
     # Public Layers — all public layers may depend on all other public
@@ -758,6 +809,7 @@ deptrac:
       - FeatureFlag
       - Idempotency
       - Integrity
+      - Introspection
       - Observability
       - Queue
       - Resilience
@@ -798,6 +850,42 @@ deptrac:
     Supervisor: *public_deps
     Tenancy: *public_deps
     Webhook: *public_deps
+    # Introspection public layer depends on its own internal (service facades inject internal implementations)
+    Introspection:
+      - CompositionRoot
+      - Api
+      - Support
+      - Container
+      - Config
+      - Core
+      - ErrorHandling
+      - Http
+      - Routing
+      - Console
+      - Extensibility
+      - Audit
+      - Auth
+      - Cache
+      - Context
+      - Database
+      - DataProtection
+      - Deploy
+      - Event
+      - FeatureFlag
+      - Idempotency
+      - Integrity
+      - Introspection
+      - Introspection_Internal
+      - Observability
+      - Queue
+      - Resilience
+      - Runtime
+      - Scheduler
+      - Security
+      - Storage
+      - Supervisor
+      - Tenancy
+      - Webhook
 
     # -----------------------------------------------------------------
     # Internal Layers — own public + Foundation + CoreTier only
@@ -837,6 +925,23 @@ deptrac:
     Supervisor_Internal: [Supervisor, Api, Support, Container, Config, Core, ErrorHandling]
     Tenancy_Internal: [Tenancy, Api, Support, Container, Config, Core, ErrorHandling]
     Webhook_Internal: [Webhook, Api, Support, Container, Config, Core, ErrorHandling]
+    # CoreRuntimeProbe introspects Container, ExtensionRegistry, Router (+ Http\Method), and Console Application (CompositionRoot)
+    Introspection_Internal:
+      [
+        Introspection,
+        Api,
+        Support,
+        Container,
+        Config,
+        Core,
+        ErrorHandling,
+        Extensibility,
+        Console,
+        Routing,
+        Http,
+        Observability,
+        CompositionRoot,
+      ]
 
     # -----------------------------------------------------------------
     # Extension Layers — depend on all core public + CompositionRoot +
@@ -987,6 +1092,81 @@ deptrac:
       - Webhook
       - SocialSsoContracts
       - SocialSsoDomain
+
+    McpServerContracts:
+      - CompositionRoot
+      - Api
+      - Support
+      - Container
+      - Config
+      - Core
+      - ErrorHandling
+      - Http
+      - Routing
+      - Console
+      - Extensibility
+      - Audit
+      - Auth
+      - Cache
+      - Context
+      - Database
+      - DataProtection
+      - Deploy
+      - Event
+      - FeatureFlag
+      - Idempotency
+      - Integrity
+      - Introspection
+      - Observability
+      - Queue
+      - Resilience
+      - Runtime
+      - Scheduler
+      - Security
+      - Storage
+      - Supervisor
+      - Tenancy
+      - Webhook
+      - McpServerDomain
+
+    McpServerDomain: *public_deps
+
+    McpServerInternal:
+      - CompositionRoot
+      - Api
+      - Support
+      - Container
+      - Config
+      - Core
+      - ErrorHandling
+      - Http
+      - Routing
+      - Console
+      - Extensibility
+      - Audit
+      - Auth
+      - Cache
+      - Context
+      - Database
+      - DataProtection
+      - Deploy
+      - Event
+      - FeatureFlag
+      - Idempotency
+      - Integrity
+      - Introspection
+      - Observability
+      - Queue
+      - Resilience
+      - Runtime
+      - Scheduler
+      - Security
+      - Storage
+      - Supervisor
+      - Tenancy
+      - Webhook
+      - McpServerContracts
+      - McpServerDomain
 
     ObservabilityExportExtension: *public_deps
     Psr7BridgeExtension: *public_deps

--- a/tools/php/phpunit.xml
+++ b/tools/php/phpunit.xml
@@ -27,6 +27,7 @@
             <directory>../../extensions/studio/src</directory>
             <directory>../../extensions/observability-export/src</directory>
             <directory>../../extensions/social-sso/src</directory>
+            <directory>../../extensions/mcp-server/src</directory>
         </include>
     </source>
 </phpunit>


### PR DESCRIPTION
## Summary

- **ORM extension** (`extensions/orm/`): attribute-driven entity mapping, query builder (select/insert/update/delete), schema builder, multi-dialect SQL compiler (SQLite, MySQL, MariaDB, PostgreSQL), encrypted column support with blind indexing, tenant scoping, optimistic locking, relation loading, and audit-integrated persistence
- **Admin panel extension** (`extensions/admin/`): resource CRUD with audit logging, bulk actions, CSV/JSON export with integrity hashing, global search, saved views, dashboard widgets, field-level visibility/redaction, rate limiting, CSRF/CSP middleware, and a full Schema Builder UI (create/alter/rename/drop tables with DDL preview and changelog)
- **Core Database Schema layer** (`src/Database/Schema/`): driver-agnostic DDL compiler, schema capabilities introspection, schema manager, identifier validation, and SQL canonicalization
- **Core Database Introspection** (`src/Database/Introspection/`): table/column metadata introspection across all supported drivers
- **Studio module API** (`extensions/studio/src/Contracts/`): `StudioModuleInterface` + registry for extensions to register sidebar nav entries, routes, and assets into Studio (ADR-0019)
- **Extension frontend convention**: unified `extensions/{name}/frontend/` for source and `extensions/{name}/dev/` for dev server entry points, with `pulsar.json` frontend bundle manifests for build tooling discovery
- **Studio frontend relocated**: moved from `resources/studio/` into `extensions/studio/frontend/` + `extensions/studio/dev/` to match the new convention

## Test plan

- [x] `composer qa` passes (cs, phpstan, psalm, boundary:check, test)
- [x] `pnpm lint && pnpm format:check && pnpm test` passes
- [x] `pnpm build:studio && pnpm build:admin` compile without errors
- [x] Schema Builder UI renders styled form (not browser defaults) at admin panel
- [x] ORM query builder produces correct SQL for all four dialects
- [x] Admin export produces CSV/JSON with HMAC integrity hash
- [x] Studio module sidebar shows Admin entry when both extensions are active

## Linked Issues
Resolves #176
Resolves #186
Resolves #197
Resolves #207
