### PR TITLE
Sprint 1.1.B.3 — Ed25519 + X25519 safe wrappers + RFC KATs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,23 +16,42 @@ Third sub-phase of Phase 1.1.B (safe Rust wrappers over the HACL\* FFI). Lands `
 * **All `Debug` impls redact secret material**. `Ed25519PrivateKey` and `X25519PrivateKey` print only the type name; public keys + signatures show a short hex prefix (8 bytes) + length suffix for identification without dumping the full bytes.
 * **Module re-exports** in `pulsar-kernel::crypto::mod` and `pulsar-kernel::prelude`: `Ed25519PrivateKey`, `Ed25519PublicKey`, `Ed25519Signature`, `X25519PrivateKey`, `X25519PublicKey`.
 
-**Tests** (8 new tests across two integration test files):
+**Tests** (21 new tests across four integration test files):
 
-* **`tests/signature_kat.rs`** (5 tests):
+* **`tests/signature_kat.rs`** (6 tests):
   - RFC 8032 § 7.1 TEST 1 (empty message) — verifies key derivation, signing produces canonical signature, both produced + reference signature verify
   - RFC 8032 § 7.1 TEST 2 (1-byte message 0x72) — same coverage
   - Tampered-message verify rejection → `SignatureVerifyFailed`
+  - Wrong-public-key verify rejection (signature produced under key A, verified under key B) → `SignatureVerifyFailed`
   - Wrong-length seed rejection (31/33 bytes vs 32) → `InvalidKeyLength`
   - Debug impl redacts seed bytes
+* **`tests/signature_property.rs`** (7 properties using `proptest`):
+  - Sign/verify round-trip across random `(seed, message)` pairs
+  - Signing is deterministic per RFC 8032 § 5.1.6 — same `(key, message)` always yields the same 64-byte signature
+  - Distinct messages under the same key produce distinct signatures (probabilistic)
+  - Distinct seeds derive distinct public keys (probabilistic)
+  - Verifying a signature produced by key A under key B's public key fails with `SignatureVerifyFailed`
+  - Single-bit message tampering after signing → `SignatureVerifyFailed`
+  - Single-bit signature tampering → `SignatureVerifyFailed`
 * **`tests/kem_kat.rs`** (3 tests):
   - RFC 7748 § 6.1 — Alice + Bob derive the same shared secret matching the reference vector; both public keys match the RFC-computed values
   - Small-order public key (u = 0) rejection → `InvalidPublicKey`
   - Wrong-length scalar rejection → `InvalidKeyLength`
+* **`tests/kem_property.rs`** (5 properties using `proptest`):
+  - Public-key derivation is deterministic — same seed yields byte-identical public point
+  - Distinct seeds derive distinct public keys (probabilistic)
+  - DH symmetry — `Alice.dh(Bob.pub)` and `Bob.dh(Alice.pub)` produce byte-identical shared secrets
+  - Distinct private keys against the same peer produce distinct shared secrets (probabilistic)
+  - DH is deterministic for fixed `(private, peer)` inputs
+
+Inputs span 0-1024-byte messages across random 32-byte seeds; per-property default is 256 cases, totalling ~3000 random inputs across all properties.
+
+**Code organisation** — `hex_encode_short` `Debug`-formatting helper hoisted from `signature.rs` + `kem.rs` into `crypto::mod` as `pub(crate) fn` (single source of truth, prevents future divergence). Module-level documentation in `crypto::mod` formalises the `SecretBox` parameter convention: `&SecretBox<[u8]>` borrowed by `AeadKey::new` (FFI immediately copies into expanded state, caller retains ownership) versus `SecretBox<[u8]>` consumed by `Ed25519PrivateKey::from_bytes` + `X25519PrivateKey::from_bytes` (wrapper retains the seed for repeated `sign` / `diffie_hellman` calls so zeroize-on-drop ownership transfers exactly once).
 
 Quality gates verified locally:
   - cargo fmt --all -- --check ✓
   - cargo clippy -p pulsar-kernel --all-targets -- -D warnings ✓
-  - cargo nextest run -p pulsar-kernel (55/55 PASS, +8 from this phase) ✓
+  - cargo nextest run -p pulsar-kernel (68/68 PASS, +21 from this phase) ✓
 
 ### Sprint 1.1 — kernel crypto (Phase 1.1.B.2: AEAD safe wrappers — merged 2026-04-28 as `833f6c9a`)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,34 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Sprint 1.1 — kernel crypto (Phase 1.1.B.2: AEAD safe wrappers, in progress)
+### Sprint 1.1 — kernel crypto (Phase 1.1.B.3: Ed25519 + X25519 safe wrappers, in progress)
+
+Third sub-phase of Phase 1.1.B (safe Rust wrappers over the HACL\* FFI). Lands `pulsar-kernel::crypto::signature` (Ed25519 per RFC 8032) and `pulsar-kernel::crypto::kem` (X25519 per RFC 7748). P-256 ECDSA + ECDH deferred to follow-up sub-phase 1.1.B.3-bis (requires deterministic-nonce machinery per RFC 6979 + secure RNG infrastructure).
+
+* **`pulsar-kernel::crypto::signature`** — Ed25519 wrappers over `EverCrypt_Ed25519_*`. `Ed25519PrivateKey::from_bytes(SecretBox<[u8]>)` constructs from a 32-byte seed wrapped in `secrecy::SecretBox<[u8]>` (zeroize-on-drop per the canonical pattern from Phase 1.1.B.2). `public_key()` derives the 32-byte verifying key. `sign(message)` produces a 64-byte deterministic signature (RFC 8032 § 5.1.6 — Ed25519 signatures are inherently deterministic, no nonce-reuse risk). `Ed25519PublicKey::verify(message, signature)` returns `Ok(())` on valid / `Err(SignatureVerifyFailed)` on invalid (no information leaked about which step failed — HACL\*'s constant-time invariant covers success/failure paths uniformly).
+* **`pulsar-kernel::crypto::kem`** — X25519 wrappers over `EverCrypt_Curve25519_*`. `X25519PrivateKey::from_bytes(SecretBox<[u8]>)` constructs from a 32-byte scalar (clamped per RFC 7748 § 5 internally by HACL\*). `public_key()` derives the 32-byte u-coordinate. `diffie_hellman(peer)` returns the 32-byte shared secret wrapped in `SecretBox<[u8]>` so downstream HKDF derivation operates on `expose_secret()` without accidental cleartext copies. Small-order public keys (e.g., u = 0) are rejected as `Error::InvalidPublicKey` per HACL\*'s F\* postcondition.
+* **All `Debug` impls redact secret material**. `Ed25519PrivateKey` and `X25519PrivateKey` print only the type name; public keys + signatures show a short hex prefix (8 bytes) + length suffix for identification without dumping the full bytes.
+* **Module re-exports** in `pulsar-kernel::crypto::mod` and `pulsar-kernel::prelude`: `Ed25519PrivateKey`, `Ed25519PublicKey`, `Ed25519Signature`, `X25519PrivateKey`, `X25519PublicKey`.
+
+**Tests** (8 new tests across two integration test files):
+
+* **`tests/signature_kat.rs`** (5 tests):
+  - RFC 8032 § 7.1 TEST 1 (empty message) — verifies key derivation, signing produces canonical signature, both produced + reference signature verify
+  - RFC 8032 § 7.1 TEST 2 (1-byte message 0x72) — same coverage
+  - Tampered-message verify rejection → `SignatureVerifyFailed`
+  - Wrong-length seed rejection (31/33 bytes vs 32) → `InvalidKeyLength`
+  - Debug impl redacts seed bytes
+* **`tests/kem_kat.rs`** (3 tests):
+  - RFC 7748 § 6.1 — Alice + Bob derive the same shared secret matching the reference vector; both public keys match the RFC-computed values
+  - Small-order public key (u = 0) rejection → `InvalidPublicKey`
+  - Wrong-length scalar rejection → `InvalidKeyLength`
+
+Quality gates verified locally:
+  - cargo fmt --all -- --check ✓
+  - cargo clippy -p pulsar-kernel --all-targets -- -D warnings ✓
+  - cargo nextest run -p pulsar-kernel (55/55 PASS, +8 from this phase) ✓
+
+### Sprint 1.1 — kernel crypto (Phase 1.1.B.2: AEAD safe wrappers — merged 2026-04-28 as `833f6c9a`)
 
 Second sub-phase of Phase 1.1.B (safe Rust wrappers over the HACL\* FFI). Lands `pulsar-kernel::crypto::aead` module with the three AEAD primitives Pulsar standardises on: AES-128-GCM, AES-256-GCM, ChaCha20-Poly1305. Subsequent sub-phases extend the surface: 1.1.B.3 signature + KEM (Ed25519 + X25519 + P-256), 1.1.B.4 HKDF + HMAC + Argon2id.
 

--- a/crates/pulsar-kernel/src/crypto/kem.rs
+++ b/crates/pulsar-kernel/src/crypto/kem.rs
@@ -37,6 +37,7 @@
 
 #![allow(unsafe_code)]
 
+use crate::crypto::hex_encode_short;
 use crate::error::{Error, Result};
 use pulsar_crypto_hacl_bindings::ffi;
 use secrecy::{ExposeSecret, SecretBox};
@@ -181,17 +182,4 @@ impl X25519PublicKey {
     pub const fn as_bytes(&self) -> &[u8; 32] {
         &self.bytes
     }
-}
-
-/// Hex-encode a byte slice with a length-truncated suffix for `Debug`
-/// formatting. Avoids dumping full key bytes into log output.
-fn hex_encode_short(bytes: &[u8]) -> String {
-    use core::fmt::Write;
-    let n = bytes.len().min(8);
-    let mut out = String::with_capacity(n * 2 + 16);
-    for b in &bytes[..n] {
-        let _ = write!(out, "{b:02x}");
-    }
-    let _ = write!(out, "…({} bytes)", bytes.len());
-    out
 }

--- a/crates/pulsar-kernel/src/crypto/kem.rs
+++ b/crates/pulsar-kernel/src/crypto/kem.rs
@@ -1,0 +1,197 @@
+//! Key encapsulation / Diffie-Hellman primitives — safe Rust wrappers
+//! over HACL\* via FFI.
+//!
+//! Per Decision 2.53 + 2.60 + ADR-0009, this module wraps the EverCrypt
+//! key-agreement dispatcher. Phase 1.1.B.3 ships X25519 (RFC 7748) —
+//! the classical key-agreement primitive Pulsar standardises on. P-256
+//! ECDH (FIPS 186-5) lands in a follow-up sub-phase. ML-KEM-768 (the
+//! NIST PQC primitive Pulsar uses for hybrid KEM per Decision 2.58)
+//! lands in Phase 1.1.C via libcrux per Decision 2.60.
+//!
+//! # X25519 properties
+//!
+//! - **Algorithm**: Curve25519 Diffie-Hellman per RFC 7748
+//! - **Private key**: 32 bytes (clamped per RFC 7748 § 5)
+//! - **Public key**: 32 bytes (u-coordinate of `[k]G` where `k` is the
+//!   clamped scalar and `G` is the curve base point)
+//! - **Shared secret**: 32 bytes
+//! - **Constant-time**: HACL\*'s F\* proofs of constant-time and
+//!   secret independence cover the scalar multiplication.
+//! - **Public-key validation**: per RFC 7748, X25519 does NOT validate
+//!   that the peer public key is "non-small-order" before computing
+//!   the DH. HACL\*'s `EverCrypt_Curve25519_ecdh` does explicit
+//!   small-order rejection — it returns `false` for the documented
+//!   degenerate cases. The wrapper surfaces this as
+//!   [`Error::InvalidPublicKey`].
+//!
+//! # Key-material handling
+//!
+//! Private keys + shared secrets are wrapped in
+//! [`secrecy::SecretBox<[u8]>`] following the canonical pattern
+//! established by `crypto::aead::AeadKey::new`. Public keys are NOT
+//! wrapped — they are public by definition.
+//!
+//! Shared secrets are returned wrapped in [`SecretBox<[u8]>`] so the
+//! caller's downstream HKDF / KDF derivation can operate on
+//! `expose_secret()` output without accidental cleartext copies.
+
+#![allow(unsafe_code)]
+
+use crate::error::{Error, Result};
+use pulsar_crypto_hacl_bindings::ffi;
+use secrecy::{ExposeSecret, SecretBox};
+use std::sync::Once;
+
+/// Ensure EverCrypt's CPU dispatcher is initialised — same `Once`
+/// pattern as the rest of `crypto`.
+static AUTOCONFIG_INIT: Once = Once::new();
+
+fn ensure_initialized() {
+    AUTOCONFIG_INIT.call_once(|| {
+        // SAFETY: idempotent C function with no caller-side state.
+        unsafe { ffi::EverCrypt_AutoConfig2_init() };
+    });
+}
+
+/// X25519 private scalar (32 bytes).
+pub struct X25519PrivateKey {
+    secret: SecretBox<[u8]>,
+}
+
+impl core::fmt::Debug for X25519PrivateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("X25519PrivateKey").finish_non_exhaustive()
+    }
+}
+
+impl X25519PrivateKey {
+    /// Private scalar length in bytes (RFC 7748 § 5).
+    pub const SCALAR_LEN: usize = 32;
+    /// Public point length in bytes (RFC 7748 § 5).
+    pub const POINT_LEN: usize = 32;
+    /// Shared secret length in bytes (RFC 7748 § 5).
+    pub const SHARED_LEN: usize = 32;
+
+    /// Construct a private key from a 32-byte scalar wrapped in
+    /// [`SecretBox<[u8]>`]. The scalar is clamped per RFC 7748 § 5
+    /// internally by HACL\* before use.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidKeyLength`] — `secret.expose_secret().len() != 32`.
+    pub fn from_bytes(secret: SecretBox<[u8]>) -> Result<Self> {
+        if secret.expose_secret().len() != Self::SCALAR_LEN {
+            return Err(Error::InvalidKeyLength {
+                expected: Self::SCALAR_LEN,
+                actual: secret.expose_secret().len(),
+            });
+        }
+        Ok(Self { secret })
+    }
+
+    /// Derive the public key corresponding to this private scalar.
+    /// Computes `[k]G` where `k` is the clamped scalar and `G` is the
+    /// Curve25519 base point (u = 9).
+    #[must_use]
+    pub fn public_key(&self) -> X25519PublicKey {
+        ensure_initialized();
+        let mut public_bytes = [0_u8; Self::POINT_LEN];
+
+        // SAFETY: EverCrypt_Curve25519_secret_to_public preconditions:
+        //   - `pub_` points to 32 writable bytes.
+        //   - `priv_` points to 32 readable bytes — length-checked at
+        //     construction time.
+        unsafe {
+            ffi::EverCrypt_Curve25519_secret_to_public(
+                public_bytes.as_mut_ptr(),
+                self.secret.expose_secret().as_ptr().cast_mut(),
+            );
+        }
+
+        X25519PublicKey {
+            bytes: public_bytes,
+        }
+    }
+
+    /// Compute the X25519 Diffie-Hellman shared secret with `peer`.
+    ///
+    /// Returns the 32-byte shared secret wrapped in [`SecretBox<[u8]>`].
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidPublicKey`] — `peer` is one of the documented
+    ///   small-order points that yields a zero or near-zero shared
+    ///   secret. HACL\*'s `EverCrypt_Curve25519_ecdh` rejects these
+    ///   cases per the F\* secret-independence postcondition.
+    pub fn diffie_hellman(&self, peer: &X25519PublicKey) -> Result<SecretBox<[u8]>> {
+        ensure_initialized();
+        let mut shared_buf = vec![0_u8; Self::SHARED_LEN];
+
+        // SAFETY: EverCrypt_Curve25519_ecdh preconditions:
+        //   - `shared` points to 32 writable bytes — `shared_buf`.
+        //   - `my_priv` points to 32 readable bytes — length-checked.
+        //   - `their_pub` points to 32 readable bytes — `peer.bytes`.
+        // Returns `bool`: true on success, false on small-order
+        // public-key rejection.
+        let valid = unsafe {
+            ffi::EverCrypt_Curve25519_ecdh(
+                shared_buf.as_mut_ptr(),
+                self.secret.expose_secret().as_ptr().cast_mut(),
+                peer.bytes.as_ptr().cast_mut(),
+            )
+        };
+
+        if !valid {
+            // Zeroize the buffer before dropping (defensive — HACL*
+            // may have written partial / leaked-shared-secret bytes
+            // before the small-order check fired).
+            shared_buf.fill(0);
+            return Err(Error::InvalidPublicKey);
+        }
+
+        Ok(SecretBox::new(shared_buf.into_boxed_slice()))
+    }
+}
+
+/// X25519 public point (32 bytes — u-coordinate).
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct X25519PublicKey {
+    bytes: [u8; 32],
+}
+
+impl core::fmt::Debug for X25519PublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("X25519PublicKey")
+            .field("bytes", &hex_encode_short(&self.bytes))
+            .finish()
+    }
+}
+
+impl X25519PublicKey {
+    /// Construct from a 32-byte u-coordinate buffer. The wrapper does
+    /// NOT validate that the bytes form a non-small-order point; the
+    /// validation happens at [`X25519PrivateKey::diffie_hellman`] time
+    /// via HACL\*'s small-order check.
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self { bytes }
+    }
+
+    /// Return the public key as a 32-byte slice.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.bytes
+    }
+}
+
+/// Hex-encode a byte slice with a length-truncated suffix for `Debug`
+/// formatting. Avoids dumping full key bytes into log output.
+fn hex_encode_short(bytes: &[u8]) -> String {
+    use core::fmt::Write;
+    let n = bytes.len().min(8);
+    let mut out = String::with_capacity(n * 2 + 16);
+    for b in &bytes[..n] {
+        let _ = write!(out, "{b:02x}");
+    }
+    let _ = write!(out, "…({} bytes)", bytes.len());
+    out
+}

--- a/crates/pulsar-kernel/src/crypto/mod.rs
+++ b/crates/pulsar-kernel/src/crypto/mod.rs
@@ -30,6 +30,33 @@
 //! variants enumerate only the modern algorithms Pulsar supports per
 //! its compliance posture (NIST SP 800-131A "FIPS-approved hash functions"
 //! plus BLAKE2 for non-FIPS deployments).
+//!
+//! # `SecretBox` parameter convention — consume vs borrow
+//!
+//! Constructors that take a [`secrecy::SecretBox<[u8]>`] follow one of
+//! two principled conventions, picked per primitive based on whether
+//! the wrapper retains the secret for repeated use or copies it once
+//! into FFI-owned state:
+//!
+//! - **Borrowed (`&SecretBox<[u8]>`)** — used by [`AeadKey::new`]. The
+//!   AEAD constructor immediately copies the key into HACL\*'s expanded
+//!   state (`EverCrypt_AEAD_create_in`) and discards the input
+//!   reference. The caller retains ownership of the original
+//!   `SecretBox` so the same key material can be re-used (e.g. to
+//!   construct a second [`AeadKey`] with a different algorithm) without
+//!   forcing a clone.
+//! - **Consumed (`SecretBox<[u8]>` by value)** — used by
+//!   [`Ed25519PrivateKey::from_bytes`] and
+//!   [`X25519PrivateKey::from_bytes`]. Signature + KEM private-key
+//!   wrappers store the seed/scalar inside the wrapper for repeated
+//!   `sign` / `diffie_hellman` calls. Consuming the input transfers
+//!   the zeroize-on-drop ownership to the wrapper — when the wrapper
+//!   is dropped the secret material is wiped exactly once, with no
+//!   dangling alias the caller could accidentally clone.
+//!
+//! Phase 1.1.B.4 (HKDF / HMAC / Argon2id) and Phase 1.1.C (libcrux PQC)
+//! follow the same rule: borrow when the FFI immediately copies and
+//! discards, consume when the wrapper retains the secret across calls.
 
 pub mod aead;
 pub mod hash;
@@ -42,3 +69,22 @@ pub use hash::{sha3_256, sha3_384, sha3_512};
 pub use hash::{sha256, sha384, sha512};
 pub use kem::{X25519PrivateKey, X25519PublicKey};
 pub use signature::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
+
+/// Hex-encode a byte slice with a length-truncated suffix for `Debug`
+/// formatting. Avoids dumping full key/signature bytes into log output
+/// while still showing enough hex to identify the value.
+///
+/// Shared between every `crypto::*` module's manual `Debug` impl on
+/// public-key / signature types — never invoked on secret material
+/// (private-key `Debug` impls use `finish_non_exhaustive()` and never
+/// touch the seed bytes).
+pub(crate) fn hex_encode_short(bytes: &[u8]) -> String {
+    use core::fmt::Write;
+    let n = bytes.len().min(8);
+    let mut out = String::with_capacity(n * 2 + 16);
+    for b in &bytes[..n] {
+        let _ = write!(out, "{b:02x}");
+    }
+    let _ = write!(out, "…({} bytes)", bytes.len());
+    out
+}

--- a/crates/pulsar-kernel/src/crypto/mod.rs
+++ b/crates/pulsar-kernel/src/crypto/mod.rs
@@ -6,8 +6,8 @@
 //!
 //! - [`hash`]   — SHA-2 (256/384/512), SHA-3 (256/384/512), BLAKE2b/2s
 //! - [`aead`]   — AES-128/256-GCM, ChaCha20-Poly1305
-//! - `signature` — Ed25519 (Phase 1.1.B.3); ML-DSA-65 hybrid via libcrux (Phase 1.1.C)
-//! - `kem`      — X25519 (Phase 1.1.B.3); ML-KEM-768 hybrid via libcrux (Phase 1.1.C)
+//! - [`signature`] — Ed25519 (RFC 8032); ML-DSA-65 hybrid via libcrux (Phase 1.1.C)
+//! - [`kem`]    — X25519 (RFC 7748); ML-KEM-768 hybrid via libcrux (Phase 1.1.C)
 //! - `hkdf`     — HKDF over SHA-2 family (Phase 1.1.B.4)
 //! - `hmac`     — HMAC over SHA-2 + BLAKE2 family (Phase 1.1.B.4)
 //! - `argon2`   — Argon2id password hashing via RustCrypto (Phase 1.1.B.4)
@@ -33,8 +33,12 @@
 
 pub mod aead;
 pub mod hash;
+pub mod kem;
+pub mod signature;
 
 pub use aead::{AeadAlgorithm, AeadKey};
 pub use hash::{HashAlgorithm, Hasher, blake2b512, blake2s256};
 pub use hash::{sha3_256, sha3_384, sha3_512};
 pub use hash::{sha256, sha384, sha512};
+pub use kem::{X25519PrivateKey, X25519PublicKey};
+pub use signature::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};

--- a/crates/pulsar-kernel/src/crypto/signature.rs
+++ b/crates/pulsar-kernel/src/crypto/signature.rs
@@ -31,6 +31,7 @@
 
 #![allow(unsafe_code)]
 
+use crate::crypto::hex_encode_short;
 use crate::error::{Error, Result};
 use pulsar_crypto_hacl_bindings::ffi;
 use secrecy::{ExposeSecret, SecretBox};
@@ -254,18 +255,4 @@ impl Ed25519Signature {
     pub const fn as_bytes(&self) -> &[u8; 64] {
         &self.bytes
     }
-}
-
-/// Hex-encode a byte slice with a length-truncated suffix for `Debug`
-/// formatting. Avoids dumping full key/signature bytes into log output
-/// while still showing enough to identify the value.
-fn hex_encode_short(bytes: &[u8]) -> String {
-    use core::fmt::Write;
-    let n = bytes.len().min(8);
-    let mut out = String::with_capacity(n * 2 + 16);
-    for b in &bytes[..n] {
-        let _ = write!(out, "{b:02x}");
-    }
-    let _ = write!(out, "…({} bytes)", bytes.len());
-    out
 }

--- a/crates/pulsar-kernel/src/crypto/signature.rs
+++ b/crates/pulsar-kernel/src/crypto/signature.rs
@@ -1,0 +1,271 @@
+//! Digital signature primitives — safe Rust wrappers over HACL\* via FFI.
+//!
+//! Per Decision 2.53 + 2.60 + ADR-0009, this module wraps the EverCrypt
+//! signature dispatcher with typed inputs/outputs. Phase 1.1.B.3 ships
+//! Ed25519 (RFC 8032) — the signature primitive Pulsar standardises
+//! on for the regulated-domain compliance surface. P-256 ECDSA
+//! (FIPS 186-5) lands in a follow-up sub-phase together with the
+//! deterministic-nonce machinery (RFC 6979).
+//!
+//! Ed25519 properties:
+//!
+//! - **Algorithm**: Edwards25519 with Ed25519 signature scheme (RFC 8032)
+//! - **Private key**: 32 bytes (the "seed"; expanded internally to a
+//!   64-byte scalar + prefix per RFC 8032 § 5.1.5)
+//! - **Public key**: 32 bytes (compressed Edwards point)
+//! - **Signature**: 64 bytes (R || s, where R is a compressed point and
+//!   s is a scalar)
+//! - **Deterministic**: Ed25519 is fully deterministic — signing the
+//!   same message with the same key always produces the same signature.
+//!   No nonce reuse risk, no RFC-6979-style derandomisation needed.
+//! - **Constant-time**: signing and verification are constant-time per
+//!   HACL\*'s F\* secret-independence proofs.
+//!
+//! # Key-material handling
+//!
+//! Private keys are wrapped in [`secrecy::SecretBox<[u8]>`] following
+//! the canonical pattern established by `crypto::aead::AeadKey::new`.
+//! Caller-side zeroize-on-drop applies to the input bytes; the FFI
+//! internally derives expanded scalar + nonce-prefix material per
+//! signing operation (no persistent state stored Rust-side).
+
+#![allow(unsafe_code)]
+
+use crate::error::{Error, Result};
+use pulsar_crypto_hacl_bindings::ffi;
+use secrecy::{ExposeSecret, SecretBox};
+use std::sync::Once;
+
+/// Ensure EverCrypt's CPU dispatcher is initialised — same `Once`
+/// pattern as `crypto::hash` and `crypto::aead`.
+static AUTOCONFIG_INIT: Once = Once::new();
+
+fn ensure_initialized() {
+    AUTOCONFIG_INIT.call_once(|| {
+        // SAFETY: idempotent C function, no caller-side state to clean
+        // up. HACL* documents the call as safe to invoke multiple times.
+        unsafe { ffi::EverCrypt_AutoConfig2_init() };
+    });
+}
+
+/// Ed25519 private signing key (32-byte seed) per RFC 8032.
+///
+/// Constructed from a [`SecretBox<[u8]>`] of exactly 32 bytes; the
+/// wrapper enforces zeroize-on-drop on the seed material via the
+/// `secrecy` crate's `ZeroizeOnDrop` impl.
+pub struct Ed25519PrivateKey {
+    seed: SecretBox<[u8]>,
+}
+
+impl core::fmt::Debug for Ed25519PrivateKey {
+    /// Print only the algorithm name — never expose seed bytes via
+    /// `Debug` formatting.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Ed25519PrivateKey").finish_non_exhaustive()
+    }
+}
+
+impl Ed25519PrivateKey {
+    /// Private-key seed length in bytes (RFC 8032 § 5.1.5).
+    pub const SEED_LEN: usize = 32;
+    /// Public-key length in bytes (RFC 8032 § 5.1.5).
+    pub const PUBLIC_KEY_LEN: usize = 32;
+    /// Signature length in bytes (RFC 8032 § 5.1.6).
+    pub const SIGNATURE_LEN: usize = 64;
+
+    /// Construct a private key from a 32-byte seed wrapped in
+    /// [`SecretBox<[u8]>`].
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidKeyLength`] — `seed.expose_secret().len() != 32`.
+    pub fn from_bytes(seed: SecretBox<[u8]>) -> Result<Self> {
+        if seed.expose_secret().len() != Self::SEED_LEN {
+            return Err(Error::InvalidKeyLength {
+                expected: Self::SEED_LEN,
+                actual: seed.expose_secret().len(),
+            });
+        }
+        Ok(Self { seed })
+    }
+
+    /// Derive the public key corresponding to this private seed.
+    /// Computes the elliptic-curve scalar multiplication
+    /// `[s]B` where `s` is the SHA-512-derived scalar from the seed
+    /// and `B` is the Edwards25519 base point.
+    #[must_use]
+    pub fn public_key(&self) -> Ed25519PublicKey {
+        ensure_initialized();
+        let mut public_bytes = [0_u8; Self::PUBLIC_KEY_LEN];
+
+        // SAFETY: EverCrypt_Ed25519_secret_to_public preconditions:
+        //   - `public_key` points to 32 writable bytes — `public_bytes`
+        //     is a freshly-zeroed 32-byte stack array.
+        //   - `private_key` points to 32 readable bytes — checked at
+        //     construction time (SEED_LEN = 32).
+        // The cast from `*const u8` to `*mut u8` is sound: HACL*
+        // documents the seed as read-only.
+        unsafe {
+            ffi::EverCrypt_Ed25519_secret_to_public(
+                public_bytes.as_mut_ptr(),
+                self.seed.expose_secret().as_ptr().cast_mut(),
+            );
+        }
+
+        Ed25519PublicKey {
+            bytes: public_bytes,
+        }
+    }
+
+    /// Sign `message` with this private key, returning a 64-byte
+    /// signature. Ed25519 signatures are deterministic per RFC 8032 §
+    /// 5.1.6 — signing the same message with the same key always
+    /// produces the same output.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InputTooLong`] — `message.len() > u32::MAX`. RFC 8032
+    ///   has no inherent length limit but HACL\*'s API takes a u32
+    ///   length; 4 GiB exceeds any plausible signed payload.
+    pub fn sign(&self, message: &[u8]) -> Result<Ed25519Signature> {
+        ensure_initialized();
+        let msg_len = u32::try_from(message.len()).map_err(|_| Error::InputTooLong {
+            actual: message.len(),
+            max: u32::MAX as usize,
+        })?;
+        let mut signature = [0_u8; Self::SIGNATURE_LEN];
+
+        // SAFETY: EverCrypt_Ed25519_sign preconditions:
+        //   - `signature` points to 64 writable bytes — `signature` is
+        //     a freshly-zeroed 64-byte stack array.
+        //   - `private_key` points to 32 readable bytes — checked at
+        //     construction time.
+        //   - `msg` points to `msg_len` readable bytes (may be empty
+        //     per RFC 8032; HACL* permits dangling-non-null when
+        //     msg_len = 0).
+        //   - `msg_len` fits in u32 — checked above.
+        unsafe {
+            ffi::EverCrypt_Ed25519_sign(
+                signature.as_mut_ptr(),
+                self.seed.expose_secret().as_ptr().cast_mut(),
+                msg_len,
+                message.as_ptr().cast_mut(),
+            );
+        }
+
+        Ok(Ed25519Signature { bytes: signature })
+    }
+}
+
+/// Ed25519 public verifying key (32 bytes — compressed Edwards point).
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Ed25519PublicKey {
+    bytes: [u8; 32],
+}
+
+impl core::fmt::Debug for Ed25519PublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Ed25519PublicKey")
+            .field("bytes", &hex_encode_short(&self.bytes))
+            .finish()
+    }
+}
+
+impl Ed25519PublicKey {
+    /// Construct from a 32-byte slice. The wrapper does NOT validate
+    /// that the bytes form a valid Edwards point; HACL\*'s
+    /// `_Ed25519_verify` performs that check at verification time
+    /// (returning `false` for invalid points).
+    pub const fn from_bytes(bytes: [u8; 32]) -> Self {
+        Self { bytes }
+    }
+
+    /// Return the public key as a 32-byte slice.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 32] {
+        &self.bytes
+    }
+
+    /// Verify `signature` over `message` under this public key.
+    /// Returns `Ok(())` if the signature is valid;
+    /// [`Error::SignatureVerifyFailed`] otherwise (no information
+    /// leaked about which step of verification failed — HACL\*'s
+    /// constant-time invariant covers the success / failure paths
+    /// uniformly).
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::SignatureVerifyFailed`] — the signature is not valid
+    ///   for the (public key, message) pair, or the public key is not
+    ///   on the Edwards curve.
+    /// - [`Error::InputTooLong`] — `message.len() > u32::MAX`.
+    pub fn verify(&self, message: &[u8], signature: &Ed25519Signature) -> Result<()> {
+        ensure_initialized();
+        let msg_len = u32::try_from(message.len()).map_err(|_| Error::InputTooLong {
+            actual: message.len(),
+            max: u32::MAX as usize,
+        })?;
+
+        // SAFETY: EverCrypt_Ed25519_verify preconditions:
+        //   - `public_key` points to 32 readable bytes — `self.bytes`.
+        //   - `msg` points to `msg_len` readable bytes.
+        //   - `signature` points to 64 readable bytes — `signature.bytes`.
+        //   - All length params fit in u32 — checked above.
+        // Returns `bool`: true iff the signature verifies.
+        let valid = unsafe {
+            ffi::EverCrypt_Ed25519_verify(
+                self.bytes.as_ptr().cast_mut(),
+                msg_len,
+                message.as_ptr().cast_mut(),
+                signature.bytes.as_ptr().cast_mut(),
+            )
+        };
+
+        if valid {
+            Ok(())
+        } else {
+            Err(Error::SignatureVerifyFailed)
+        }
+    }
+}
+
+/// Ed25519 signature (64 bytes — R || s).
+#[derive(Clone, Copy, Eq, PartialEq, Hash)]
+pub struct Ed25519Signature {
+    bytes: [u8; 64],
+}
+
+impl core::fmt::Debug for Ed25519Signature {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("Ed25519Signature")
+            .field("bytes", &hex_encode_short(&self.bytes))
+            .finish()
+    }
+}
+
+impl Ed25519Signature {
+    /// Construct from a 64-byte signature buffer.
+    pub const fn from_bytes(bytes: [u8; 64]) -> Self {
+        Self { bytes }
+    }
+
+    /// Return the signature as a 64-byte slice.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; 64] {
+        &self.bytes
+    }
+}
+
+/// Hex-encode a byte slice with a length-truncated suffix for `Debug`
+/// formatting. Avoids dumping full key/signature bytes into log output
+/// while still showing enough to identify the value.
+fn hex_encode_short(bytes: &[u8]) -> String {
+    use core::fmt::Write;
+    let n = bytes.len().min(8);
+    let mut out = String::with_capacity(n * 2 + 16);
+    for b in &bytes[..n] {
+        let _ = write!(out, "{b:02x}");
+    }
+    let _ = write!(out, "…({} bytes)", bytes.len());
+    out
+}

--- a/crates/pulsar-kernel/src/prelude.rs
+++ b/crates/pulsar-kernel/src/prelude.rs
@@ -5,5 +5,8 @@
 //! frequently used items per sub-module — algorithm enums, hash entry
 //! points, error type, and the `Result` alias.
 
-pub use crate::crypto::{AeadAlgorithm, AeadKey, HashAlgorithm, Hasher};
+pub use crate::crypto::{
+    AeadAlgorithm, AeadKey, Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature, HashAlgorithm,
+    Hasher, X25519PrivateKey, X25519PublicKey,
+};
 pub use crate::error::{Error, Result};

--- a/crates/pulsar-kernel/tests/kem_kat.rs
+++ b/crates/pulsar-kernel/tests/kem_kat.rs
@@ -1,0 +1,108 @@
+//! Known-answer tests for `pulsar_kernel::crypto::kem`.
+//!
+//! RFC 7748 § 6.1 X25519 reference vector. Tests the public-key
+//! derivation + Diffie-Hellman shared secret round-trip in both
+//! directions (Alice → Bob and Bob → Alice produce the same secret).
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pulsar_kernel::crypto::kem::{X25519PrivateKey, X25519PublicKey};
+use secrecy::{ExposeSecret, SecretBox};
+
+fn private_from_hex(hex: &str) -> X25519PrivateKey {
+    let bytes = hex::decode(hex).expect("valid hex");
+    let secret = SecretBox::new(bytes.into_boxed_slice());
+    X25519PrivateKey::from_bytes(secret).expect("valid 32-byte scalar")
+}
+
+fn public_from_hex(hex: &str) -> X25519PublicKey {
+    let bytes = hex::decode(hex).expect("valid hex");
+    let mut out = [0_u8; 32];
+    out.copy_from_slice(&bytes);
+    X25519PublicKey::from_bytes(out)
+}
+
+/// RFC 7748 § 6.1 — Alice and Bob derive the same shared secret.
+#[test]
+fn x25519_rfc_7748_section_6_1_shared_secret() {
+    let alice_private =
+        private_from_hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
+    let alice_public_expected =
+        public_from_hex("8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a");
+    let bob_private =
+        private_from_hex("5dab087e624a8a4b79e17f8b83800ee66f3bb1292618b6fd1c2f8b27ff88e0eb");
+    let bob_public_expected =
+        public_from_hex("de9edb7d7b7dc1b4d35b61c2ece435373f8343c85b78674dadfc7e146f882b4f");
+    let expected_shared =
+        hex::decode("4a5d9d5ba4ce2de1728e3bf480350f25e07e21c947d19e3376f09b3c1e161742")
+            .expect("valid hex");
+
+    // Public-key derivation matches the RFC vector.
+    let alice_public = alice_private.public_key();
+    assert_eq!(alice_public.as_bytes(), alice_public_expected.as_bytes());
+    let bob_public = bob_private.public_key();
+    assert_eq!(bob_public.as_bytes(), bob_public_expected.as_bytes());
+
+    // Alice and Bob compute the same shared secret.
+    let alice_shared = alice_private
+        .diffie_hellman(&bob_public)
+        .expect("Alice DH should succeed");
+    let bob_shared = bob_private
+        .diffie_hellman(&alice_public)
+        .expect("Bob DH should succeed");
+
+    assert_eq!(
+        alice_shared.expose_secret(),
+        expected_shared.as_slice(),
+        "Alice DH shared secret must match RFC 7748 § 6.1 vector",
+    );
+    assert_eq!(
+        bob_shared.expose_secret(),
+        expected_shared.as_slice(),
+        "Bob DH shared secret must match RFC 7748 § 6.1 vector",
+    );
+}
+
+/// HACL\*'s `EverCrypt_Curve25519_ecdh` rejects the documented
+/// small-order point (all-zero u-coordinate) as `Error::InvalidPublicKey`.
+#[test]
+fn x25519_rejects_small_order_public_key() {
+    use pulsar_kernel::error::Error;
+
+    let private =
+        private_from_hex("77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a");
+    // u = 0 is the canonical small-order point — yields the
+    // identity-element shared secret which HACL* rejects per the F*
+    // postcondition.
+    let small_order = X25519PublicKey::from_bytes([0_u8; 32]);
+
+    match private.diffie_hellman(&small_order) {
+        Err(Error::InvalidPublicKey) => {} // expected
+        other => panic!("expected InvalidPublicKey; got {other:?}"),
+    }
+}
+
+/// Wrong-length scalar → InvalidKeyLength.
+#[test]
+fn x25519_private_key_rejects_wrong_scalar_length() {
+    use pulsar_kernel::error::Error;
+
+    let too_short = SecretBox::new(vec![0_u8; 31].into_boxed_slice());
+    let too_long = SecretBox::new(vec![0_u8; 33].into_boxed_slice());
+
+    match X25519PrivateKey::from_bytes(too_short) {
+        Err(Error::InvalidKeyLength {
+            expected: 32,
+            actual: 31,
+        }) => {}
+        other => panic!("expected InvalidKeyLength; got {other:?}"),
+    }
+
+    match X25519PrivateKey::from_bytes(too_long) {
+        Err(Error::InvalidKeyLength {
+            expected: 32,
+            actual: 33,
+        }) => {}
+        other => panic!("expected InvalidKeyLength; got {other:?}"),
+    }
+}

--- a/crates/pulsar-kernel/tests/kem_property.rs
+++ b/crates/pulsar-kernel/tests/kem_property.rs
@@ -1,0 +1,179 @@
+//! Property tests for `pulsar_kernel::crypto::kem` (X25519).
+//!
+//! Per plan Section XVII.19 testing convention. Each property is run by
+//! `proptest` against randomly-generated 32-byte scalars across the
+//! full input range the FFI surface accepts.
+//!
+//! The properties below are the security-critical X25519 invariants:
+//!   - Public-key derivation is deterministic — same seed yields same
+//!     public point (RFC 7748 § 6 + § 5 clamping is pure).
+//!   - Distinct seeds yield distinct public keys (probabilistic).
+//!   - Diffie-Hellman is symmetric — `Alice.dh(Bob.pub)` and
+//!     `Bob.dh(Alice.pub)` produce byte-identical shared secrets. The
+//!     fundamental DH correctness property (RFC 7748 § 6.1).
+//!   - Distinct private-key pairs against the same peer produce
+//!     distinct shared secrets (probabilistic).
+//!
+//! Public keys are always derived from random seeds via `public_key()`
+//! rather than constructed from arbitrary bytes via `from_bytes` —
+//! HACL\*'s scalar multiplication of the clamped seed against the
+//! Curve25519 base point guarantees on-curve, non-small-order output.
+//! Random 32-byte u-coordinates would otherwise hit the documented
+//! small-order subgroup with negligible-but-nonzero probability and
+//! would have to be filtered with `prop_assume!`.
+//!
+//! These properties are necessary (though not sufficient) for the
+//! key-agreement-correctness contract Pulsar relies on at higher layers
+//! (Noise transport handshakes, hybrid post-quantum KEM construction
+//! per Phase 1.1.C, session-token X25519 derivation).
+
+// `expect`/`unwrap` are allowed in tests per CLAUDE.md §5.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use proptest::prelude::*;
+use pulsar_kernel::crypto::kem::X25519PrivateKey;
+use secrecy::{ExposeSecret, SecretBox};
+
+/// Strategy producing a 32-byte X25519 scalar as a raw `Vec<u8>`. The
+/// scalar is clamped per RFC 7748 § 5 internally by HACL\* before use,
+/// so any 32-byte input is well-formed.
+fn scalar_strategy() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 32..=32)
+}
+
+/// Construct an [`X25519PrivateKey`] from a 32-byte vector. Caller must
+/// ensure the slice is exactly 32 bytes — the underlying constructor
+/// returns `Error::InvalidKeyLength` otherwise.
+fn private_from_vec(bytes: Vec<u8>) -> X25519PrivateKey {
+    let secret = SecretBox::new(bytes.into_boxed_slice());
+    X25519PrivateKey::from_bytes(secret).expect("32-byte scalar should be accepted")
+}
+
+proptest::proptest! {
+    /// Public-key derivation is deterministic — calling `public_key()`
+    /// twice on the same private key yields byte-identical output. The
+    /// scalar multiplication of the clamped seed against the Curve25519
+    /// base point is a pure function with no caller-visible state.
+    #[test]
+    fn public_key_derivation_is_deterministic(
+        seed in scalar_strategy(),
+    ) {
+        let private = private_from_vec(seed);
+        let pub_first = private.public_key();
+        let pub_second = private.public_key();
+        proptest::prop_assert_eq!(
+            pub_first.as_bytes(),
+            pub_second.as_bytes(),
+            "X25519 public-key derivation must be deterministic",
+        );
+    }
+
+    /// Distinct seeds yield distinct public keys (probabilistic). RFC
+    /// 7748 § 5 clamping coalesces 2¹⁹ pre-clamp seeds onto each clamped
+    /// scalar; for random 32-byte seeds the chance of two random inputs
+    /// falling in the same equivalence class is ~2⁻²²⁹ — effectively
+    /// zero for any realistic test budget.
+    #[test]
+    fn distinct_seeds_yield_distinct_public_keys(
+        seed_a in scalar_strategy(),
+        seed_b in scalar_strategy(),
+    ) {
+        proptest::prop_assume!(seed_a != seed_b);
+        let private_a = private_from_vec(seed_a);
+        let private_b = private_from_vec(seed_b);
+        let pub_a = private_a.public_key();
+        let pub_b = private_b.public_key();
+        proptest::prop_assert_ne!(
+            pub_a.as_bytes(),
+            pub_b.as_bytes(),
+            "distinct seeds must derive distinct public keys",
+        );
+    }
+
+    /// X25519 Diffie-Hellman is symmetric: `Alice.dh(Bob.pub)` and
+    /// `Bob.dh(Alice.pub)` produce byte-identical shared secrets for
+    /// any pair of seeds. The fundamental DH correctness property
+    /// validated against RFC 7748 § 6.1's reference vector in
+    /// `kem_kat.rs` and generalised here over random key pairs.
+    #[test]
+    fn diffie_hellman_is_symmetric(
+        seed_a in scalar_strategy(),
+        seed_b in scalar_strategy(),
+    ) {
+        let alice = private_from_vec(seed_a);
+        let bob = private_from_vec(seed_b);
+        let alice_public = alice.public_key();
+        let bob_public = bob.public_key();
+
+        let alice_shared = alice
+            .diffie_hellman(&bob_public)
+            .expect("Alice DH should succeed against derived peer key");
+        let bob_shared = bob
+            .diffie_hellman(&alice_public)
+            .expect("Bob DH should succeed against derived peer key");
+
+        proptest::prop_assert_eq!(
+            alice_shared.expose_secret(),
+            bob_shared.expose_secret(),
+            "X25519 DH must be symmetric — both parties derive the same shared secret",
+        );
+    }
+
+    /// Two distinct private keys talking to the same peer produce
+    /// distinct shared secrets (probabilistic). A regression that
+    /// produced colliding shared secrets across distinct private keys
+    /// would indicate a serious FFI bug or scalar-multiplication
+    /// regression.
+    #[test]
+    fn distinct_private_keys_yield_distinct_shared_secrets(
+        seed_a in scalar_strategy(),
+        seed_b in scalar_strategy(),
+        peer_seed in scalar_strategy(),
+    ) {
+        proptest::prop_assume!(seed_a != seed_b);
+
+        let alice = private_from_vec(seed_a);
+        let bob = private_from_vec(seed_b);
+        let peer = private_from_vec(peer_seed);
+        let peer_public = peer.public_key();
+
+        let alice_shared = alice
+            .diffie_hellman(&peer_public)
+            .expect("Alice DH should succeed");
+        let bob_shared = bob
+            .diffie_hellman(&peer_public)
+            .expect("Bob DH should succeed");
+
+        proptest::prop_assert_ne!(
+            alice_shared.expose_secret(),
+            bob_shared.expose_secret(),
+            "distinct private keys must derive distinct shared secrets against the same peer",
+        );
+    }
+
+    /// Two DH operations with the same `(private, peer)` pair produce
+    /// byte-identical shared secrets — DH is a pure function of its
+    /// inputs, no caller-visible state.
+    #[test]
+    fn diffie_hellman_is_deterministic(
+        seed in scalar_strategy(),
+        peer_seed in scalar_strategy(),
+    ) {
+        let private = private_from_vec(seed);
+        let peer = private_from_vec(peer_seed);
+        let peer_public = peer.public_key();
+
+        let shared_first = private
+            .diffie_hellman(&peer_public)
+            .expect("first DH should succeed");
+        let shared_second = private
+            .diffie_hellman(&peer_public)
+            .expect("second DH should succeed");
+
+        proptest::prop_assert_eq!(
+            shared_first.expose_secret(),
+            shared_second.expose_secret(),
+            "X25519 DH must be deterministic for fixed (private, peer) inputs",
+        );
+    }
+}

--- a/crates/pulsar-kernel/tests/signature_kat.rs
+++ b/crates/pulsar-kernel/tests/signature_kat.rs
@@ -1,0 +1,156 @@
+//! Known-answer tests for `pulsar_kernel::crypto::signature`.
+//!
+//! RFC 8032 § 7.1 Ed25519 reference vectors. Each test exercises the
+//! full sign + verify round-trip plus byte-for-byte comparison against
+//! the reference output.
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pulsar_kernel::crypto::signature::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
+use secrecy::SecretBox;
+
+fn private_from_hex(hex: &str) -> Ed25519PrivateKey {
+    let bytes = hex::decode(hex).expect("valid hex");
+    let secret = SecretBox::new(bytes.into_boxed_slice());
+    Ed25519PrivateKey::from_bytes(secret).expect("valid 32-byte seed")
+}
+
+fn public_from_hex(hex: &str) -> Ed25519PublicKey {
+    let bytes = hex::decode(hex).expect("valid hex");
+    let mut out = [0_u8; 32];
+    out.copy_from_slice(&bytes);
+    Ed25519PublicKey::from_bytes(out)
+}
+
+fn sig_from_hex(hex: &str) -> Ed25519Signature {
+    let bytes = hex::decode(hex).expect("valid hex");
+    let mut out = [0_u8; 64];
+    out.copy_from_slice(&bytes);
+    Ed25519Signature::from_bytes(out)
+}
+
+/// RFC 8032 § 7.1 TEST 1 — empty message.
+#[test]
+fn ed25519_rfc_8032_test_1_empty_message() {
+    let private =
+        private_from_hex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+    let expected_public =
+        public_from_hex("d75a980182b10ab7d54bfed3c964073a0ee172f3daa62325af021a68f707511a");
+    let expected_signature = sig_from_hex(
+        "e5564300c360ac729086e2cc806e828a84877f1eb8e5d974d873e065224901555fb8821590a33bacc61e39701cf9b46bd25bf5f0595bbe24655141438e7a100b",
+    );
+
+    // Public-key derivation
+    let derived_public = private.public_key();
+    assert_eq!(
+        derived_public.as_bytes(),
+        expected_public.as_bytes(),
+        "Ed25519 public-key derivation mismatch",
+    );
+
+    // Sign
+    let signature = private.sign(b"").expect("Ed25519 sign should succeed");
+    assert_eq!(
+        signature.as_bytes(),
+        expected_signature.as_bytes(),
+        "Ed25519 signature mismatch on empty message",
+    );
+
+    // Verify the produced signature
+    expected_public
+        .verify(b"", &signature)
+        .expect("Ed25519 verify should succeed on authentic signature");
+
+    // Verify the reference signature directly
+    expected_public
+        .verify(b"", &expected_signature)
+        .expect("Ed25519 reference signature must verify");
+}
+
+/// RFC 8032 § 7.1 TEST 2 — single-byte message 0x72.
+#[test]
+fn ed25519_rfc_8032_test_2_one_byte_message() {
+    let private =
+        private_from_hex("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb");
+    let expected_public =
+        public_from_hex("3d4017c3e843895a92b70aa74d1b7ebc9c982ccf2ec4968cc0cd55f12af4660c");
+    let message = &[0x72_u8];
+    let expected_signature = sig_from_hex(
+        "92a009a9f0d4cab8720e820b5f642540a2b27b5416503f8fb3762223ebdb69da085ac1e43e15996e458f3613d0f11d8c387b2eaeb4302aeeb00d291612bb0c00",
+    );
+
+    let derived_public = private.public_key();
+    assert_eq!(derived_public.as_bytes(), expected_public.as_bytes());
+
+    let signature = private.sign(message).expect("Ed25519 sign should succeed");
+    assert_eq!(signature.as_bytes(), expected_signature.as_bytes());
+
+    expected_public
+        .verify(message, &signature)
+        .expect("verify of just-signed message should succeed");
+}
+
+/// Tampering the message causes verification to fail.
+#[test]
+fn ed25519_verify_rejects_tampered_message() {
+    use pulsar_kernel::error::Error;
+
+    let private =
+        private_from_hex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+    let public = private.public_key();
+    let signature = private.sign(b"hello").expect("sign should succeed");
+
+    match public.verify(b"hellp", &signature) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed; got {other:?}"),
+    }
+}
+
+/// Wrong-length seed → InvalidKeyLength.
+#[test]
+fn ed25519_private_key_rejects_wrong_seed_length() {
+    use pulsar_kernel::error::Error;
+
+    let too_short = SecretBox::new(vec![0_u8; 31].into_boxed_slice());
+    let too_long = SecretBox::new(vec![0_u8; 33].into_boxed_slice());
+
+    match Ed25519PrivateKey::from_bytes(too_short) {
+        Err(Error::InvalidKeyLength {
+            expected: 32,
+            actual: 31,
+        }) => {}
+        other => panic!("expected InvalidKeyLength {{ expected: 32, actual: 31 }}; got {other:?}"),
+    }
+
+    match Ed25519PrivateKey::from_bytes(too_long) {
+        Err(Error::InvalidKeyLength {
+            expected: 32,
+            actual: 33,
+        }) => {}
+        other => panic!("expected InvalidKeyLength {{ expected: 32, actual: 33 }}; got {other:?}"),
+    }
+}
+
+/// Debug impls do not leak seed / signature bytes.
+#[test]
+fn ed25519_debug_impls_redact_secrets() {
+    let private =
+        private_from_hex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+    let signature = private.sign(b"x").expect("sign should succeed");
+
+    let private_debug = format!("{private:?}");
+    assert!(
+        !private_debug.contains("9d61"),
+        "private-key Debug must not leak seed bytes; got: {private_debug}",
+    );
+
+    let pub_debug = format!("{:?}", private.public_key());
+    // Public key Debug shows a short hex prefix — that's expected;
+    // public keys are not secret.
+    assert!(pub_debug.contains("Ed25519PublicKey"));
+
+    // Signature Debug shows a short hex prefix — signatures are not
+    // secret per RFC 8032 (only the secret key is).
+    let sig_debug = format!("{signature:?}");
+    assert!(sig_debug.contains("Ed25519Signature"));
+}

--- a/crates/pulsar-kernel/tests/signature_kat.rs
+++ b/crates/pulsar-kernel/tests/signature_kat.rs
@@ -106,6 +106,32 @@ fn ed25519_verify_rejects_tampered_message() {
     }
 }
 
+/// Verifying a signature under an unrelated public key fails. Signs
+/// `message` under key A and attempts verification under key B's public
+/// key — expects `SignatureVerifyFailed` regardless of whether the
+/// (message, key A) signature was otherwise authentic.
+#[test]
+fn ed25519_verify_rejects_wrong_public_key() {
+    use pulsar_kernel::error::Error;
+
+    // Key A — RFC 8032 § 7.1 TEST 1 seed
+    let private_a =
+        private_from_hex("9d61b19deffd5a60ba844af492ec2cc44449c5697b326919703bac031cae7f60");
+    // Key B — RFC 8032 § 7.1 TEST 2 seed (distinct from A)
+    let private_b =
+        private_from_hex("4ccd089b28ff96da9db6c346ec114e0f5b8a319f35aba624da8cf6ed4fb8a6fb");
+
+    let public_b = private_b.public_key();
+    let signature_a = private_a
+        .sign(b"cross-key check")
+        .expect("sign should succeed");
+
+    match public_b.verify(b"cross-key check", &signature_a) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed; got {other:?}"),
+    }
+}
+
 /// Wrong-length seed → InvalidKeyLength.
 #[test]
 fn ed25519_private_key_rejects_wrong_seed_length() {

--- a/crates/pulsar-kernel/tests/signature_property.rs
+++ b/crates/pulsar-kernel/tests/signature_property.rs
@@ -1,0 +1,211 @@
+//! Property tests for `pulsar_kernel::crypto::signature` (Ed25519).
+//!
+//! Per plan Section XVII.19 testing convention. Each property is run by
+//! `proptest` against randomly-generated seeds + messages across the
+//! full input range the FFI surface accepts.
+//!
+//! The properties below are the security-critical Ed25519 invariants:
+//!   - Sign / verify round-trip with the same `(key, message)` succeeds
+//!     for any well-formed seed + message.
+//!   - Signing is deterministic per RFC 8032 § 5.1.6 — the same
+//!     `(key, message)` pair always yields the same 64-byte signature.
+//!   - Distinct messages under the same key produce distinct signatures
+//!     (probabilistic — a regression that produced colliding signatures
+//!     would indicate a serious FFI bug).
+//!   - Distinct seeds yield distinct public keys (probabilistic).
+//!   - A signature produced by key A does NOT verify under key B's
+//!     public key — fundamental authenticity property.
+//!   - Tampering any byte of the message after signing causes
+//!     verification to return `Error::SignatureVerifyFailed`.
+//!
+//! These properties are necessary (though not sufficient) for the
+//! signature-correctness contract Pulsar relies on at higher layers
+//! (audit-chain Ed25519 signatures, AS-AT timestamping, attestation
+//! envelopes, JWS-equivalent token signing).
+
+// `expect`/`unwrap` are allowed in tests per CLAUDE.md §5.
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use proptest::prelude::*;
+use pulsar_kernel::crypto::signature::Ed25519PrivateKey;
+use pulsar_kernel::error::Error;
+use secrecy::SecretBox;
+
+/// Strategy producing a 32-byte Ed25519 seed as a raw `Vec<u8>`. Wrapping
+/// into [`SecretBox<[u8]>`] is deferred to [`private_from_vec`] so the
+/// raw bytes can also be compared for inequality in two-key properties.
+fn seed_strategy() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 32..=32)
+}
+
+/// Construct an [`Ed25519PrivateKey`] from a 32-byte vector. Caller must
+/// ensure the slice is exactly 32 bytes — the underlying constructor
+/// returns `Error::InvalidKeyLength` otherwise.
+fn private_from_vec(bytes: Vec<u8>) -> Ed25519PrivateKey {
+    let secret = SecretBox::new(bytes.into_boxed_slice());
+    Ed25519PrivateKey::from_bytes(secret).expect("32-byte seed should be accepted")
+}
+
+proptest::proptest! {
+    /// Sign then verify under the derived public key recovers
+    /// `Ok(())` for every `(seed, message)` pair. The fundamental
+    /// Ed25519 correctness property (RFC 8032 § 5.1.6 + § 5.1.7).
+    #[test]
+    fn sign_verify_round_trip(
+        seed in seed_strategy(),
+        message in proptest::collection::vec(any::<u8>(), 0..1024),
+    ) {
+        let private = private_from_vec(seed);
+        let public = private.public_key();
+        let signature = private.sign(&message).expect("sign should succeed");
+        public
+            .verify(&message, &signature)
+            .expect("verify should succeed on authentic signature");
+    }
+
+    /// Signing is deterministic — the same `(key, message)` pair always
+    /// produces the same 64-byte signature regardless of how many times
+    /// `sign` is invoked. Required by RFC 8032 § 5.1.6 and load-bearing
+    /// for downstream invariants (audit-chain signatures must be
+    /// reproducible across replays).
+    #[test]
+    fn signing_is_deterministic(
+        seed in seed_strategy(),
+        message in proptest::collection::vec(any::<u8>(), 0..512),
+    ) {
+        let private = private_from_vec(seed);
+        let sig_first = private.sign(&message).expect("first sign should succeed");
+        let sig_second = private.sign(&message).expect("second sign should succeed");
+        proptest::prop_assert_eq!(
+            sig_first.as_bytes(),
+            sig_second.as_bytes(),
+            "Ed25519 signatures must be deterministic per RFC 8032 § 5.1.6",
+        );
+    }
+
+    /// Distinct messages under the same key produce distinct signatures.
+    /// Probabilistic — Ed25519 signatures are 64 random-looking bytes, so
+    /// for any pair of distinct messages the chance of identical output
+    /// is negligible (~2⁻⁵¹².) A regression that produced colliding
+    /// signatures would indicate a serious FFI bug.
+    #[test]
+    fn distinct_messages_yield_distinct_signatures(
+        seed in seed_strategy(),
+        msg_a in proptest::collection::vec(any::<u8>(), 1..256),
+        msg_b in proptest::collection::vec(any::<u8>(), 1..256),
+    ) {
+        proptest::prop_assume!(msg_a != msg_b);
+        let private = private_from_vec(seed);
+        let sig_a = private.sign(&msg_a).expect("sign a should succeed");
+        let sig_b = private.sign(&msg_b).expect("sign b should succeed");
+        proptest::prop_assert_ne!(
+            sig_a.as_bytes(),
+            sig_b.as_bytes(),
+            "distinct messages must produce distinct signatures",
+        );
+    }
+
+    /// Distinct seeds yield distinct public keys (probabilistic).
+    /// SHA-512 of a 32-byte random seed is collision-resistant to ~2⁻²⁵⁶
+    /// so for random seeds the public keys differ with overwhelming
+    /// probability.
+    #[test]
+    fn distinct_seeds_yield_distinct_public_keys(
+        seed_a in seed_strategy(),
+        seed_b in seed_strategy(),
+    ) {
+        proptest::prop_assume!(seed_a != seed_b);
+        let private_a = private_from_vec(seed_a);
+        let private_b = private_from_vec(seed_b);
+        let pub_a = private_a.public_key();
+        let pub_b = private_b.public_key();
+        proptest::prop_assert_ne!(
+            pub_a.as_bytes(),
+            pub_b.as_bytes(),
+            "distinct seeds must derive distinct public keys",
+        );
+    }
+
+    /// Verifying a signature produced by key A under key B's public key
+    /// returns `Err(SignatureVerifyFailed)` for any pair of distinct
+    /// keys + any message. The fundamental authenticity property.
+    #[test]
+    fn verify_rejects_wrong_public_key(
+        seed_a in seed_strategy(),
+        seed_b in seed_strategy(),
+        message in proptest::collection::vec(any::<u8>(), 0..256),
+    ) {
+        proptest::prop_assume!(seed_a != seed_b);
+        let private_a = private_from_vec(seed_a);
+        let private_b = private_from_vec(seed_b);
+        let public_b = private_b.public_key();
+        let signature_a = private_a.sign(&message).expect("sign a should succeed");
+        match public_b.verify(&message, &signature_a) {
+            Err(Error::SignatureVerifyFailed) => {} // expected
+            other => proptest::prop_assert!(
+                false,
+                "verify under wrong public key must fail with SignatureVerifyFailed; got {other:?}",
+            ),
+        }
+    }
+
+    /// Flipping any single bit of the message after signing causes
+    /// verification to return `Err(SignatureVerifyFailed)`. Validates
+    /// the integrity property of Ed25519 — the signature commits to the
+    /// exact message bytes via SHA-512 hashing per RFC 8032 § 5.1.6.
+    #[test]
+    fn verify_rejects_tampered_message(
+        seed in seed_strategy(),
+        message in proptest::collection::vec(any::<u8>(), 1..256),
+        flip_byte_idx in 0_usize..512,
+        flip_bit_idx in 0_u8..8,
+    ) {
+        let private = private_from_vec(seed);
+        let public = private.public_key();
+        let signature = private.sign(&message).expect("sign should succeed");
+
+        // Move `message` into `tampered`; the original is unused after
+        // signing, so cloning would be redundant per clippy.
+        let mut tampered = message;
+        let actual_idx = flip_byte_idx % tampered.len();
+        tampered[actual_idx] ^= 1_u8 << flip_bit_idx;
+
+        match public.verify(&tampered, &signature) {
+            Err(Error::SignatureVerifyFailed) => {} // expected
+            other => proptest::prop_assert!(
+                false,
+                "verify of tampered message must fail with SignatureVerifyFailed; got {other:?}",
+            ),
+        }
+    }
+
+    /// Flipping any single bit of the signature after producing it
+    /// causes verification to return `Err(SignatureVerifyFailed)`.
+    /// Validates that the (R, s) signature components are bound to the
+    /// authentication outcome — a partial signature does not verify.
+    #[test]
+    fn verify_rejects_tampered_signature(
+        seed in seed_strategy(),
+        message in proptest::collection::vec(any::<u8>(), 0..256),
+        flip_byte_idx in 0_usize..64,
+        flip_bit_idx in 0_u8..8,
+    ) {
+        use pulsar_kernel::crypto::signature::Ed25519Signature;
+
+        let private = private_from_vec(seed);
+        let public = private.public_key();
+        let signature = private.sign(&message).expect("sign should succeed");
+
+        let mut tampered_bytes = *signature.as_bytes();
+        tampered_bytes[flip_byte_idx % 64] ^= 1_u8 << flip_bit_idx;
+        let tampered = Ed25519Signature::from_bytes(tampered_bytes);
+
+        match public.verify(&message, &tampered) {
+            Err(Error::SignatureVerifyFailed) => {} // expected
+            other => proptest::prop_assert!(
+                false,
+                "verify of tampered signature must fail with SignatureVerifyFailed; got {other:?}",
+            ),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Third sub-phase of Phase 1.1.B (safe Rust wrappers over the HACL\* FFI). Lands `pulsar-kernel::crypto::signature` (Ed25519 per RFC 8032) and `pulsar-kernel::crypto::kem` (X25519 per RFC 7748). 55/55 kernel tests pass. P-256 ECDSA + ECDH deferred to follow-up sub-phase 1.1.B.3-bis.

### What this PR does

**`signature.rs` — Ed25519 (RFC 8032)**:
- `Ed25519PrivateKey::from_bytes(SecretBox<[u8]>)` — 32-byte seed, zeroize-on-drop
- `public_key() -> Ed25519PublicKey` (32 bytes)
- `sign(message) -> Ed25519Signature` (64 bytes, deterministic per RFC 8032 § 5.1.6)
- `Ed25519PublicKey::verify(msg, sig) -> Result<()>` constant-time
- Debug impls redact secret bytes

**`kem.rs` — X25519 (RFC 7748)**:
- `X25519PrivateKey::from_bytes(SecretBox<[u8]>)` — 32-byte scalar (clamped by HACL\*)
- `public_key() -> X25519PublicKey` (32 bytes)
- `diffie_hellman(peer) -> Result<SecretBox<[u8]>>` — shared secret wrapped for HKDF
- Small-order public keys → `Error::InvalidPublicKey`

**Pattern continuity from Phase 1.1.B.2**: all private keys wrapped in `secrecy::SecretBox<[u8]>`; same `ensure_initialized` Once pattern; same SAFETY comment style; `Debug` redacts secrets.

### What this PR is **not**

- **No P-256** — ECDSA (FIPS 186-5) needs RFC 6979 deterministic nonce + secure RNG infrastructure not yet wired; ECDH similar concerns. Deferred to Phase 1.1.B.3-bis.
- No HKDF / HMAC / Argon2id (Phase 1.1.B.4)
- No Creusot contracts or TLA+ specs (Phase 1.1.D)

### Tests

**`signature_kat.rs`** (5 tests):
- RFC 8032 § 7.1 TEST 1 (empty message) — full key derivation + signing + verify against canonical signature
- RFC 8032 § 7.1 TEST 2 (1-byte message 0x72) — same
- Tampered-message verify rejection
- Wrong-length seed rejection
- Debug redaction

**`kem_kat.rs`** (3 tests):
- RFC 7748 § 6.1 — Alice/Bob mutual DH matches reference `4a5d9d5b...e161742`
- Small-order public key (u=0) rejection
- Wrong-length scalar rejection

## Test plan

- [x] `cargo fmt --all -- --check` — green
- [x] `cargo clippy -p pulsar-kernel --all-targets -- -D warnings` — green
- [x] `cargo nextest run -p pulsar-kernel` — 55/55 PASS
- [ ] `/review 403` — multi-perspective on signature/KEM API + Send/Sync soundness + RFC vector accuracy
- [ ] `/security-review` — verify no new attack surface