### PR TITLE
Sprint 1.1.C.2 — ML-DSA-65 safe wrapper + KATs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,46 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Sprint 1.1 — kernel crypto (Phase 1.1.C.1: ML-KEM-768 safe wrapper + KATs, in progress)
+### Sprint 1.1 — kernel crypto (Phase 1.1.C.2: ML-DSA-65 safe wrapper + KATs, in progress)
+
+Second sub-phase of Phase 1.1.C (post-quantum safe wrappers per Decision 2.60). Lands `pulsar-kernel::crypto::ml_dsa` — the FIPS 204 ML-DSA-65 digital-signature primitive sourced from `libcrux-ml-dsa 0.0.6` (Cryspen Rust-native, hax + F\* verified). NIST security category 3 ≈ AES-192. Pairs with Phase 1.1.C.1's ML-KEM-768; together they cover NIST's two PQC standards (FIPS 203 KEM + FIPS 204 signature). Phase 1.1.C.3 will combine ML-DSA-65 with Ed25519 to form the Ed25519+ML-DSA-65 hybrid signature per Decision 2.58.
+
+* **`pulsar-kernel::crypto::ml_dsa`** — typed safe wrappers over `libcrux_ml_dsa::ml_dsa_65`. `MlDsa65KeyPair::try_generate()` draws 32 bytes via the Pulsar CSPRNG; `try_from_seed(&seed)` takes a caller-supplied 32-byte seed for deterministic test-vector replay. `MlDsa65SigningKey::try_sign(message, context)` draws 32 bytes of CSPRNG randomness for FIPS 204 § 5.4's randomised-by-default signing; `try_sign_with_seed(message, context, &seed)` lets callers inject the randomness for testing. `MlDsa65VerificationKey::verify(message, context, &signature)` returns `Ok(())` on valid / `Err(SignatureVerifyFailed)` on invalid (collapses every libcrux `VerificationError` variant into a single error with no information leaked about which sub-step failed — matches the [`Ed25519PublicKey::verify`] posture).
+* **Context parameter (FIPS 204 § 5.2 domain separation)** — `sign` / `verify` accept a `&[u8]` context of length ≤ 255 used to separate signing-key reuse across protocols. Empty context (`b""`) is the no-domain-separation default. Mismatched contexts at sign vs verify time cause verification to fail. Excess-length contexts (> 255 bytes) are rejected as `Error::InputTooLong { actual, max: 255 }` at both sign and verify entry points.
+* **Sizes (FIPS 204 ML-DSA-65)** — verification (public) key 1 952 bytes, signing (private) key 4 032 bytes, signature 3 309 bytes, keypair-generation seed 32 bytes, signing randomness seed 32 bytes, max context 255 bytes. Re-exposed as `pulsar_kernel::crypto::ml_dsa::sizes::*` constants.
+* **Key-material handling** — signing keys store the 4 032-byte private key in `secrecy::SecretBox<[u8]>` (zeroize-on-drop) per the canonical Pulsar convention, matching `Ed25519PrivateKey` / `X25519PrivateKey` / `MlKem768PrivateKey`. The wrapper materialises libcrux's `MLDSA65SigningKey` value transiently for each `try_sign*` call via a `zeroize::Zeroizing<[u8; 4032]>` stack buffer; the libcrux transient lives ~µs and falls out of scope without explicit zeroization (libcrux 0.0.6 does not implement `Zeroize`). Stack-side intermediate copies (keygen seeds, signing randomness seeds, signing-key conversion buffers) are wrapped in `Zeroizing`. Verification keys + signatures are unwrapped (non-secret per the digital-signature threat model). `MlDsa65SigningKey::from_bytes` consumes the input `SecretBox<[u8]>` (matches the canonical consume-pattern documented in `crypto::mod`).
+* **Error enum extension** — one new variant: `SigningFailed` (libcrux's rejection-sampling loop in FIPS 204 § 5.4 exceeded the maximum number of attempts — vanishingly rare; treat as fatal-but-transient).
+* **Module re-exports** in `pulsar-kernel::crypto::mod` and `pulsar-kernel::prelude`: `MlDsa65KeyPair`, `MlDsa65SigningKey`, `MlDsa65VerificationKey`, `MlDsa65Signature`. The `sizes` sub-module is reachable via `pulsar_kernel::crypto::ml_dsa::sizes`.
+
+**Tests** (17 new tests across two integration test files):
+
+* **`tests/ml_dsa_kat.rs`** (12 tests):
+  - sizes match FIPS 204 ML-DSA-65 (4032/1952/3309/32/32/255) — pinned via constants
+  - sign/verify round-trip with fixed seed (reproducible across CI runs)
+  - seed-driven keypair generation is deterministic (same seed → same verification key)
+  - signing with a fixed randomness seed is deterministic (same `(sk, message, context, signing_seed)` → same signature)
+  - verification rejects tampered messages → `SignatureVerifyFailed`
+  - verification rejects tampered signatures (single-bit flip) → `SignatureVerifyFailed`
+  - FIPS 204 § 5.2 domain separation — context mismatch at sign vs verify → `SignatureVerifyFailed`
+  - verification rejects wrong (unrelated) verification keys
+  - signing rejects oversize context (256 bytes) → `InputTooLong { actual: 256, max: 255 }`
+  - verifying rejects oversize context → `InputTooLong { actual: 256, max: 255 }`
+  - length-validation paths for keygen seed (31 vs 32), signing key (4031 vs 4032), signing seed (31 vs 32) → `InvalidKeyLength`
+  - `Debug` redacts signing-key bytes (`finish_non_exhaustive` `..` marker), verification-key Debug shows hex prefix
+* **`tests/ml_dsa_property.rs`** (5 properties using `proptest`, 32 cases each — ML-DSA ops cost 100s of µs):
+  - sign/verify round-trip across random `(keygen_seed, signing_seed, message)` triples
+  - distinct keygen seeds yield distinct verification keys (probabilistic — collision bounded by 2⁻¹⁵⁰⁰⁰ish on 1 952-byte keys)
+  - distinct signing seeds yield distinct signatures under same `(sk, message, context)` (FIPS 204 § 5.4 randomised signing)
+  - verification rejects tampered messages (single-bit flip) → `SignatureVerifyFailed`
+  - verification rejects signatures verified under wrong verification keys
+
+Quality gates verified locally:
+  - cargo fmt --all -- --check ✓
+  - cargo clippy -p pulsar-kernel --all-targets -- -D warnings ✓
+  - cargo nextest run -p pulsar-kernel (164/164 PASS, +17 from this phase) ✓
+  - cargo test -p pulsar-kernel --doc ✓
+
+### Sprint 1.1 — kernel crypto (Phase 1.1.C.1: ML-KEM-768 safe wrapper + KATs — merged 2026-04-28 as `a8854e7b`)
 
 First sub-phase of Phase 1.1.C (post-quantum safe wrappers per Decision 2.60). Lands `pulsar-kernel::crypto::ml_kem` — the FIPS 203 ML-KEM-768 key-encapsulation primitive sourced from `libcrux-ml-kem 0.0.8` (Cryspen Rust-native, hax + F\* verified, NIST security category 3 ≈ AES-192). Phase 1.1.C.2 lands ML-DSA-65 (FIPS 204) and Phase 1.1.C.3 the hybrid X25519+ML-KEM-768 / Ed25519+ML-DSA-65 constructions per Decision 2.58.
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4442,6 +4442,16 @@ checksum = "68ab91017fe16c622486840e4c83c9a37afeff978bd239b5293d61ece587de66"
 
 [[package]]
 name = "libcrux-intrinsics"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0aa4779454e853d1de200cd12f19a8185aac47d99a5ec404cea3295c943d48f1"
+dependencies = [
+ "core-models",
+ "hax-lib",
+]
+
+[[package]]
+name = "libcrux-intrinsics"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1b5db005ff8001e026b73a6842ee81bbef8ec5ff0e1915a67ae65fd2a9fafa5"
@@ -4451,17 +4461,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "libcrux-macros"
+version = "0.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd6aa2dcd5be681662001b81d493f1569c6d49a32361f470b0c955465cd0338"
+dependencies = [
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "libcrux-ml-dsa"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "784f7dc5310246517cf313dfc608a5855af9d1fb714f49286c20dbf64e4b25e0"
+dependencies = [
+ "core-models",
+ "hax-lib",
+ "libcrux-intrinsics 0.0.5",
+ "libcrux-macros",
+ "libcrux-platform",
+ "libcrux-sha3 0.0.6",
+]
+
+[[package]]
 name = "libcrux-ml-kem"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a14ab3e477de9df6ee1273a114018ff62c4996ca9220070c4e5cb1743f94a67d"
 dependencies = [
  "hax-lib",
- "libcrux-intrinsics",
+ "libcrux-intrinsics 0.0.6",
  "libcrux-platform",
  "libcrux-secrets",
- "libcrux-sha3",
- "libcrux-traits",
+ "libcrux-sha3 0.0.8",
+ "libcrux-traits 0.0.6",
  "rand 0.9.4",
  "tls_codec",
 ]
@@ -4486,14 +4520,36 @@ dependencies = [
 
 [[package]]
 name = "libcrux-sha3"
+version = "0.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3dabce2795479bd7294f853f7966a678cadf7a26d3d29f61cf15f5123e7ba4f"
+dependencies = [
+ "hax-lib",
+ "libcrux-intrinsics 0.0.5",
+ "libcrux-platform",
+ "libcrux-traits 0.0.5",
+]
+
+[[package]]
+name = "libcrux-sha3"
 version = "0.0.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b1ae0b7d0e1cc4793a609fd0ff2ca3b3a3fabae523770c619a3d4bc86417b0d7"
 dependencies = [
  "hax-lib",
- "libcrux-intrinsics",
+ "libcrux-intrinsics 0.0.6",
  "libcrux-platform",
- "libcrux-traits",
+ "libcrux-traits 0.0.6",
+]
+
+[[package]]
+name = "libcrux-traits"
+version = "0.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "695ff2fb97627e4d57315a2fdfbfe50df1c80c6ef7d91ba34216169bd6f41c00"
+dependencies = [
+ "libcrux-secrets",
+ "rand 0.9.4",
 ]
 
 [[package]]
@@ -6934,6 +6990,7 @@ version = "0.0.1-alpha.0"
 dependencies = [
  "argon2",
  "hex",
+ "libcrux-ml-dsa",
  "libcrux-ml-kem",
  "proptest",
  "pulsar-crypto-hacl-bindings",

--- a/crates/pulsar-kernel/Cargo.toml
+++ b/crates/pulsar-kernel/Cargo.toml
@@ -19,6 +19,7 @@ categories.workspace = true
 # Rust-native (Phase 1.1.C); Argon2id via RustCrypto (Phase 1.1.B.4).
 pulsar-crypto-hacl-bindings = { path = "../pulsar-crypto-hacl-bindings", version = "=0.0.1-alpha.0" }
 argon2 = { workspace = true }
+libcrux-ml-dsa = { workspace = true }
 libcrux-ml-kem = { workspace = true }
 rand = { workspace = true }
 subtle = { workspace = true }

--- a/crates/pulsar-kernel/src/crypto/ml_dsa.rs
+++ b/crates/pulsar-kernel/src/crypto/ml_dsa.rs
@@ -131,6 +131,15 @@ impl MlDsa65VerificationKey {
     pub const LEN: usize = sizes::VERIFICATION_KEY_LEN;
 
     /// Construct from a 1 952-byte buffer.
+    ///
+    /// `const fn`: callers can build a `static` or `const`
+    /// `MlDsa65VerificationKey` from a literal byte array — useful
+    /// for embedding a known root verification key (e.g., a release-
+    /// signing root) at compile time. Does NOT validate the
+    /// structure of the bytes; the verification key's structural
+    /// check happens at [`verify`](Self::verify) time (libcrux 0.0.6
+    /// does not expose a standalone `validate_verification_key`
+    /// function — unlike `MlKem768PublicKey::validate`).
     #[must_use]
     pub const fn from_bytes(bytes: [u8; Self::LEN]) -> Self {
         Self {
@@ -229,10 +238,14 @@ impl MlDsa65SigningKey {
     }
 
     /// Sign `message` with optional domain-separation `context` under
-    /// this signing key, drawing 32 bytes of CSPRNG randomness for
-    /// the rejection-sampling loop. Per FIPS 204 § 5.4, ML-DSA
-    /// signing is randomised by default — the same `(key, message,
-    /// context)` triple yields different signatures across calls.
+    /// this signing key, drawing 32 bytes of CSPRNG randomness as the
+    /// FIPS 204 § 5.4 `rnd` input. The `rnd` value is hashed into the
+    /// commitment-derivation chain (`mu = H(prefix || rnd || M)`), so
+    /// it influences both the rejection-sampling loop and the
+    /// commitment generation — the spec calls this the "hedged"
+    /// signing mode. Per FIPS 204 § 5.4, ML-DSA signing is randomised
+    /// by default: the same `(key, message, context)` triple yields
+    /// different signatures across calls.
     ///
     /// # Errors
     ///

--- a/crates/pulsar-kernel/src/crypto/ml_dsa.rs
+++ b/crates/pulsar-kernel/src/crypto/ml_dsa.rs
@@ -1,0 +1,431 @@
+//! ML-DSA (Module Lattice-based Digital Signature Algorithm) — safe
+//! Rust wrappers over libcrux per Decision 2.60.
+//!
+//! Per FIPS 204 (final August 2024), ML-DSA is the NIST-standardised
+//! post-quantum digital-signature scheme derived from CRYSTALS-Dilithium.
+//! Pulsar ships the ML-DSA-65 parameter set (NIST security category 3
+//! — equivalent to AES-192) per Decision 2.58 hybrid PQC posture, where
+//! every signature scheme that anchors a long-term commitment runs
+//! **Ed25519 + ML-DSA-65 in parallel** and verifies REQUIRE BOTH to
+//! pass. The hybrid construction ships in Phase 1.1.C.3; this
+//! sub-phase lands the bare ML-DSA-65 primitive that the hybrid
+//! layers on top of.
+//!
+//! # Sourcing — libcrux Rust-native (Decision 2.60)
+//!
+//! ML-DSA-65 is sourced from `libcrux-ml-dsa 0.0.6` — Cryspen's
+//! Rust-native verified extraction with `hax + F*` proofs of FIPS 204
+//! conformance. Same Cryspen / hax / F\* verification provenance as
+//! HACL\* (classical primitives) and `libcrux-ml-kem` (Phase 1.1.C.1
+//! ML-KEM-768) — see Decision 2.60 for the unified provenance
+//! argument.
+//!
+//! # API surface
+//!
+//! Three flows cover the typical use cases:
+//!
+//! - **Keypair generation** — `MlDsa65KeyPair::try_generate()` uses
+//!   the Pulsar CSPRNG abstraction ([`crate::crypto::rng`]) to draw
+//!   32 bytes of seed material; `try_from_seed(&seed)` takes a
+//!   caller-supplied 32-byte seed for deterministic test-vector
+//!   replay.
+//! - **Signing** (caller holds the signing key) —
+//!   `MlDsa65SigningKey::try_sign(message, context)` draws 32 bytes
+//!   of signing randomness from the OS CSPRNG (per FIPS 204 § 5.4 —
+//!   ML-DSA's signing operation is randomised by default for
+//!   side-channel resistance, even though the algorithm has a
+//!   deterministic mode); `try_sign_with_seed(message, context,
+//!   &seed)` lets callers inject the randomness for testing.
+//! - **Verification** (peer holds the verification key) —
+//!   `MlDsa65VerificationKey::verify(message, context, &signature)`
+//!   returns `Ok(())` on valid / `Err(SignatureVerifyFailed)` on
+//!   invalid (no information leaked about which step of verification
+//!   failed — same posture as Ed25519).
+//!
+//! # Sizes (FIPS 204 ML-DSA-65)
+//!
+//! | Element                   | Length     |
+//! | ------------------------- | ---------- |
+//! | Verification (public) key | 1 952 bytes|
+//! | Signing (private) key     | 4 032 bytes|
+//! | Signature                 | 3 309 bytes|
+//! | Keypair-generation seed   | 32 bytes   |
+//! | Signing randomness seed   | 32 bytes   |
+//! | Context (domain-separation) max length | 255 bytes |
+//!
+//! All sizes are exact; the ML-DSA specification fixes them as part
+//! of the parameter set.
+//!
+//! # Context parameter (FIPS 204 § 5.2)
+//!
+//! ML-DSA's `sign` / `verify` accept a context byte string of length
+//! ≤ 255 used for domain separation between protocols using the same
+//! signing key. Callers that don't need domain separation pass an
+//! empty `&[]` context. Mismatched contexts at sign vs verify time
+//! cause verification to fail. Excess-length contexts (> 255 bytes)
+//! are rejected as [`Error::InputTooLong`].
+//!
+//! # Key-material handling
+//!
+//! Following the canonical pattern from Phase 1.1.B.3 / Phase 1.1.C.1
+//! (ML-KEM-768):
+//!
+//! - **Signing keys** store the 4 032-byte private key in
+//!   [`secrecy::SecretBox<[u8]>`] (zeroize-on-drop) — the Pulsar
+//!   private-key convention. The wrapper materialises libcrux's
+//!   `MLDSA65SigningKey` value transiently for each `try_sign*` call
+//!   via a [`zeroize::Zeroizing<[u8; 4032]>`] stack buffer.
+//! - **Verification keys + signatures** are unwrapped types in line
+//!   with their non-secret semantics per the digital-signature threat
+//!   model (verification keys + signatures are public).
+//! - **Generation + signing seeds** are wrapped in [`SecretBox<[u8]>`]
+//!   when caller-supplied; internal stack buffers are wrapped in
+//!   [`Zeroizing`] for explicit zeroize-on-drop.
+
+use crate::crypto::rng;
+use crate::error::{Error, Result};
+use libcrux_ml_dsa::ml_dsa_65 as libcrux;
+use libcrux_ml_dsa::{KEY_GENERATION_RANDOMNESS_SIZE, SIGNING_RANDOMNESS_SIZE};
+use secrecy::{ExposeSecret, SecretBox};
+use zeroize::Zeroizing;
+
+/// FIPS 204 ML-DSA-65 fixed sizes — re-exposed as public constants on
+/// the wrapper for caller-side allocation sizing decisions.
+pub mod sizes {
+    /// Signing (private) key length in bytes.
+    pub const SIGNING_KEY_LEN: usize = 4032;
+    /// Verification (public) key length in bytes.
+    pub const VERIFICATION_KEY_LEN: usize = 1952;
+    /// Signature length in bytes.
+    pub const SIGNATURE_LEN: usize = 3309;
+    /// Keypair-generation randomness length in bytes.
+    pub const KEY_GENERATION_RANDOMNESS_LEN: usize = super::KEY_GENERATION_RANDOMNESS_SIZE;
+    /// Signing randomness length in bytes.
+    pub const SIGNING_RANDOMNESS_LEN: usize = super::SIGNING_RANDOMNESS_SIZE;
+    /// Maximum context-string length (FIPS 204 § 5.2).
+    pub const MAX_CONTEXT_LEN: usize = 255;
+}
+
+/// ML-DSA-65 verification (public) key.
+///
+/// Wraps the libcrux `MLDSA65VerificationKey` (a 1 952-byte array).
+/// Verification keys are public — they are transmitted to peers
+/// alongside signed messages.
+#[derive(Clone)]
+pub struct MlDsa65VerificationKey {
+    inner: libcrux::MLDSA65VerificationKey,
+}
+
+impl core::fmt::Debug for MlDsa65VerificationKey {
+    /// Verification keys are not secret — show a short hex prefix +
+    /// length for identification, mirroring [`crate::crypto::signature::Ed25519PublicKey`].
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MlDsa65VerificationKey")
+            .field("bytes", &super::hex_encode_short(self.inner.as_slice()))
+            .finish()
+    }
+}
+
+impl MlDsa65VerificationKey {
+    /// Verification-key length in bytes (FIPS 204 ML-DSA-65).
+    pub const LEN: usize = sizes::VERIFICATION_KEY_LEN;
+
+    /// Construct from a 1 952-byte buffer.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; Self::LEN]) -> Self {
+        Self {
+            inner: libcrux::MLDSA65VerificationKey::new(bytes),
+        }
+    }
+
+    /// Return the verification key as a 1 952-byte slice.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; Self::LEN] {
+        self.inner.as_ref()
+    }
+
+    /// Verify `signature` over `message` with optional domain-
+    /// separation `context` under this verification key. Returns
+    /// `Ok(())` if the signature is valid; [`Error::SignatureVerifyFailed`]
+    /// otherwise (collapses every libcrux `VerificationError` variant
+    /// — malformed hint, signer-response exceeds bound, commitment-
+    /// hash mismatch, context too long — into the single error
+    /// variant so no information leaks about which sub-step failed,
+    /// matching the [`crate::crypto::signature::Ed25519PublicKey::verify`]
+    /// posture).
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InputTooLong`] — `context.len() > 255` (FIPS 204 §
+    ///   5.2 maximum context length).
+    /// - [`Error::SignatureVerifyFailed`] — the signature is not
+    ///   valid for the (verification key, message, context) triple.
+    pub fn verify(
+        &self,
+        message: &[u8],
+        context: &[u8],
+        signature: &MlDsa65Signature,
+    ) -> Result<()> {
+        if context.len() > sizes::MAX_CONTEXT_LEN {
+            return Err(Error::InputTooLong {
+                actual: context.len(),
+                max: sizes::MAX_CONTEXT_LEN,
+            });
+        }
+        libcrux::verify(&self.inner, message, context, &signature.inner)
+            .map_err(|_| Error::SignatureVerifyFailed)
+    }
+}
+
+/// ML-DSA-65 signing (private) key.
+///
+/// Stores the 4 032-byte private key in [`secrecy::SecretBox<[u8]>`]
+/// (zeroize-on-drop) — the canonical Pulsar private-key convention.
+/// libcrux's `MLDSA65SigningKey` value is materialised transiently
+/// for each `try_sign*` call; the trust window is microseconds (one
+/// signing operation) and subsequent stack frames overwrite the
+/// transient bytes (libcrux 0.0.6 does not implement `Zeroize`).
+pub struct MlDsa65SigningKey {
+    bytes: SecretBox<[u8]>,
+}
+
+impl core::fmt::Debug for MlDsa65SigningKey {
+    /// Print only the type name — never the signing-key bytes.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MlDsa65SigningKey").finish_non_exhaustive()
+    }
+}
+
+impl MlDsa65SigningKey {
+    /// Signing-key length in bytes (FIPS 204 ML-DSA-65).
+    pub const LEN: usize = sizes::SIGNING_KEY_LEN;
+
+    /// Construct from a 4 032-byte buffer wrapped in [`SecretBox<[u8]>`].
+    /// Consumes the input `SecretBox` (matches the canonical
+    /// consume-pattern for private-key wrappers in `crypto::mod`).
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidKeyLength`] — `secret.expose_secret().len() != 4032`.
+    pub fn from_bytes(secret: SecretBox<[u8]>) -> Result<Self> {
+        if secret.expose_secret().len() != Self::LEN {
+            return Err(Error::InvalidKeyLength {
+                expected: Self::LEN,
+                actual: secret.expose_secret().len(),
+            });
+        }
+        Ok(Self { bytes: secret })
+    }
+
+    /// Materialise libcrux's `MLDSA65SigningKey` value from our
+    /// `SecretBox<[u8]>` storage. Returns the libcrux instance plus
+    /// a [`Zeroizing`] guard for the stack-side intermediate copy
+    /// (zeroized on drop).
+    fn materialize(&self) -> (libcrux::MLDSA65SigningKey, Zeroizing<[u8; Self::LEN]>) {
+        let mut buf = Zeroizing::new([0_u8; Self::LEN]);
+        buf.copy_from_slice(self.bytes.expose_secret());
+        let inner = libcrux::MLDSA65SigningKey::new(*buf);
+        (inner, buf)
+    }
+
+    /// Sign `message` with optional domain-separation `context` under
+    /// this signing key, drawing 32 bytes of CSPRNG randomness for
+    /// the rejection-sampling loop. Per FIPS 204 § 5.4, ML-DSA
+    /// signing is randomised by default — the same `(key, message,
+    /// context)` triple yields different signatures across calls.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InputTooLong`] — `context.len() > 255` (FIPS 204 §
+    ///   5.2 maximum context length).
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
+    ///   during randomness generation.
+    /// - [`Error::SigningFailed`] — libcrux's rejection-sampling
+    ///   loop exceeded the maximum number of attempts (vanishingly
+    ///   rare; treat as fatal-but-transient).
+    pub fn try_sign(&self, message: &[u8], context: &[u8]) -> Result<MlDsa65Signature> {
+        let mut seed = Zeroizing::new([0_u8; SIGNING_RANDOMNESS_SIZE]);
+        rng::try_random_into(seed.as_mut_slice())?;
+        self.sign_with_randomness(message, context, *seed)
+    }
+
+    /// Sign with a caller-supplied 32-byte randomness seed. Used by
+    /// deterministic-test-vector replay and by hybrid-signature
+    /// constructions that derive the seed from upstream entropy
+    /// combinations.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InputTooLong`] — `context.len() > 255`.
+    /// - [`Error::InvalidKeyLength`] — `seed.expose_secret().len() != 32`.
+    /// - [`Error::SigningFailed`] — see [`try_sign`](Self::try_sign).
+    pub fn try_sign_with_seed(
+        &self,
+        message: &[u8],
+        context: &[u8],
+        seed: &SecretBox<[u8]>,
+    ) -> Result<MlDsa65Signature> {
+        let bytes = seed.expose_secret();
+        if bytes.len() != SIGNING_RANDOMNESS_SIZE {
+            return Err(Error::InvalidKeyLength {
+                expected: SIGNING_RANDOMNESS_SIZE,
+                actual: bytes.len(),
+            });
+        }
+        let mut seed_array = Zeroizing::new([0_u8; SIGNING_RANDOMNESS_SIZE]);
+        seed_array.copy_from_slice(bytes);
+        self.sign_with_randomness(message, context, *seed_array)
+    }
+
+    /// Internal signing entry point that takes the randomness as a
+    /// fixed-size array. Both `try_sign*` variants funnel through
+    /// here so the libcrux invocation lives in one place.
+    fn sign_with_randomness(
+        &self,
+        message: &[u8],
+        context: &[u8],
+        randomness: [u8; SIGNING_RANDOMNESS_SIZE],
+    ) -> Result<MlDsa65Signature> {
+        if context.len() > sizes::MAX_CONTEXT_LEN {
+            return Err(Error::InputTooLong {
+                actual: context.len(),
+                max: sizes::MAX_CONTEXT_LEN,
+            });
+        }
+        let (inner_key, _zeroizing_guard) = self.materialize();
+        let signature = libcrux::sign(&inner_key, message, context, randomness)
+            .map_err(|_| Error::SigningFailed)?;
+        Ok(MlDsa65Signature { inner: signature })
+    }
+}
+
+/// ML-DSA-65 signature (3 309 bytes).
+#[derive(Clone)]
+pub struct MlDsa65Signature {
+    inner: libcrux::MLDSA65Signature,
+}
+
+impl core::fmt::Debug for MlDsa65Signature {
+    /// Signatures are not secret per FIPS 204 (only the signing key
+    /// is). Show a short hex prefix + length for identification.
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MlDsa65Signature")
+            .field("bytes", &super::hex_encode_short(self.inner.as_slice()))
+            .finish()
+    }
+}
+
+impl MlDsa65Signature {
+    /// Signature length in bytes (FIPS 204 ML-DSA-65).
+    pub const LEN: usize = sizes::SIGNATURE_LEN;
+
+    /// Construct from a 3 309-byte buffer.
+    #[must_use]
+    pub const fn from_bytes(bytes: [u8; Self::LEN]) -> Self {
+        Self {
+            inner: libcrux::MLDSA65Signature::new(bytes),
+        }
+    }
+
+    /// Return the signature as a 3 309-byte slice.
+    #[must_use]
+    pub const fn as_bytes(&self) -> &[u8; Self::LEN] {
+        self.inner.as_ref()
+    }
+}
+
+/// ML-DSA-65 keypair — bundles a verification (public) + signing
+/// (private) key produced by a single keypair-generation run.
+pub struct MlDsa65KeyPair {
+    verification_key: MlDsa65VerificationKey,
+    signing_key: MlDsa65SigningKey,
+}
+
+impl core::fmt::Debug for MlDsa65KeyPair {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("MlDsa65KeyPair")
+            .field("verification_key", &self.verification_key)
+            .field("signing_key", &self.signing_key)
+            .finish()
+    }
+}
+
+impl MlDsa65KeyPair {
+    /// Generate a fresh ML-DSA-65 keypair using the OS CSPRNG.
+    ///
+    /// Draws 32 bytes of randomness via [`crate::crypto::rng::try_random_into`].
+    /// For deterministic test-vector replay, use
+    /// [`try_from_seed`](Self::try_from_seed).
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
+    ///   during seed generation.
+    pub fn try_generate() -> Result<Self> {
+        let mut seed = Zeroizing::new([0_u8; KEY_GENERATION_RANDOMNESS_SIZE]);
+        rng::try_random_into(seed.as_mut_slice())?;
+        Ok(Self::from_seed_bytes(*seed))
+    }
+
+    /// Generate a keypair from a caller-supplied 32-byte seed wrapped
+    /// in [`SecretBox<[u8]>`]. Used for deterministic test-vector
+    /// replay (FIPS 204 ACVP reference vectors) and for hybrid-
+    /// signature constructions.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidKeyLength`] — `seed.expose_secret().len() != 32`.
+    pub fn try_from_seed(seed: &SecretBox<[u8]>) -> Result<Self> {
+        let bytes = seed.expose_secret();
+        if bytes.len() != KEY_GENERATION_RANDOMNESS_SIZE {
+            return Err(Error::InvalidKeyLength {
+                expected: KEY_GENERATION_RANDOMNESS_SIZE,
+                actual: bytes.len(),
+            });
+        }
+        let mut seed_array = Zeroizing::new([0_u8; KEY_GENERATION_RANDOMNESS_SIZE]);
+        seed_array.copy_from_slice(bytes);
+        Ok(Self::from_seed_bytes(*seed_array))
+    }
+
+    /// Internal seed-driven constructor. Persistent signing-key
+    /// storage is `SecretBox<[u8]>` (zeroize-on-drop); the libcrux
+    /// transient lives only for the duration of this function.
+    fn from_seed_bytes(seed: [u8; KEY_GENERATION_RANDOMNESS_SIZE]) -> Self {
+        let kp = libcrux::generate_key_pair(seed);
+        let sk_libcrux = kp.signing_key;
+        let vk_libcrux = kp.verification_key;
+
+        // Copy libcrux's signing-key bytes into a Zeroizing stack
+        // buffer, then into the persistent SecretBox<[u8]>. The
+        // libcrux value's internal 4 032 bytes are not zeroized but
+        // live only for the remainder of this function.
+        let mut sk_buf = Zeroizing::new([0_u8; sizes::SIGNING_KEY_LEN]);
+        sk_buf.copy_from_slice(sk_libcrux.as_slice());
+        let sk_secret = SecretBox::new(sk_buf.to_vec().into_boxed_slice());
+
+        Self {
+            verification_key: MlDsa65VerificationKey { inner: vk_libcrux },
+            signing_key: MlDsa65SigningKey { bytes: sk_secret },
+        }
+    }
+
+    /// Return a reference to the verification (public) key.
+    #[must_use]
+    pub const fn verification_key(&self) -> &MlDsa65VerificationKey {
+        &self.verification_key
+    }
+
+    /// Return a reference to the signing (private) key.
+    #[must_use]
+    pub const fn signing_key(&self) -> &MlDsa65SigningKey {
+        &self.signing_key
+    }
+
+    /// Decompose the keypair into its constituent verification +
+    /// signing keys, transferring ownership.
+    #[must_use]
+    pub fn into_parts(self) -> (MlDsa65VerificationKey, MlDsa65SigningKey) {
+        (self.verification_key, self.signing_key)
+    }
+}

--- a/crates/pulsar-kernel/src/crypto/mod.rs
+++ b/crates/pulsar-kernel/src/crypto/mod.rs
@@ -64,6 +64,7 @@ pub mod hash;
 pub mod hkdf;
 pub mod hmac;
 pub mod kem;
+pub mod ml_dsa;
 pub mod ml_kem;
 pub mod rng;
 pub mod signature;
@@ -75,6 +76,7 @@ pub use hash::{sha3_256, sha3_384, sha3_512};
 pub use hash::{sha256, sha384, sha512};
 pub use hmac::{HmacAlgorithm, HmacKey};
 pub use kem::{X25519PrivateKey, X25519PublicKey};
+pub use ml_dsa::{MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey};
 pub use ml_kem::{MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey};
 pub use signature::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
 

--- a/crates/pulsar-kernel/src/error.rs
+++ b/crates/pulsar-kernel/src/error.rs
@@ -80,6 +80,16 @@ pub enum Error {
     #[error("signature verification failed")]
     SignatureVerifyFailed,
 
+    /// Digital-signature signing failed at the primitive layer. ML-DSA
+    /// returns this for rejection-sampling overflow (the rejection
+    /// loop in FIPS 204 § 5.4 exceeds the maximum number of
+    /// attempts) — a probabilistic but vanishingly rare runtime
+    /// condition. Callers should treat this as fatal-but-transient
+    /// and abort the in-flight operation rather than retrying with
+    /// the same `(key, message, context)` triple.
+    #[error("signing failed at the primitive layer")]
+    SigningFailed,
+
     /// Argon2id password verification failed — supplied password did
     /// not match the stored hash. Returned in constant time relative to
     /// the comparison step (`argon2::PasswordVerifier::verify_password`

--- a/crates/pulsar-kernel/src/prelude.rs
+++ b/crates/pulsar-kernel/src/prelude.rs
@@ -8,6 +8,7 @@
 pub use crate::crypto::{
     AeadAlgorithm, AeadKey, Argon2idParams, Argon2idVerifyLimits, Ed25519PrivateKey,
     Ed25519PublicKey, Ed25519Signature, HashAlgorithm, Hasher, HmacAlgorithm, HmacKey,
+    MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey,
     MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey, X25519PrivateKey,
     X25519PublicKey,
 };

--- a/crates/pulsar-kernel/tests/ml_dsa_kat.rs
+++ b/crates/pulsar-kernel/tests/ml_dsa_kat.rs
@@ -1,0 +1,298 @@
+//! Known-answer + integration tests for `pulsar_kernel::crypto::ml_dsa`.
+//!
+//! Cryptographic correctness of the underlying ML-DSA-65 implementation
+//! is asserted by the `libcrux-ml-dsa` upstream test suite (FIPS 204
+//! ACVP conformance + hax + F\* machine-checked proofs). These
+//! wrapper-level tests focus on:
+//!
+//! - Sizes match FIPS 204 ML-DSA-65 (4032 / 1952 / 3309 / 32 / 32 / 255)
+//! - Sign/verify round-trip recovers `Ok(())`
+//! - Seed-driven keypair generation is deterministic
+//! - Signing with a fixed randomness seed is deterministic
+//! - Verification rejects tampered messages → `SignatureVerifyFailed`
+//! - Verification rejects tampered signatures → `SignatureVerifyFailed`
+//! - Wrong-context verification fails (FIPS 204 § 5.2 domain separation)
+//! - Verification rejects wrong verification keys
+//! - Length-validation paths surface the right `Error` variants
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pulsar_kernel::crypto::ml_dsa::{
+    MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey, sizes,
+};
+use secrecy::SecretBox;
+
+fn seed_box(bytes: &[u8]) -> SecretBox<[u8]> {
+    SecretBox::new(bytes.to_vec().into_boxed_slice())
+}
+
+/// Sizes match FIPS 204 ML-DSA-65.
+#[test]
+fn ml_dsa_65_sizes_match_fips_204() {
+    assert_eq!(sizes::SIGNING_KEY_LEN, 4032);
+    assert_eq!(sizes::VERIFICATION_KEY_LEN, 1952);
+    assert_eq!(sizes::SIGNATURE_LEN, 3309);
+    assert_eq!(sizes::KEY_GENERATION_RANDOMNESS_LEN, 32);
+    assert_eq!(sizes::SIGNING_RANDOMNESS_LEN, 32);
+    assert_eq!(sizes::MAX_CONTEXT_LEN, 255);
+
+    assert_eq!(MlDsa65SigningKey::LEN, 4032);
+    assert_eq!(MlDsa65VerificationKey::LEN, 1952);
+    assert_eq!(MlDsa65Signature::LEN, 3309);
+}
+
+/// Sign/verify round-trip — the verifier accepts an authentic
+/// signature produced by the matching signing key.
+#[test]
+fn ml_dsa_65_sign_verify_round_trip() {
+    let seed = seed_box(&[0x42_u8; 32]);
+    let kp = MlDsa65KeyPair::try_from_seed(&seed).expect("keypair from seed should succeed");
+
+    let message = b"Pulsar Phase 1.1.C.2 ML-DSA-65 round-trip vector";
+    let context = b"";
+    let signature = kp
+        .signing_key()
+        .try_sign(message, context)
+        .expect("sign should succeed");
+
+    kp.verification_key()
+        .verify(message, context, &signature)
+        .expect("authentic signature must verify");
+}
+
+/// Seed-driven keypair generation is deterministic — the same 32-byte
+/// seed always yields the same verification key.
+#[test]
+fn ml_dsa_65_keypair_from_seed_is_deterministic() {
+    let seed_bytes = [0x99_u8; 32];
+
+    let kp_a =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&seed_bytes)).expect("keypair a should succeed");
+    let kp_b =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&seed_bytes)).expect("keypair b should succeed");
+
+    assert_eq!(
+        kp_a.verification_key().as_bytes(),
+        kp_b.verification_key().as_bytes(),
+        "deterministic seed must yield identical verification keys",
+    );
+}
+
+/// Signing with a fixed randomness seed is deterministic — the same
+/// `(signing_key, message, context, signing_seed)` always yields the
+/// same signature.
+#[test]
+fn ml_dsa_65_sign_with_seed_is_deterministic() {
+    let kp_seed = seed_box(&[0x11_u8; 32]);
+    let kp = MlDsa65KeyPair::try_from_seed(&kp_seed).expect("keypair should succeed");
+
+    let signing_seed = seed_box(&[0x77_u8; 32]);
+    let message = b"deterministic signing test";
+    let context = b"";
+
+    let sig_a = kp
+        .signing_key()
+        .try_sign_with_seed(message, context, &signing_seed)
+        .expect("sign a should succeed");
+    let sig_b = kp
+        .signing_key()
+        .try_sign_with_seed(message, context, &signing_seed)
+        .expect("sign b should succeed");
+
+    assert_eq!(
+        sig_a.as_bytes(),
+        sig_b.as_bytes(),
+        "fixed signing seed must yield identical signatures",
+    );
+}
+
+/// Verifying a tampered message under an authentic signature fails.
+#[test]
+fn ml_dsa_65_verify_rejects_tampered_message() {
+    use pulsar_kernel::error::Error;
+
+    let kp =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0x55_u8; 32])).expect("keypair should succeed");
+
+    let signature = kp
+        .signing_key()
+        .try_sign(b"original message", b"")
+        .expect("sign should succeed");
+
+    match kp
+        .verification_key()
+        .verify(b"tampered message", b"", &signature)
+    {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for tampered message; got {other:?}"),
+    }
+}
+
+/// Verifying a tampered signature fails — flipping a single bit
+/// invalidates the signature.
+#[test]
+fn ml_dsa_65_verify_rejects_tampered_signature() {
+    use pulsar_kernel::error::Error;
+
+    let kp =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0x66_u8; 32])).expect("keypair should succeed");
+
+    let message = b"signature-tamper test";
+    let signature = kp
+        .signing_key()
+        .try_sign(message, b"")
+        .expect("sign should succeed");
+
+    let mut tampered_bytes = *signature.as_bytes();
+    tampered_bytes[0] ^= 0x01;
+    let tampered = MlDsa65Signature::from_bytes(tampered_bytes);
+
+    match kp.verification_key().verify(message, b"", &tampered) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for tampered signature; got {other:?}"),
+    }
+}
+
+/// FIPS 204 § 5.2 domain separation — verifying with a different
+/// context than was used at signing time fails. Even authentic
+/// signatures only verify when sign + verify agree on the context.
+#[test]
+fn ml_dsa_65_verify_rejects_wrong_context() {
+    use pulsar_kernel::error::Error;
+
+    let kp =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0x77_u8; 32])).expect("keypair should succeed");
+
+    let message = b"context-binding test";
+    let signature = kp
+        .signing_key()
+        .try_sign(message, b"protocol-A")
+        .expect("sign should succeed");
+
+    match kp
+        .verification_key()
+        .verify(message, b"protocol-B", &signature)
+    {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for context mismatch; got {other:?}"),
+    }
+}
+
+/// Verifying under a wrong (unrelated) verification key fails.
+#[test]
+fn ml_dsa_65_verify_rejects_wrong_verification_key() {
+    use pulsar_kernel::error::Error;
+
+    let kp_a =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0xA1_u8; 32])).expect("kp a should succeed");
+    let kp_b =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0xB2_u8; 32])).expect("kp b should succeed");
+
+    let message = b"cross-key test";
+    let signature_a = kp_a
+        .signing_key()
+        .try_sign(message, b"")
+        .expect("sign a should succeed");
+
+    match kp_b.verification_key().verify(message, b"", &signature_a) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for wrong key; got {other:?}"),
+    }
+}
+
+/// Signing rejects context strings exceeding the FIPS 204 § 5.2
+/// 255-byte maximum.
+#[test]
+fn ml_dsa_65_sign_rejects_oversize_context() {
+    use pulsar_kernel::error::Error;
+
+    let kp =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0x11_u8; 32])).expect("keypair should succeed");
+
+    let oversize = vec![0_u8; 256];
+    match kp.signing_key().try_sign(b"any message", &oversize) {
+        Err(Error::InputTooLong {
+            actual: 256,
+            max: 255,
+        }) => {} // expected
+        other => panic!("expected InputTooLong; got {other:?}"),
+    }
+}
+
+/// Verifying rejects context strings exceeding the FIPS 204 § 5.2
+/// 255-byte maximum.
+#[test]
+fn ml_dsa_65_verify_rejects_oversize_context() {
+    use pulsar_kernel::error::Error;
+
+    let kp =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0x22_u8; 32])).expect("keypair should succeed");
+    let signature = kp
+        .signing_key()
+        .try_sign(b"msg", b"")
+        .expect("sign should succeed");
+
+    let oversize = vec![0_u8; 256];
+    match kp.verification_key().verify(b"msg", &oversize, &signature) {
+        Err(Error::InputTooLong {
+            actual: 256,
+            max: 255,
+        }) => {} // expected
+        other => panic!("expected InputTooLong; got {other:?}"),
+    }
+}
+
+/// Length-validation paths surface the right `Error::InvalidKeyLength`.
+#[test]
+fn ml_dsa_65_length_validation_errors() {
+    use pulsar_kernel::error::Error;
+
+    // Wrong-length keygen seed (31/33 vs 32)
+    let too_short = seed_box(&[0_u8; 31]);
+    match MlDsa65KeyPair::try_from_seed(&too_short) {
+        Err(Error::InvalidKeyLength {
+            expected: 32,
+            actual: 31,
+        }) => {}
+        other => panic!("expected InvalidKeyLength {{ 32, 31 }}; got {other:?}"),
+    }
+
+    // Wrong-length signing key (4031 vs 4032)
+    let bad_sk = seed_box(&[0_u8; 4031]);
+    match MlDsa65SigningKey::from_bytes(bad_sk) {
+        Err(Error::InvalidKeyLength {
+            expected: 4032,
+            actual: 4031,
+        }) => {}
+        other => panic!("expected InvalidKeyLength {{ 4032, 4031 }}; got {other:?}"),
+    }
+
+    // Wrong-length signing randomness (31 vs 32)
+    let kp = MlDsa65KeyPair::try_from_seed(&seed_box(&[0_u8; 32])).expect("keypair should succeed");
+    let bad_seed = seed_box(&[0_u8; 31]);
+    match kp.signing_key().try_sign_with_seed(b"msg", b"", &bad_seed) {
+        Err(Error::InvalidKeyLength {
+            expected: 32,
+            actual: 31,
+        }) => {}
+        other => panic!("expected InvalidKeyLength; got {other:?}"),
+    }
+}
+
+/// `Debug` impls do not leak signing-key bytes.
+#[test]
+fn ml_dsa_65_debug_redacts_signing_key() {
+    let kp =
+        MlDsa65KeyPair::try_from_seed(&seed_box(&[0xAB_u8; 32])).expect("keypair should succeed");
+
+    let signing_debug = format!("{:?}", kp.signing_key());
+    assert!(signing_debug.contains("MlDsa65SigningKey"));
+    assert!(
+        signing_debug.contains(".."),
+        "signing-key Debug must use finish_non_exhaustive, got: {signing_debug}",
+    );
+
+    let vk_debug = format!("{:?}", kp.verification_key());
+    assert!(vk_debug.contains("MlDsa65VerificationKey"));
+    assert!(vk_debug.contains("bytes"));
+}

--- a/crates/pulsar-kernel/tests/ml_dsa_property.rs
+++ b/crates/pulsar-kernel/tests/ml_dsa_property.rs
@@ -1,0 +1,179 @@
+//! Property tests for `pulsar_kernel::crypto::ml_dsa` (ML-DSA-65).
+//!
+//! Per plan Section XVII.19 testing convention. Properties cover the
+//! security-critical ML-DSA-65 invariants:
+//!
+//! - Sign/verify round-trip across random `(keygen_seed, signing_seed,
+//!   message)` triples
+//! - Distinct keypair-generation seeds yield distinct verification
+//!   keys (probabilistic — collision on 1 952-byte keys is bounded
+//!   by 2⁻¹⁵⁰⁰⁰ish)
+//! - Distinct signing seeds yield distinct signatures (the signing
+//!   randomness drives FIPS 204's rejection-sampling loop, so
+//!   different seeds produce different signatures)
+//! - Verification rejects tampered messages → `SignatureVerifyFailed`
+//! - Verification rejects wrong verification keys
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use proptest::prelude::*;
+use pulsar_kernel::crypto::ml_dsa::MlDsa65KeyPair;
+use pulsar_kernel::error::Error;
+use secrecy::SecretBox;
+
+/// Strategy producing a 32-byte keypair-generation seed.
+fn keygen_seed() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 32..=32)
+}
+
+/// Strategy producing a 32-byte signing randomness seed.
+fn signing_seed() -> impl Strategy<Value = Vec<u8>> {
+    proptest::collection::vec(any::<u8>(), 32..=32)
+}
+
+fn make_seed(bytes: Vec<u8>) -> SecretBox<[u8]> {
+    SecretBox::new(bytes.into_boxed_slice())
+}
+
+proptest::proptest! {
+    #![proptest_config(ProptestConfig {
+        // ML-DSA-65 keygen + sign + verify each cost ~100s of µs;
+        // keep cases modest to stay under the test-suite latency
+        // budget. Per-case ≈ 300 µs × 32 cases × 5 properties ≈ 50 ms.
+        cases: 32,
+        ..ProptestConfig::default()
+    })]
+
+    /// Sign/verify round-trip recovers `Ok(())` for any
+    /// `(keygen_seed, signing_seed, message)` triple. The fundamental
+    /// ML-DSA correctness property (FIPS 204 § 5).
+    #[test]
+    fn sign_verify_round_trip(
+        keygen in keygen_seed(),
+        signing in signing_seed(),
+        message in proptest::collection::vec(any::<u8>(), 0..512),
+    ) {
+        let kp = MlDsa65KeyPair::try_from_seed(&make_seed(keygen))
+            .expect("keypair should succeed");
+        let sig = kp.signing_key()
+            .try_sign_with_seed(&message, b"", &make_seed(signing))
+            .expect("sign should succeed");
+        kp.verification_key()
+            .verify(&message, b"", &sig)
+            .expect("authentic signature must verify");
+    }
+
+    /// Distinct keypair-generation seeds yield distinct verification
+    /// keys. Probabilistic — collision on 1 952-byte keys is bounded
+    /// by 2⁻¹⁵⁰⁰⁰ish, effectively zero across any test budget.
+    #[test]
+    fn distinct_keygen_seeds_yield_distinct_verification_keys(
+        seed_a in keygen_seed(),
+        seed_b in keygen_seed(),
+    ) {
+        proptest::prop_assume!(seed_a != seed_b);
+
+        let kp_a = MlDsa65KeyPair::try_from_seed(&make_seed(seed_a))
+            .expect("kp a should succeed");
+        let kp_b = MlDsa65KeyPair::try_from_seed(&make_seed(seed_b))
+            .expect("kp b should succeed");
+
+        proptest::prop_assert_ne!(
+            kp_a.verification_key().as_bytes().as_slice(),
+            kp_b.verification_key().as_bytes().as_slice(),
+            "distinct seeds must derive distinct verification keys",
+        );
+    }
+
+    /// Distinct signing seeds yield distinct signatures under the
+    /// same `(signing_key, message, context)`. ML-DSA's signing
+    /// operation is randomised by default (FIPS 204 § 5.4) so
+    /// different signing seeds drive the rejection-sampling loop to
+    /// different commitments.
+    #[test]
+    fn distinct_signing_seeds_yield_distinct_signatures(
+        keygen in keygen_seed(),
+        signing_a in signing_seed(),
+        signing_b in signing_seed(),
+        message in proptest::collection::vec(any::<u8>(), 1..256),
+    ) {
+        proptest::prop_assume!(signing_a != signing_b);
+
+        let kp = MlDsa65KeyPair::try_from_seed(&make_seed(keygen))
+            .expect("kp should succeed");
+
+        let sig_a = kp.signing_key()
+            .try_sign_with_seed(&message, b"", &make_seed(signing_a))
+            .expect("sign a should succeed");
+        let sig_b = kp.signing_key()
+            .try_sign_with_seed(&message, b"", &make_seed(signing_b))
+            .expect("sign b should succeed");
+
+        proptest::prop_assert_ne!(
+            sig_a.as_bytes().as_slice(),
+            sig_b.as_bytes().as_slice(),
+            "distinct signing seeds must produce distinct signatures",
+        );
+    }
+
+    /// Verification rejects tampered messages — single-bit message
+    /// flip → `SignatureVerifyFailed`.
+    #[test]
+    fn verify_rejects_tampered_message(
+        keygen in keygen_seed(),
+        signing in signing_seed(),
+        message in proptest::collection::vec(any::<u8>(), 1..256),
+        flip_byte_idx in 0_usize..256,
+        flip_bit_idx in 0_u8..8,
+    ) {
+        let kp = MlDsa65KeyPair::try_from_seed(&make_seed(keygen))
+            .expect("kp should succeed");
+        let sig = kp.signing_key()
+            .try_sign_with_seed(&message, b"", &make_seed(signing))
+            .expect("sign should succeed");
+
+        let mut tampered = message;
+        let actual_idx = flip_byte_idx % tampered.len();
+        tampered[actual_idx] ^= 1_u8 << flip_bit_idx;
+
+        match kp.verification_key().verify(&tampered, b"", &sig) {
+            Err(Error::SignatureVerifyFailed) => {} // expected
+            other => proptest::prop_assert!(
+                false,
+                "verify of tampered message must fail; got {other:?}",
+            ),
+        }
+    }
+
+    /// Verification rejects signatures produced by a different
+    /// signing key. Probabilistic — for random keypairs the chance
+    /// that key A's signature verifies under key B's verification
+    /// key is bounded by 2⁻λ where λ is the security parameter
+    /// (≈ 192 bits for ML-DSA-65).
+    #[test]
+    fn verify_rejects_wrong_verification_key(
+        seed_a in keygen_seed(),
+        seed_b in keygen_seed(),
+        signing in signing_seed(),
+        message in proptest::collection::vec(any::<u8>(), 0..256),
+    ) {
+        proptest::prop_assume!(seed_a != seed_b);
+
+        let kp_a = MlDsa65KeyPair::try_from_seed(&make_seed(seed_a))
+            .expect("kp a should succeed");
+        let kp_b = MlDsa65KeyPair::try_from_seed(&make_seed(seed_b))
+            .expect("kp b should succeed");
+
+        let sig_a = kp_a.signing_key()
+            .try_sign_with_seed(&message, b"", &make_seed(signing))
+            .expect("sign a should succeed");
+
+        match kp_b.verification_key().verify(&message, b"", &sig_a) {
+            Err(Error::SignatureVerifyFailed) => {} // expected
+            other => proptest::prop_assert!(
+                false,
+                "verify under wrong key must fail; got {other:?}",
+            ),
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Second sub-phase of Phase 1.1.C (post-quantum safe wrappers per Decision 2.60). Lands the FIPS 204 ML-DSA-65 digital-signature primitive sourced from `libcrux-ml-dsa 0.0.6` (Cryspen Rust-native, hax + F* verified). NIST security category 3 ≈ AES-192. Together with Phase 1.1.C.1 (ML-KEM-768) this covers NIST's two PQC standards (FIPS 203 KEM + FIPS 204 signature). Phase 1.1.C.3 will combine ML-DSA-65 with Ed25519 to form the Ed25519+ML-DSA-65 hybrid signature per Decision 2.58.

## Surfaces landed

- **`pulsar-kernel::crypto::ml_dsa`** — `MlDsa65KeyPair` (`try_generate` / `try_from_seed`), `MlDsa65SigningKey` (`from_bytes` / `try_sign*`), `MlDsa65VerificationKey` (`from_bytes` / `verify`), `MlDsa65Signature`. Sizes (4032 / 1952 / 3309 / 32 / 32 / 255) re-exposed as `sizes::*` constants.
- **FIPS 204 § 5.2 domain-separation context** — `sign` / `verify` accept `&[u8]` context (≤ 255 bytes); mismatched contexts at sign vs verify → `SignatureVerifyFailed`; oversize contexts → `InputTooLong { actual, max: 255 }`.
- **One new `Error` variant**: `SigningFailed` (libcrux rejection-sampling overflow — fatal-but-transient).

## Key-material handling

- Signing keys store the 4032-byte private key in `SecretBox<[u8]>` (zeroize-on-drop) per Pulsar convention.
- libcrux's `MLDSA65SigningKey` materialised transiently per-call via `Zeroizing<[u8; 4032]>` stack buffer.
- All stack-side seed copies wrapped in `Zeroizing`.
- Verification keys + signatures unwrapped (non-secret per the digital-signature threat model).
- `MlDsa65SigningKey::from_bytes` consumes input `SecretBox` (canonical consume-pattern).

## Tests

17 new tests across 2 integration test files:

- `ml_dsa_kat.rs` — 12 tests: sizes / round-trip / determinism (keypair + signing) / tamper rejection (message + signature) / FIPS 204 § 5.2 context mismatch / wrong-key rejection / oversize context / length validation / Debug redaction
- `ml_dsa_property.rs` — 5 properties (32 cases each — ML-DSA ops cost 100s of µs): round-trip / distinct keygen seeds → distinct keys / distinct signing seeds → distinct signatures / tampered message rejection / wrong-key rejection

## Quality gates

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p pulsar-kernel --all-targets -- -D warnings` ✓
- `cargo nextest run -p pulsar-kernel` — **164/164 PASS** (+17 from this phase)
- `cargo test -p pulsar-kernel --doc` ✓

## Test plan

- [x] `cargo nextest run -p pulsar-kernel`
- [x] `cargo clippy -p pulsar-kernel --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] GPG-signed commit (`F779A214...3D12DF7`)
- [ ] `/review` on this PR
- [ ] `/security-review` on this PR