### PR TITLE
Sprint 1.1.C.3 — hybrid X25519+ML-KEM-768 KEM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,43 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Sprint 1.1 — kernel crypto (Phase 1.1.C.2: ML-DSA-65 safe wrapper + KATs, in progress)
+### Sprint 1.1 — kernel crypto (Phase 1.1.C.3: hybrid X25519+ML-KEM-768 KEM, in progress)
+
+Third sub-phase of Phase 1.1.C. Lands `pulsar-kernel::crypto::hybrid_kem` — the **hybrid X25519+ML-KEM-768 key-encapsulation mechanism** per Decision 2.58 (every Pulsar protocol that uses key encapsulation runs both KEMs in parallel and combines the shared secrets via HKDF-SHA-256). Defence-in-depth posture: a future quantum adversary cannot break the ML-KEM-768 share, and a future structural attack against ML-KEM-768 leaves the X25519 share at 128-bit-equivalent classical security. The two schemes share neither hardness assumption nor implementation surface. Phase 1.1.C.4 will land the symmetric Ed25519+ML-DSA-65 hybrid signature.
+
+* **`pulsar-kernel::crypto::hybrid_kem`** — typed safe wrappers orchestrating the X25519 + ML-KEM-768 primitives shipped by Phase 1.1.B.3 and Phase 1.1.C.1. `HybridKemKeyPair::try_generate()` independently generates an X25519 keypair (32-byte CSPRNG scalar) and an ML-KEM-768 keypair (64-byte CSPRNG seed) — the two share no entropy. `HybridKemPublicKey::try_encapsulate()` generates an ephemeral X25519 keypair, computes `ss_x25519 = eph_sk.dh(peer_x25519)` + runs `ML-KEM-768::encapsulate(peer_mlkem)`, then combines via HKDF-SHA-256 (salt = `pulsar-hybrid-kem-x25519-mlkem768-v1`, IKM = `ss_x25519 || ss_mlkem`). `HybridKemPrivateKey::try_decapsulate(&ct)` is symmetric. `validate()` on the public key delegates to `MlKem768PublicKey::validate` (FIPS 203 § 7.2); the X25519 share is validated lazily at encapsulation time via HACL\*'s small-order rejection.
+* **Wire format** — IETF X25519MLKEM768 codepoint convention: `pk_x25519 || pk_mlkem` (32 + 1 184 = 1 216 bytes), ciphertext `eph_pk_x25519 || ct_mlkem` (32 + 1 088 = 1 120 bytes). `to_bytes` / `from_bytes` round-trip verified by tests. Wire-format private-key length 2 432 bytes (32 + 2 400) — though the hybrid private key is held in memory as `(X25519PrivateKey, MlKem768PrivateKey)` rather than a serialized buffer.
+* **HKDF combiner (Decision 2.58)** — `HKDF-SHA-256(salt = pulsar-hybrid-kem-x25519-mlkem768-v1, IKM = ss_x25519 || ss_mlkem, info = "", length = 32)`. The salt label provides domain separation against any other Pulsar HKDF use of the same IKM material. The combiner is structurally HKDF-Extract followed by HKDF-Expand to 32 bytes (calls into the existing `crypto::hkdf::hkdf` convenience helper).
+* **Constituent-primitive zeroization** — the hybrid private key holds an `X25519PrivateKey` (SecretBox-wrapped 32-byte scalar) alongside an `MlKem768PrivateKey` (SecretBox-wrapped 2 400-byte private key). Both inherit the canonical Pulsar zeroize-on-drop posture from Phase 1.1.B.3 / Phase 1.1.C.1 — no new private-key storage introduced.
+* **`X25519PrivateKey::try_generate()`** — added in this phase to support hybrid-KEM ephemeral keypair generation. Draws 32 bytes via `crate::crypto::rng::try_random_bytes` and constructs via `from_bytes`. Same convenience API also added to `Ed25519PrivateKey::try_generate()` for the upcoming Phase 1.1.C.4 hybrid signature.
+* **Module re-exports** in `pulsar-kernel::crypto::mod` and `pulsar-kernel::prelude`: `HybridKemKeyPair`, `HybridKemPublicKey`, `HybridKemPrivateKey`, `HybridKemCiphertext`. The `sizes` sub-module is reachable via `pulsar_kernel::crypto::hybrid_kem::sizes`.
+
+**Tests** (14 new tests across two integration test files):
+
+* **`tests/hybrid_kem_kat.rs`** (10 tests):
+  - sizes match IETF X25519MLKEM768 codepoint (1216 / 2432 / 1120 / 32) — pinned via constants
+  - encap/decap round-trip — encapsulator's combined shared secret equals decapsulator's combined shared secret
+  - public-key wire format round-trip (`to_bytes` ↔ `from_bytes`) — preserves both X25519 and ML-KEM shares byte-identically
+  - ciphertext wire format round-trip — recovered ciphertext decapsulates to identical shared secret
+  - distinct hybrid keypairs yield distinct public keys (probabilistic)
+  - `validate()` accepts a fresh hybrid public key (delegates to ML-KEM § 7.2 modulus check)
+  - tampered X25519 ephemeral share (replaced with all-zeros small-order point) → `InvalidPublicKey` from HACL\*'s F\* postcondition rejection
+  - tampered ML-KEM share (single-bit flip) → divergent shared secret per FIPS 203 § 7.3 implicit rejection (decap doesn't error, just produces uncorrelated output)
+  - tampered X25519 share (non-small-order single-bit flip) → divergent shared secret (validates that the HKDF combiner actually mixes the X25519 share — a wrapper bug that ignored `ss_x25519` would produce identical output despite tampering)
+  - `Debug` redaction on hybrid private key (`finish_non_exhaustive`)
+* **`tests/hybrid_kem_property.rs`** (4 properties using `proptest`, 32 cases each — hybrid ops cost ~250 µs):
+  - encap/decap round-trip across CSPRNG-driven keypairs
+  - distinct keypairs yield distinct public keys
+  - distinct encap calls under same public key yield distinct ciphertexts (both X25519 ephemeral and ML-KEM seed are fresh per call)
+  - wire-format `to_bytes` / `from_bytes` is a perfect round-trip preserving KEM correctness
+
+Quality gates verified locally:
+  - cargo fmt --all -- --check ✓
+  - cargo clippy -p pulsar-kernel --all-targets -- -D warnings ✓
+  - cargo nextest run -p pulsar-kernel (178/178 PASS, +14 from this phase) ✓
+  - cargo test -p pulsar-kernel --doc ✓
+
+### Sprint 1.1 — kernel crypto (Phase 1.1.C.2: ML-DSA-65 safe wrapper + KATs — merged 2026-04-28 as `60521c16`)
 
 Second sub-phase of Phase 1.1.C (post-quantum safe wrappers per Decision 2.60). Lands `pulsar-kernel::crypto::ml_dsa` — the FIPS 204 ML-DSA-65 digital-signature primitive sourced from `libcrux-ml-dsa 0.0.6` (Cryspen Rust-native, hax + F\* verified). NIST security category 3 ≈ AES-192. Pairs with Phase 1.1.C.1's ML-KEM-768; together they cover NIST's two PQC standards (FIPS 203 KEM + FIPS 204 signature). Phase 1.1.C.3 will combine ML-DSA-65 with Ed25519 to form the Ed25519+ML-DSA-65 hybrid signature per Decision 2.58.
 

--- a/crates/pulsar-kernel/src/crypto/hybrid_kem.rs
+++ b/crates/pulsar-kernel/src/crypto/hybrid_kem.rs
@@ -1,0 +1,455 @@
+//! Hybrid post-quantum + classical key-encapsulation mechanism.
+//!
+//! Per Decision 2.58 hybrid PQC posture from Sprint 1.1, every protocol
+//! that uses key encapsulation runs **X25519 + ML-KEM-768 in parallel**
+//! and combines the resulting shared secrets via HKDF-SHA-256. This
+//! sub-phase ships the safe Rust wrapper that orchestrates the two
+//! constituent primitives (security-reviewed in Phase 1.1.B.3 for
+//! X25519 and Phase 1.1.C.1 for ML-KEM-768).
+//!
+//! # Why hybrid KEM
+//!
+//! - **Quantum resistance** — ML-KEM-768 is FIPS 203's NIST-PQC KEM.
+//!   A future quantum adversary cannot break the ML-KEM-768 share.
+//! - **Classical fallback** — X25519 is RFC 7748's elliptic-curve
+//!   Diffie-Hellman with two decades of cryptanalytic scrutiny. If a
+//!   structural attack is discovered against ML-KEM-768 (the lattice-
+//!   assumption analogue of "P = NP for SVP"), the classical share
+//!   still provides 128-bit-equivalent security.
+//! - **Defence in depth via independent primitives** — the two
+//!   schemes share neither hardness assumption nor implementation
+//!   surface. A break against one does not propagate to the other.
+//!
+//! Reference deployments: Cloudflare PQ-Hybrid (Cloudflare TLS), Google
+//! Chrome PQ-TLS, Apple iMessage PQ3, IETF
+//! draft-ietf-tls-hybrid-design.
+//!
+//! # Combiner
+//!
+//! Per Decision 2.58, the shared secrets are combined via HKDF-SHA-256:
+//!
+//! ```text
+//! IKM = ss_x25519 || ss_mlkem            // 32 + 32 = 64 bytes
+//! salt = "pulsar-hybrid-kem-x25519-mlkem768-v1"
+//! info = ""
+//! shared_secret = HKDF-SHA-256(salt, IKM, info, 32)
+//! ```
+//!
+//! The salt label provides domain separation against any other Pulsar
+//! HKDF use of the same IKM. The combiner is structurally an HKDF-Extract
+//! followed by HKDF-Expand to 32 bytes (matching the [`crate::crypto::hkdf::hkdf`]
+//! convenience helper).
+//!
+//! # Wire format
+//!
+//! - **Public key** = `pk_x25519 || pk_mlkem`              (32  + 1 184 = 1 216 bytes)
+//! - **Private key** = stored separately as `(X25519PrivateKey, MlKem768PrivateKey)`
+//!   — the wire format for serialization is `sk_x25519 || sk_mlkem` (32 + 2 400 = 2 432 bytes)
+//! - **Ciphertext** = `eph_pk_x25519 || ct_mlkem`          (32  + 1 088 = 1 120 bytes)
+//!
+//! These layouts match the IETF X25519MLKEM768 codepoint convention
+//! (X25519 share first, ML-KEM-768 share second).
+//!
+//! # Encapsulation flow
+//!
+//! 1. Encapsulator generates an **ephemeral X25519 keypair** (`eph_sk`, `eph_pk`).
+//! 2. Encapsulator computes `ss_x25519 = eph_sk.dh(peer_pk_x25519)`.
+//! 3. Encapsulator runs `ML-KEM-768::encapsulate(peer_pk_mlkem) -> (ct_mlkem, ss_mlkem)`.
+//! 4. Encapsulator combines `(ss_x25519, ss_mlkem)` via HKDF.
+//! 5. Encapsulator transmits `eph_pk || ct_mlkem` to the peer.
+//!
+//! Decapsulation is symmetric: extract `eph_pk_x25519` and `ct_mlkem`
+//! from the ciphertext, do `ss_x25519 = my_sk_x25519.dh(eph_pk_x25519)`,
+//! `ss_mlkem = my_sk_mlkem.decapsulate(ct_mlkem)`, combine via HKDF.
+
+use crate::crypto::hkdf;
+use crate::crypto::hmac::HmacAlgorithm;
+use crate::crypto::kem::{X25519PrivateKey, X25519PublicKey};
+use crate::crypto::ml_kem::{
+    MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey,
+};
+use crate::error::Result;
+use secrecy::{ExposeSecret, SecretBox};
+
+/// HKDF salt used as the hybrid-KEM domain-separation label. Versioned
+/// so a future combiner change can revise the salt without colliding
+/// with stored material derived from the v1 combiner.
+const HYBRID_SALT: &[u8] = b"pulsar-hybrid-kem-x25519-mlkem768-v1";
+
+/// Hybrid X25519 + ML-KEM-768 fixed sizes — re-exposed as public
+/// constants for caller-side allocation sizing.
+pub mod sizes {
+    /// Hybrid public-key length in bytes: `32 + 1184 = 1216`.
+    pub const PUBLIC_KEY_LEN: usize = 32 + 1184;
+    /// Hybrid private-key wire-format length in bytes: `32 + 2400 = 2432`.
+    pub const PRIVATE_KEY_LEN: usize = 32 + 2400;
+    /// Hybrid ciphertext length in bytes: `32 + 1088 = 1120`.
+    pub const CIPHERTEXT_LEN: usize = 32 + 1088;
+    /// Hybrid shared-secret length in bytes (HKDF-Expand output).
+    pub const SHARED_SECRET_LEN: usize = 32;
+    /// X25519 share offset within the ciphertext (`[0..32]`).
+    pub const X25519_OFFSET: usize = 0;
+    /// X25519 share length within the ciphertext / public key.
+    pub const X25519_LEN: usize = 32;
+    /// ML-KEM-768 share offset within the public key (`[32..1216]`).
+    pub const MLKEM_PUBLIC_KEY_OFFSET: usize = 32;
+    /// ML-KEM-768 share offset within the ciphertext (`[32..1120]`).
+    pub const MLKEM_CIPHERTEXT_OFFSET: usize = 32;
+    /// ML-KEM-768 ciphertext length within the hybrid ciphertext.
+    pub const MLKEM_CIPHERTEXT_LEN: usize = 1088;
+    /// ML-KEM-768 public key length within the hybrid public key.
+    pub const MLKEM_PUBLIC_KEY_LEN: usize = 1184;
+}
+
+/// Hybrid (classical + post-quantum) KEM public key.
+///
+/// Holds an [`X25519PublicKey`] alongside an [`MlKem768PublicKey`].
+/// Encapsulation runs both KEMs in parallel and combines the
+/// resulting shared secrets per Decision 2.58.
+#[derive(Clone)]
+pub struct HybridKemPublicKey {
+    classical: X25519PublicKey,
+    pqc: MlKem768PublicKey,
+}
+
+impl core::fmt::Debug for HybridKemPublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridKemPublicKey")
+            .field("classical", &self.classical)
+            .field("pqc", &self.pqc)
+            .finish()
+    }
+}
+
+impl HybridKemPublicKey {
+    /// Hybrid public-key length in bytes (`32 + 1184 = 1216`).
+    pub const LEN: usize = sizes::PUBLIC_KEY_LEN;
+
+    /// Construct from a 1 216-byte buffer in IETF X25519MLKEM768 wire
+    /// format: `pk_x25519 || pk_mlkem`. Does NOT validate either
+    /// share — call [`validate`](Self::validate) before encapsulating
+    /// against keys received from untrusted peers.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; Self::LEN]) -> Self {
+        let mut x25519_bytes = [0_u8; 32];
+        x25519_bytes.copy_from_slice(&bytes[0..32]);
+        let classical = X25519PublicKey::from_bytes(x25519_bytes);
+
+        let mut mlkem_bytes = [0_u8; sizes::MLKEM_PUBLIC_KEY_LEN];
+        mlkem_bytes.copy_from_slice(&bytes[32..]);
+        let pqc = MlKem768PublicKey::from_bytes(mlkem_bytes);
+
+        Self { classical, pqc }
+    }
+
+    /// Construct from individual X25519 + ML-KEM-768 public keys.
+    /// Used when the caller already holds the constituent public keys
+    /// in their typed forms (e.g., from a structured key-exchange
+    /// payload).
+    #[must_use]
+    pub const fn from_parts(classical: X25519PublicKey, pqc: MlKem768PublicKey) -> Self {
+        Self { classical, pqc }
+    }
+
+    /// Return the X25519 share.
+    #[must_use]
+    pub const fn classical(&self) -> &X25519PublicKey {
+        &self.classical
+    }
+
+    /// Return the ML-KEM-768 share.
+    #[must_use]
+    pub const fn pqc(&self) -> &MlKem768PublicKey {
+        &self.pqc
+    }
+
+    /// Serialize the hybrid public key to the IETF X25519MLKEM768 wire
+    /// format: `pk_x25519 || pk_mlkem`.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; Self::LEN] {
+        let mut out = [0_u8; Self::LEN];
+        out[0..32].copy_from_slice(self.classical.as_bytes());
+        out[32..].copy_from_slice(self.pqc.as_bytes());
+        out
+    }
+
+    /// Validate the hybrid public key. Validates the ML-KEM-768 share
+    /// per FIPS 203 § 7.2 (modulus check); the X25519 share is
+    /// validated lazily at encapsulation time via HACL\*'s
+    /// small-order-rejection check inside `diffie_hellman`.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidPublicKey`] — the ML-KEM share fails its
+    ///   FIPS-203 modulus check, or the X25519 share is the
+    ///   small-order all-zeros point (caught at encapsulation time).
+    pub fn validate(&self) -> Result<()> {
+        // ML-KEM has explicit FIPS 203 § 7.2 validation.
+        self.pqc.validate()?;
+        // X25519 has no spec-mandated explicit validation step
+        // (RFC 7748 says small-order checks are at DH time, which
+        // HACL* handles via Error::InvalidPublicKey from diffie_hellman).
+        // We could probe by doing a dummy DH against a fresh ephemeral
+        // key, but that adds ~µs per call; defer to actual encap.
+        Ok(())
+    }
+
+    /// Encapsulate against this hybrid public key.
+    ///
+    /// 1. Generate an ephemeral X25519 keypair.
+    /// 2. Compute `ss_x25519 = eph_sk.dh(self.classical)`.
+    /// 3. Run `ML-KEM-768::encapsulate(self.pqc) -> (ct_mlkem, ss_mlkem)`.
+    /// 4. Combine `(ss_x25519, ss_mlkem)` via HKDF-SHA-256.
+    ///
+    /// Returns the hybrid ciphertext (`eph_pk_x25519 || ct_mlkem`)
+    /// and the 32-byte combined shared secret.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
+    ///   during ephemeral-keypair or ML-KEM seed generation.
+    /// - [`Error::InvalidPublicKey`] — the X25519 share is a
+    ///   small-order point (HACL\*'s F\* postcondition).
+    pub fn try_encapsulate(&self) -> Result<(HybridKemCiphertext, SecretBox<[u8]>)> {
+        // 1. Ephemeral X25519 keypair.
+        let ephemeral_secret = X25519PrivateKey::try_generate()?;
+        let ephemeral_public = ephemeral_secret.public_key();
+        let ss_x25519 = ephemeral_secret.diffie_hellman(&self.classical)?;
+
+        // 2. ML-KEM-768 encapsulation.
+        let (ct_mlkem, ss_mlkem) = self.pqc.try_encapsulate()?;
+
+        // 3. Combine via HKDF-SHA-256. IKM = ss_x25519 || ss_mlkem.
+        let combined_ikm = combine_ikm(ss_x25519.expose_secret(), ss_mlkem.expose_secret());
+        let shared_secret = hkdf::hkdf(
+            HmacAlgorithm::Sha256,
+            HYBRID_SALT,
+            &combined_ikm,
+            &[],
+            sizes::SHARED_SECRET_LEN,
+        )?;
+
+        Ok((
+            HybridKemCiphertext {
+                classical: ephemeral_public,
+                pqc: ct_mlkem,
+            },
+            shared_secret,
+        ))
+    }
+}
+
+/// Hybrid (classical + post-quantum) KEM private key.
+///
+/// Holds an [`X25519PrivateKey`] alongside an [`MlKem768PrivateKey`].
+/// Decapsulation runs both KEMs in parallel and combines the
+/// resulting shared secrets per Decision 2.58.
+pub struct HybridKemPrivateKey {
+    classical: X25519PrivateKey,
+    pqc: MlKem768PrivateKey,
+}
+
+impl core::fmt::Debug for HybridKemPrivateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridKemPrivateKey")
+            .field("classical", &self.classical)
+            .field("pqc", &self.pqc)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HybridKemPrivateKey {
+    /// Construct from individual X25519 + ML-KEM-768 private keys.
+    #[must_use]
+    pub const fn from_parts(classical: X25519PrivateKey, pqc: MlKem768PrivateKey) -> Self {
+        Self { classical, pqc }
+    }
+
+    /// Return the X25519 share.
+    #[must_use]
+    pub const fn classical(&self) -> &X25519PrivateKey {
+        &self.classical
+    }
+
+    /// Return the ML-KEM-768 share.
+    #[must_use]
+    pub const fn pqc(&self) -> &MlKem768PrivateKey {
+        &self.pqc
+    }
+
+    /// Decapsulate `ciphertext` under this hybrid private key. Returns
+    /// the 32-byte combined shared secret.
+    ///
+    /// 1. Compute `ss_x25519 = self.classical.dh(ciphertext.classical)`.
+    /// 2. Run `ML-KEM-768::decapsulate(ciphertext.pqc) -> ss_mlkem`.
+    /// 3. Combine `(ss_x25519, ss_mlkem)` via HKDF-SHA-256.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InvalidPublicKey`] — the X25519 ephemeral share in
+    ///   `ciphertext` is a small-order point (HACL\*'s F\*
+    ///   postcondition rejects this).
+    pub fn try_decapsulate(&self, ciphertext: &HybridKemCiphertext) -> Result<SecretBox<[u8]>> {
+        // 1. X25519 DH against the ciphertext's ephemeral share.
+        let ss_x25519 = self.classical.diffie_hellman(&ciphertext.classical)?;
+
+        // 2. ML-KEM-768 decapsulation. Note: ML-KEM decap is infallible
+        // per FIPS 203 § 7.3 implicit rejection — a tampered ML-KEM
+        // ciphertext yields a deterministic-but-uncorrelated ss_mlkem,
+        // which the HKDF combiner mixes into a useless shared secret
+        // (the legitimate peer cannot match). The protocol layer
+        // catches this via key confirmation.
+        let ss_mlkem = self.pqc.decapsulate(&ciphertext.pqc);
+
+        // 3. Combine via HKDF-SHA-256.
+        let combined_ikm = combine_ikm(ss_x25519.expose_secret(), ss_mlkem.expose_secret());
+        hkdf::hkdf(
+            HmacAlgorithm::Sha256,
+            HYBRID_SALT,
+            &combined_ikm,
+            &[],
+            sizes::SHARED_SECRET_LEN,
+        )
+    }
+}
+
+/// Hybrid KEM ciphertext (`eph_pk_x25519 || ct_mlkem`, 1 120 bytes).
+#[derive(Clone)]
+pub struct HybridKemCiphertext {
+    classical: X25519PublicKey,
+    pqc: MlKem768Ciphertext,
+}
+
+impl core::fmt::Debug for HybridKemCiphertext {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridKemCiphertext")
+            .field("classical", &self.classical)
+            .field("pqc", &self.pqc)
+            .finish()
+    }
+}
+
+impl HybridKemCiphertext {
+    /// Hybrid ciphertext length in bytes (`32 + 1088 = 1120`).
+    pub const LEN: usize = sizes::CIPHERTEXT_LEN;
+
+    /// Construct from a 1 120-byte buffer in IETF X25519MLKEM768 wire
+    /// format: `eph_pk_x25519 || ct_mlkem`.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; Self::LEN]) -> Self {
+        let mut x25519_bytes = [0_u8; 32];
+        x25519_bytes.copy_from_slice(&bytes[0..32]);
+        let classical = X25519PublicKey::from_bytes(x25519_bytes);
+
+        let mut mlkem_bytes = [0_u8; sizes::MLKEM_CIPHERTEXT_LEN];
+        mlkem_bytes.copy_from_slice(&bytes[32..]);
+        let pqc = MlKem768Ciphertext::from_bytes(mlkem_bytes);
+
+        Self { classical, pqc }
+    }
+
+    /// Construct from individual ephemeral X25519 public key + ML-KEM
+    /// ciphertext.
+    #[must_use]
+    pub const fn from_parts(classical: X25519PublicKey, pqc: MlKem768Ciphertext) -> Self {
+        Self { classical, pqc }
+    }
+
+    /// Serialize to the IETF X25519MLKEM768 wire format.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; Self::LEN] {
+        let mut out = [0_u8; Self::LEN];
+        out[0..32].copy_from_slice(self.classical.as_bytes());
+        out[32..].copy_from_slice(self.pqc.as_bytes());
+        out
+    }
+
+    /// Return the X25519 ephemeral share.
+    #[must_use]
+    pub const fn classical(&self) -> &X25519PublicKey {
+        &self.classical
+    }
+
+    /// Return the ML-KEM-768 ciphertext share.
+    #[must_use]
+    pub const fn pqc(&self) -> &MlKem768Ciphertext {
+        &self.pqc
+    }
+}
+
+/// Hybrid KEM keypair — bundles an X25519 + ML-KEM-768 keypair pair
+/// produced by a single keypair-generation flow.
+pub struct HybridKemKeyPair {
+    public_key: HybridKemPublicKey,
+    private_key: HybridKemPrivateKey,
+}
+
+impl core::fmt::Debug for HybridKemKeyPair {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridKemKeyPair")
+            .field("public_key", &self.public_key)
+            .field("private_key", &self.private_key)
+            .finish()
+    }
+}
+
+impl HybridKemKeyPair {
+    /// Generate a fresh hybrid keypair using the OS CSPRNG.
+    ///
+    /// Independently generates an X25519 keypair (32-byte random
+    /// scalar) and an ML-KEM-768 keypair (64-byte CSPRNG seed). The
+    /// two keypairs share no entropy — keypair-isolation invariant
+    /// from Decision 2.58.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
+    ///   during either constituent keypair generation.
+    pub fn try_generate() -> Result<Self> {
+        let classical_secret = X25519PrivateKey::try_generate()?;
+        let classical_public = classical_secret.public_key();
+
+        let mlkem_keypair = MlKem768KeyPair::try_generate()?;
+        let (mlkem_public, mlkem_private) = mlkem_keypair.into_parts();
+
+        Ok(Self {
+            public_key: HybridKemPublicKey {
+                classical: classical_public,
+                pqc: mlkem_public,
+            },
+            private_key: HybridKemPrivateKey {
+                classical: classical_secret,
+                pqc: mlkem_private,
+            },
+        })
+    }
+
+    /// Return a reference to the hybrid public key.
+    #[must_use]
+    pub const fn public_key(&self) -> &HybridKemPublicKey {
+        &self.public_key
+    }
+
+    /// Return a reference to the hybrid private key.
+    #[must_use]
+    pub const fn private_key(&self) -> &HybridKemPrivateKey {
+        &self.private_key
+    }
+
+    /// Decompose the keypair into its constituent public + private
+    /// keys, transferring ownership.
+    #[must_use]
+    pub fn into_parts(self) -> (HybridKemPublicKey, HybridKemPrivateKey) {
+        (self.public_key, self.private_key)
+    }
+}
+
+/// Combine two 32-byte shared secrets into a 64-byte HKDF input
+/// keying material wrapped in [`SecretBox<[u8]>`]. Order is
+/// `ss_classical || ss_pqc` per the IETF X25519MLKEM768 convention.
+fn combine_ikm(ss_classical: &[u8], ss_pqc: &[u8]) -> SecretBox<[u8]> {
+    let mut combined = Vec::with_capacity(ss_classical.len() + ss_pqc.len());
+    combined.extend_from_slice(ss_classical);
+    combined.extend_from_slice(ss_pqc);
+    SecretBox::new(combined.into_boxed_slice())
+}

--- a/crates/pulsar-kernel/src/crypto/hybrid_kem.rs
+++ b/crates/pulsar-kernel/src/crypto/hybrid_kem.rs
@@ -68,7 +68,7 @@ use crate::crypto::kem::{X25519PrivateKey, X25519PublicKey};
 use crate::crypto::ml_kem::{
     MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey,
 };
-use crate::error::Result;
+use crate::error::{Error, Result};
 use secrecy::{ExposeSecret, SecretBox};
 
 /// HKDF salt used as the hybrid-KEM domain-separation label. Versioned
@@ -173,25 +173,26 @@ impl HybridKemPublicKey {
         out
     }
 
-    /// Validate the hybrid public key. Validates the ML-KEM-768 share
-    /// per FIPS 203 § 7.2 (modulus check); the X25519 share is
-    /// validated lazily at encapsulation time via HACL\*'s
-    /// small-order-rejection check inside `diffie_hellman`.
+    /// Validate the hybrid public key.
+    ///
+    /// **Scope**: validates ONLY the ML-KEM-768 share per FIPS 203 §
+    /// 7.2 (modulus check). The X25519 share has no spec-mandated
+    /// pre-DH validation step — RFC 7748 specifies small-order
+    /// rejection at Diffie-Hellman time, which HACL\* enforces inside
+    /// [`X25519PrivateKey::diffie_hellman`] via its F\* postcondition
+    /// (returning [`Error::InvalidPublicKey`] from
+    /// [`try_encapsulate`](Self::try_encapsulate) when the X25519
+    /// share is small-order). Callers that need eager X25519
+    /// validation must probe via a dummy DH against a fresh
+    /// ephemeral key — Pulsar's wrapper deliberately defers this to
+    /// keep `validate()` free of latency-introducing dummy operations.
     ///
     /// # Errors
     ///
     /// - [`Error::InvalidPublicKey`] — the ML-KEM share fails its
-    ///   FIPS-203 modulus check, or the X25519 share is the
-    ///   small-order all-zeros point (caught at encapsulation time).
+    ///   FIPS-203 § 7.2 modulus check.
     pub fn validate(&self) -> Result<()> {
-        // ML-KEM has explicit FIPS 203 § 7.2 validation.
-        self.pqc.validate()?;
-        // X25519 has no spec-mandated explicit validation step
-        // (RFC 7748 says small-order checks are at DH time, which
-        // HACL* handles via Error::InvalidPublicKey from diffie_hellman).
-        // We could probe by doing a dummy DH against a fresh ephemeral
-        // key, but that adds ~µs per call; defer to actual encap.
-        Ok(())
+        self.pqc.validate()
     }
 
     /// Encapsulate against this hybrid public key.
@@ -207,9 +208,18 @@ impl HybridKemPublicKey {
     /// # Errors
     ///
     /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
-    ///   during ephemeral-keypair or ML-KEM seed generation.
-    /// - [`Error::InvalidPublicKey`] — the X25519 share is a
-    ///   small-order point (HACL\*'s F\* postcondition).
+    ///   during EITHER the ephemeral X25519 keypair generation (32
+    ///   bytes via [`X25519PrivateKey::try_generate`]) OR the ML-KEM
+    ///   encapsulation seed generation (32 bytes via
+    ///   [`MlKem768PublicKey::try_encapsulate`]). Both call sites
+    ///   route through [`crate::crypto::rng::try_random_into`].
+    /// - [`Error::InvalidPublicKey`] — the stored X25519 public key
+    ///   share is a small-order point that the ephemeral DH cannot
+    ///   produce a useful shared secret against (HACL\*'s F\*
+    ///   postcondition rejects small-order peers).
+    /// - [`Error::InvalidKeyLength`] — defensive check inside the
+    ///   HKDF combiner; not reachable on the happy path because the
+    ///   constituent shared secrets are spec-fixed at 32 bytes.
     pub fn try_encapsulate(&self) -> Result<(HybridKemCiphertext, SecretBox<[u8]>)> {
         // 1. Ephemeral X25519 keypair.
         let ephemeral_secret = X25519PrivateKey::try_generate()?;
@@ -220,7 +230,7 @@ impl HybridKemPublicKey {
         let (ct_mlkem, ss_mlkem) = self.pqc.try_encapsulate()?;
 
         // 3. Combine via HKDF-SHA-256. IKM = ss_x25519 || ss_mlkem.
-        let combined_ikm = combine_ikm(ss_x25519.expose_secret(), ss_mlkem.expose_secret());
+        let combined_ikm = combine_ikm(ss_x25519.expose_secret(), ss_mlkem.expose_secret())?;
         let shared_secret = hkdf::hkdf(
             HmacAlgorithm::Sha256,
             HYBRID_SALT,
@@ -289,6 +299,9 @@ impl HybridKemPrivateKey {
     /// - [`Error::InvalidPublicKey`] — the X25519 ephemeral share in
     ///   `ciphertext` is a small-order point (HACL\*'s F\*
     ///   postcondition rejects this).
+    /// - [`Error::InvalidKeyLength`] — defensive check inside the
+    ///   HKDF combiner; not reachable on the happy path because the
+    ///   constituent shared secrets are spec-fixed at 32 bytes.
     pub fn try_decapsulate(&self, ciphertext: &HybridKemCiphertext) -> Result<SecretBox<[u8]>> {
         // 1. X25519 DH against the ciphertext's ephemeral share.
         let ss_x25519 = self.classical.diffie_hellman(&ciphertext.classical)?;
@@ -302,7 +315,7 @@ impl HybridKemPrivateKey {
         let ss_mlkem = self.pqc.decapsulate(&ciphertext.pqc);
 
         // 3. Combine via HKDF-SHA-256.
-        let combined_ikm = combine_ikm(ss_x25519.expose_secret(), ss_mlkem.expose_secret());
+        let combined_ikm = combine_ikm(ss_x25519.expose_secret(), ss_mlkem.expose_secret())?;
         hkdf::hkdf(
             HmacAlgorithm::Sha256,
             HYBRID_SALT,
@@ -444,12 +457,47 @@ impl HybridKemKeyPair {
     }
 }
 
+/// Expected length of the X25519 shared-secret share fed into the
+/// hybrid combiner (RFC 7748 § 5).
+const X25519_SHARED_LEN: usize = 32;
+
+/// Expected length of the ML-KEM-768 shared-secret share fed into
+/// the hybrid combiner (FIPS 203 § 6.1).
+const MLKEM_SHARED_LEN: usize = 32;
+
 /// Combine two 32-byte shared secrets into a 64-byte HKDF input
 /// keying material wrapped in [`SecretBox<[u8]>`]. Order is
 /// `ss_classical || ss_pqc` per the IETF X25519MLKEM768 convention.
-fn combine_ikm(ss_classical: &[u8], ss_pqc: &[u8]) -> SecretBox<[u8]> {
+///
+/// Validates input lengths against the spec-fixed
+/// [`X25519_SHARED_LEN`] / [`MLKEM_SHARED_LEN`] constants — a future
+/// refactor that accidentally passes wrong-length material fails fast
+/// with [`Error::InvalidKeyLength`] instead of silently deriving a
+/// different shared secret. In normal operation both inputs always
+/// satisfy the length invariant by construction (HACL\* X25519 DH
+/// always returns 32 bytes; libcrux ML-KEM-768 decap always returns
+/// 32 bytes), so the check is defence-in-depth, not load-bearing on
+/// the happy path.
+///
+/// # Errors
+///
+/// - [`Error::InvalidKeyLength`] — `ss_classical.len() != 32` or
+///   `ss_pqc.len() != 32`.
+fn combine_ikm(ss_classical: &[u8], ss_pqc: &[u8]) -> Result<SecretBox<[u8]>> {
+    if ss_classical.len() != X25519_SHARED_LEN {
+        return Err(Error::InvalidKeyLength {
+            expected: X25519_SHARED_LEN,
+            actual: ss_classical.len(),
+        });
+    }
+    if ss_pqc.len() != MLKEM_SHARED_LEN {
+        return Err(Error::InvalidKeyLength {
+            expected: MLKEM_SHARED_LEN,
+            actual: ss_pqc.len(),
+        });
+    }
     let mut combined = Vec::with_capacity(ss_classical.len() + ss_pqc.len());
     combined.extend_from_slice(ss_classical);
     combined.extend_from_slice(ss_pqc);
-    SecretBox::new(combined.into_boxed_slice())
+    Ok(SecretBox::new(combined.into_boxed_slice()))
 }

--- a/crates/pulsar-kernel/src/crypto/kem.rs
+++ b/crates/pulsar-kernel/src/crypto/kem.rs
@@ -78,6 +78,21 @@ impl X25519PrivateKey {
         Ok(Self { secret })
     }
 
+    /// Generate a fresh X25519 private key using the OS CSPRNG.
+    ///
+    /// Draws 32 bytes via [`crate::crypto::rng::try_random_into`] and
+    /// wraps them in [`SecretBox<[u8]>`]. HACL\*'s clamping (RFC 7748
+    /// § 5) is applied internally on first use, so any 32-byte
+    /// random input is acceptable as a scalar.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error.
+    pub fn try_generate() -> Result<Self> {
+        let bytes = crate::crypto::rng::try_random_bytes(Self::SCALAR_LEN)?;
+        Self::from_bytes(SecretBox::new(bytes.into_boxed_slice()))
+    }
+
     /// Derive the public key corresponding to this private scalar.
     /// Computes `[k]G` where `k` is the clamped scalar and `G` is the
     /// Curve25519 base point (u = 9).

--- a/crates/pulsar-kernel/src/crypto/kem.rs
+++ b/crates/pulsar-kernel/src/crypto/kem.rs
@@ -80,10 +80,12 @@ impl X25519PrivateKey {
 
     /// Generate a fresh X25519 private key using the OS CSPRNG.
     ///
-    /// Draws 32 bytes via [`crate::crypto::rng::try_random_into`] and
-    /// wraps them in [`SecretBox<[u8]>`]. HACL\*'s clamping (RFC 7748
-    /// § 5) is applied internally on first use, so any 32-byte
-    /// random input is acceptable as a scalar.
+    /// Draws 32 bytes via [`crate::crypto::rng::try_random_bytes`]
+    /// (a heap-allocating `Vec<u8>` that becomes the
+    /// [`SecretBox<[u8]>`] backing storage in a single allocation —
+    /// no intermediate stack copy). HACL\*'s clamping (RFC 7748 § 5)
+    /// is applied internally on first use, so any 32-byte random
+    /// input is acceptable as a scalar.
     ///
     /// # Errors
     ///

--- a/crates/pulsar-kernel/src/crypto/mod.rs
+++ b/crates/pulsar-kernel/src/crypto/mod.rs
@@ -63,6 +63,7 @@ pub mod argon2;
 pub mod hash;
 pub mod hkdf;
 pub mod hmac;
+pub mod hybrid_kem;
 pub mod kem;
 pub mod ml_dsa;
 pub mod ml_kem;
@@ -75,6 +76,9 @@ pub use hash::{HashAlgorithm, Hasher, blake2b512, blake2s256};
 pub use hash::{sha3_256, sha3_384, sha3_512};
 pub use hash::{sha256, sha384, sha512};
 pub use hmac::{HmacAlgorithm, HmacKey};
+pub use hybrid_kem::{
+    HybridKemCiphertext, HybridKemKeyPair, HybridKemPrivateKey, HybridKemPublicKey,
+};
 pub use kem::{X25519PrivateKey, X25519PublicKey};
 pub use ml_dsa::{MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey};
 pub use ml_kem::{MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey};

--- a/crates/pulsar-kernel/src/crypto/signature.rs
+++ b/crates/pulsar-kernel/src/crypto/signature.rs
@@ -77,6 +77,22 @@ impl Ed25519PrivateKey {
         Ok(Self { seed })
     }
 
+    /// Generate a fresh Ed25519 private key using the OS CSPRNG.
+    ///
+    /// Draws 32 bytes via [`crate::crypto::rng::try_random_into`] and
+    /// wraps them in [`SecretBox<[u8]>`]. The seed is hashed via
+    /// SHA-512 internally on first use to derive the actual signing
+    /// scalar (RFC 8032 § 5.1.5), so any 32-byte random input is
+    /// acceptable.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error.
+    pub fn try_generate() -> Result<Self> {
+        let bytes = crate::crypto::rng::try_random_bytes(Self::SEED_LEN)?;
+        Self::from_bytes(SecretBox::new(bytes.into_boxed_slice()))
+    }
+
     /// Derive the public key corresponding to this private seed.
     /// Computes the elliptic-curve scalar multiplication
     /// `[s]B` where `s` is the SHA-512-derived scalar from the seed

--- a/crates/pulsar-kernel/src/crypto/signature.rs
+++ b/crates/pulsar-kernel/src/crypto/signature.rs
@@ -79,11 +79,12 @@ impl Ed25519PrivateKey {
 
     /// Generate a fresh Ed25519 private key using the OS CSPRNG.
     ///
-    /// Draws 32 bytes via [`crate::crypto::rng::try_random_into`] and
-    /// wraps them in [`SecretBox<[u8]>`]. The seed is hashed via
-    /// SHA-512 internally on first use to derive the actual signing
-    /// scalar (RFC 8032 § 5.1.5), so any 32-byte random input is
-    /// acceptable.
+    /// Draws 32 bytes via [`crate::crypto::rng::try_random_bytes`]
+    /// (a heap-allocating `Vec<u8>` that becomes the
+    /// [`SecretBox<[u8]>`] backing storage in a single allocation —
+    /// no intermediate stack copy). The seed is hashed via SHA-512
+    /// internally on first use to derive the actual signing scalar
+    /// (RFC 8032 § 5.1.5), so any 32-byte random input is acceptable.
     ///
     /// # Errors
     ///

--- a/crates/pulsar-kernel/src/prelude.rs
+++ b/crates/pulsar-kernel/src/prelude.rs
@@ -8,8 +8,8 @@
 pub use crate::crypto::{
     AeadAlgorithm, AeadKey, Argon2idParams, Argon2idVerifyLimits, Ed25519PrivateKey,
     Ed25519PublicKey, Ed25519Signature, HashAlgorithm, Hasher, HmacAlgorithm, HmacKey,
-    MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey,
-    MlKem768Ciphertext, MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey, X25519PrivateKey,
-    X25519PublicKey,
+    HybridKemCiphertext, HybridKemKeyPair, HybridKemPrivateKey, HybridKemPublicKey, MlDsa65KeyPair,
+    MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey, MlKem768Ciphertext,
+    MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey, X25519PrivateKey, X25519PublicKey,
 };
 pub use crate::error::{Error, Result};

--- a/crates/pulsar-kernel/tests/hybrid_kem_kat.rs
+++ b/crates/pulsar-kernel/tests/hybrid_kem_kat.rs
@@ -152,7 +152,6 @@ fn hybrid_kem_validate_accepts_fresh_public_key() {
 #[test]
 fn hybrid_kem_decap_rejects_small_order_x25519_in_ciphertext() {
     use pulsar_kernel::crypto::kem::X25519PublicKey;
-    use pulsar_kernel::crypto::ml_kem::MlKem768Ciphertext;
     use pulsar_kernel::error::Error;
 
     let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
@@ -169,11 +168,8 @@ fn hybrid_kem_decap_rejects_small_order_x25519_in_ciphertext() {
 
     match kp.private_key().try_decapsulate(&tampered) {
         Err(Error::InvalidPublicKey) => {} // expected
-        other => panic!("expected InvalidPublicKey for small-order X25519 share; got {other:?}",),
+        other => panic!("expected InvalidPublicKey for small-order X25519 share; got {other:?}"),
     }
-
-    // For coverage: drop unused import warnings on MlKem768Ciphertext (used implicitly)
-    let _: Option<MlKem768Ciphertext> = None;
 }
 
 /// Tampering the ML-KEM share in the ciphertext yields a divergent
@@ -242,9 +238,9 @@ fn hybrid_kem_decap_diverges_on_tampered_x25519_share() {
     );
 }
 
-/// `Debug` impls do not leak signing-key bytes. Hybrid private key
+/// `Debug` impls do not leak private-key bytes. Hybrid private key
 /// uses `finish_non_exhaustive`; constituent shares delegate to their
-/// own redacting Debug impls.
+/// own redacting Debug impls (X25519 + ML-KEM private keys).
 #[test]
 fn hybrid_kem_debug_redacts_private_key() {
     let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");

--- a/crates/pulsar-kernel/tests/hybrid_kem_kat.rs
+++ b/crates/pulsar-kernel/tests/hybrid_kem_kat.rs
@@ -1,0 +1,257 @@
+//! Known-answer + integration tests for `pulsar_kernel::crypto::hybrid_kem`.
+//!
+//! Hybrid X25519+ML-KEM-768 KEM per Decision 2.58. Cryptographic
+//! correctness of the constituent primitives is asserted by the
+//! upstream test suites (HACL\* for X25519, libcrux for ML-KEM-768);
+//! these wrapper-level tests focus on the hybrid orchestration:
+//!
+//! - Sizes match the IETF X25519MLKEM768 codepoint (1216 / 1120 / 32)
+//! - Encap/decap round-trip — encapsulator's combined shared secret
+//!   equals decapsulator's combined shared secret
+//! - Wire-format serialization round-trip (`to_bytes` ↔ `from_bytes`)
+//!   for public keys + ciphertexts
+//! - Constituent primitives are independently zeroized — the X25519
+//!   private key and ML-KEM private key share no entropy
+//! - HKDF combiner correctly mixes both shares — corrupting either
+//!   constituent shared secret yields a different combined output
+//!   (validates that a future X25519-only or ML-KEM-only break does
+//!   NOT propagate to the hybrid)
+//! - Tampered X25519 share in ciphertext fails decap (small-order
+//!   rejection from HACL\*)
+//! - Tampered ML-KEM share in ciphertext yields a divergent shared
+//!   secret (FIPS 203 § 7.3 implicit rejection)
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pulsar_kernel::crypto::hybrid_kem::{
+    HybridKemCiphertext, HybridKemKeyPair, HybridKemPublicKey, sizes,
+};
+use secrecy::ExposeSecret;
+
+/// Sizes match the IETF X25519MLKEM768 codepoint convention.
+#[test]
+fn hybrid_kem_sizes_match_ietf_codepoint() {
+    assert_eq!(sizes::PUBLIC_KEY_LEN, 1216);
+    assert_eq!(sizes::PRIVATE_KEY_LEN, 2432);
+    assert_eq!(sizes::CIPHERTEXT_LEN, 1120);
+    assert_eq!(sizes::SHARED_SECRET_LEN, 32);
+    assert_eq!(sizes::X25519_LEN, 32);
+    assert_eq!(sizes::MLKEM_PUBLIC_KEY_LEN, 1184);
+    assert_eq!(sizes::MLKEM_CIPHERTEXT_LEN, 1088);
+
+    assert_eq!(HybridKemPublicKey::LEN, 1216);
+    assert_eq!(HybridKemCiphertext::LEN, 1120);
+}
+
+/// Hybrid encap/decap round-trip — encapsulator's combined shared
+/// secret equals decapsulator's combined shared secret. Drives the
+/// full HKDF-SHA-256 combiner over both X25519 + ML-KEM-768 shares.
+#[test]
+fn hybrid_kem_encap_decap_round_trip() {
+    let kp = HybridKemKeyPair::try_generate().expect("hybrid keypair should succeed");
+
+    let (ciphertext, encap_secret) = kp
+        .public_key()
+        .try_encapsulate()
+        .expect("encapsulate should succeed");
+
+    let decap_secret = kp
+        .private_key()
+        .try_decapsulate(&ciphertext)
+        .expect("decapsulate should succeed");
+
+    assert_eq!(
+        encap_secret.expose_secret(),
+        decap_secret.expose_secret(),
+        "hybrid encap shared secret must equal hybrid decap shared secret",
+    );
+    assert_eq!(encap_secret.expose_secret().len(), 32);
+}
+
+/// Public-key wire format round-trip — `to_bytes` followed by
+/// `from_bytes` recovers the same public key (byte-equal in both
+/// constituent halves).
+#[test]
+fn hybrid_kem_public_key_serialization_round_trip() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    let original_pk = kp.public_key().clone();
+
+    let serialized = original_pk.to_bytes();
+    assert_eq!(serialized.len(), 1216);
+    let recovered = HybridKemPublicKey::from_bytes(&serialized);
+
+    assert_eq!(
+        original_pk.classical().as_bytes(),
+        recovered.classical().as_bytes(),
+        "X25519 share must round-trip identically",
+    );
+    assert_eq!(
+        original_pk.pqc().as_bytes(),
+        recovered.pqc().as_bytes(),
+        "ML-KEM share must round-trip identically",
+    );
+}
+
+/// Ciphertext wire format round-trip.
+#[test]
+fn hybrid_kem_ciphertext_serialization_round_trip() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    let (original_ct, _ss) = kp
+        .public_key()
+        .try_encapsulate()
+        .expect("encapsulate should succeed");
+
+    let serialized = original_ct.to_bytes();
+    assert_eq!(serialized.len(), 1120);
+    let recovered = HybridKemCiphertext::from_bytes(&serialized);
+
+    // Round-tripped ciphertext must decapsulate to the same shared
+    // secret as the original.
+    let ss_original = kp
+        .private_key()
+        .try_decapsulate(&original_ct)
+        .expect("decap original should succeed");
+    let ss_recovered = kp
+        .private_key()
+        .try_decapsulate(&recovered)
+        .expect("decap recovered should succeed");
+    assert_eq!(
+        ss_original.expose_secret(),
+        ss_recovered.expose_secret(),
+        "wire-format round-trip must preserve decapsulation output",
+    );
+}
+
+/// Distinct hybrid keypairs yield distinct public keys (probabilistic).
+#[test]
+fn hybrid_kem_distinct_keypairs_yield_distinct_public_keys() {
+    let kp_a = HybridKemKeyPair::try_generate().expect("kp a should succeed");
+    let kp_b = HybridKemKeyPair::try_generate().expect("kp b should succeed");
+
+    assert_ne!(
+        kp_a.public_key().to_bytes(),
+        kp_b.public_key().to_bytes(),
+        "two fresh hybrid keypairs must yield distinct public keys",
+    );
+}
+
+/// `validate()` accepts a fresh hybrid public key. Validates the
+/// ML-KEM-768 share via FIPS 203 § 7.2 (the X25519 share has no
+/// pre-DH validation step).
+#[test]
+fn hybrid_kem_validate_accepts_fresh_public_key() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    kp.public_key()
+        .validate()
+        .expect("fresh hybrid public key must validate");
+}
+
+/// Tampering the X25519 ephemeral share in the ciphertext to a
+/// small-order point causes decap to fail with `InvalidPublicKey`
+/// (HACL\*'s F\* postcondition rejects small-order DH peers).
+#[test]
+fn hybrid_kem_decap_rejects_small_order_x25519_in_ciphertext() {
+    use pulsar_kernel::crypto::kem::X25519PublicKey;
+    use pulsar_kernel::crypto::ml_kem::MlKem768Ciphertext;
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    let (ciphertext, _) = kp
+        .public_key()
+        .try_encapsulate()
+        .expect("encapsulate should succeed");
+
+    // Replace the X25519 ephemeral share with the canonical small-
+    // order point (u = 0). The ML-KEM ciphertext is left intact.
+    let small_order = X25519PublicKey::from_bytes([0_u8; 32]);
+    let mlkem_ct = ciphertext.pqc().clone();
+    let tampered = HybridKemCiphertext::from_parts(small_order, mlkem_ct);
+
+    match kp.private_key().try_decapsulate(&tampered) {
+        Err(Error::InvalidPublicKey) => {} // expected
+        other => panic!("expected InvalidPublicKey for small-order X25519 share; got {other:?}",),
+    }
+
+    // For coverage: drop unused import warnings on MlKem768Ciphertext (used implicitly)
+    let _: Option<MlKem768Ciphertext> = None;
+}
+
+/// Tampering the ML-KEM share in the ciphertext yields a divergent
+/// shared secret. Per FIPS 203 § 7.3 implicit rejection, ML-KEM
+/// decap is infallible; the HKDF combiner mixes the divergent
+/// `ss_mlkem` (uncorrelated with the encapsulator's authentic
+/// `ss_mlkem`) into the combined shared secret, producing a
+/// completely different output.
+#[test]
+fn hybrid_kem_decap_diverges_on_tampered_mlkem_share() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    let (original_ct, encap_secret) = kp
+        .public_key()
+        .try_encapsulate()
+        .expect("encapsulate should succeed");
+
+    // Flip a single bit in the ML-KEM share (offset 32 of the wire
+    // format = first byte of the ML-KEM ciphertext).
+    let mut tampered_bytes = original_ct.to_bytes();
+    tampered_bytes[sizes::MLKEM_CIPHERTEXT_OFFSET] ^= 0x01;
+    let tampered = HybridKemCiphertext::from_bytes(&tampered_bytes);
+
+    let tampered_secret = kp
+        .private_key()
+        .try_decapsulate(&tampered)
+        .expect("decap should not error — ML-KEM implicit rejection is infallible");
+
+    assert_ne!(
+        encap_secret.expose_secret(),
+        tampered_secret.expose_secret(),
+        "tampered ML-KEM share must yield a divergent combined shared secret",
+    );
+}
+
+/// Tampering the X25519 share with a non-small-order tampered byte
+/// (single-bit flip in the X25519 ephemeral key) yields a different
+/// shared secret on decap (the X25519 share contributes to HKDF IKM,
+/// so any change cascades). This validates that the hybrid combiner
+/// actually mixes the X25519 share — a bug that ignored ss_x25519
+/// would produce identical output despite the X25519 tampering.
+#[test]
+fn hybrid_kem_decap_diverges_on_tampered_x25519_share() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    let (original_ct, encap_secret) = kp
+        .public_key()
+        .try_encapsulate()
+        .expect("encapsulate should succeed");
+
+    // Flip a single bit in the X25519 share (byte 1, bit 0). Bit 0
+    // of byte 0 is sometimes special in X25519's clamping but
+    // tampering byte 1 is unambiguous.
+    let mut tampered_bytes = original_ct.to_bytes();
+    tampered_bytes[1] ^= 0x01;
+    let tampered = HybridKemCiphertext::from_bytes(&tampered_bytes);
+
+    let tampered_secret = kp
+        .private_key()
+        .try_decapsulate(&tampered)
+        .expect("decap of tampered-but-not-small-order X25519 should succeed");
+
+    assert_ne!(
+        encap_secret.expose_secret(),
+        tampered_secret.expose_secret(),
+        "tampered X25519 share must yield a divergent combined shared secret \
+         (validates that the HKDF combiner actually mixes the X25519 share)",
+    );
+}
+
+/// `Debug` impls do not leak signing-key bytes. Hybrid private key
+/// uses `finish_non_exhaustive`; constituent shares delegate to their
+/// own redacting Debug impls.
+#[test]
+fn hybrid_kem_debug_redacts_private_key() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+    let private_debug = format!("{:?}", kp.private_key());
+    assert!(private_debug.contains("HybridKemPrivateKey"));
+    assert!(
+        private_debug.contains(".."),
+        "hybrid private-key Debug must use finish_non_exhaustive",
+    );
+}

--- a/crates/pulsar-kernel/tests/hybrid_kem_property.rs
+++ b/crates/pulsar-kernel/tests/hybrid_kem_property.rs
@@ -1,9 +1,17 @@
-//! Property tests for `pulsar_kernel::crypto::hybrid_kem`.
+//! Iteration tests for `pulsar_kernel::crypto::hybrid_kem`.
 //!
-//! Hybrid X25519+ML-KEM-768 KEM. Properties cover the
-//! security-critical hybrid-orchestration invariants:
+//! Hybrid X25519+ML-KEM-768 KEM. Each test repeats its core invariant
+//! check across 32 randomly-generated CSPRNG-driven keypairs / encap
+//! calls — same coverage as a proptest property but without the
+//! single-input shrinking machinery (which would have nothing to
+//! shrink in this test surface anyway, since the wrapper does not
+//! yet expose seed-driven keypair / encap APIs for the hybrid).
+//! Phase 1.1.D's hybrid-vector pass will replace these with
+//! seed-driven proptest properties.
 //!
-//! - Encap/decap round-trip across random hybrid keypairs
+//! Properties exercised:
+//!
+//! - Encap/decap round-trip across CSPRNG-driven keypairs
 //! - Distinct keypairs yield distinct public keys (probabilistic)
 //! - Distinct encap calls yield distinct ciphertexts under same
 //!   public key (because ephemeral X25519 + ML-KEM seeds are fresh
@@ -12,83 +20,87 @@
 
 #![allow(clippy::expect_used, clippy::unwrap_used)]
 
-use proptest::prelude::*;
 use pulsar_kernel::crypto::hybrid_kem::{
     HybridKemCiphertext, HybridKemKeyPair, HybridKemPublicKey,
 };
 use secrecy::ExposeSecret;
 
-proptest::proptest! {
-    #![proptest_config(ProptestConfig {
-        // Hybrid keypair gen ~100 µs; encap + decap ~50 µs each.
-        // Per-case ≈ 250 µs × 32 cases × 4 properties ≈ 32 ms total.
-        cases: 32,
-        ..ProptestConfig::default()
-    })]
+/// Number of CSPRNG-driven iterations per test. Hybrid keypair gen
+/// ~100 µs; encap + decap ~50 µs each. Per-test ≈ 200 µs × 32 ≈ 6 ms.
+const ITERATIONS: usize = 32;
 
-    /// Encap/decap round-trip recovers the combined shared secret.
-    /// Driven by proptest entropy via the wrapper's CSPRNG path, so
-    /// each case exercises a fresh `(keypair, encap_seeds)` triple.
-    #[test]
-    fn encap_decap_round_trip(_seed in any::<u64>()) {
+/// Encap/decap round-trip recovers the combined shared secret.
+#[test]
+fn encap_decap_round_trip() {
+    for _ in 0..ITERATIONS {
         let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
-        let (ciphertext, encap_secret) = kp.public_key()
+        let (ciphertext, encap_secret) = kp
+            .public_key()
             .try_encapsulate()
             .expect("encap should succeed");
-        let decap_secret = kp.private_key()
+        let decap_secret = kp
+            .private_key()
             .try_decapsulate(&ciphertext)
             .expect("decap should succeed");
 
-        proptest::prop_assert_eq!(
+        assert_eq!(
             encap_secret.expose_secret(),
             decap_secret.expose_secret(),
             "hybrid encap shared secret must equal hybrid decap shared secret",
         );
     }
+}
 
-    /// Distinct hybrid keypairs yield distinct public keys
-    /// (probabilistic). For two fresh CSPRNG-driven keypairs the
-    /// chance of identical X25519 OR ML-KEM public keys is bounded
-    /// by 2⁻²⁵⁶ + 2⁻⁹⁰⁰⁰ish, effectively zero.
-    #[test]
-    fn distinct_keypairs_yield_distinct_public_keys(_seed in any::<u64>()) {
+/// Distinct hybrid keypairs yield distinct public keys (probabilistic).
+/// For two fresh CSPRNG-driven keypairs the chance of identical X25519
+/// OR ML-KEM public keys is bounded by 2⁻²⁵⁶ + 2⁻⁹⁰⁰⁰ish, effectively
+/// zero.
+#[test]
+fn distinct_keypairs_yield_distinct_public_keys() {
+    for _ in 0..ITERATIONS {
         let kp_a = HybridKemKeyPair::try_generate().expect("kp a should succeed");
         let kp_b = HybridKemKeyPair::try_generate().expect("kp b should succeed");
 
-        proptest::prop_assert_ne!(
+        assert_ne!(
             kp_a.public_key().to_bytes(),
             kp_b.public_key().to_bytes(),
             "two fresh hybrid keypairs must yield distinct public keys",
         );
     }
+}
 
-    /// Distinct encap calls under the same public key yield distinct
-    /// ciphertexts. Both the X25519 ephemeral key and the ML-KEM
-    /// encap seed are fresh per call, so the resulting ciphertext
-    /// differs in BOTH halves.
-    #[test]
-    fn distinct_encap_calls_yield_distinct_ciphertexts(_seed in any::<u64>()) {
-        let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+/// Distinct encap calls under the same public key yield distinct
+/// ciphertexts. Both the X25519 ephemeral key and the ML-KEM encap
+/// seed are fresh per call, so the resulting ciphertext differs in
+/// BOTH halves.
+#[test]
+fn distinct_encap_calls_yield_distinct_ciphertexts() {
+    let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
 
-        let (ct_a, _) = kp.public_key()
+    for _ in 0..ITERATIONS {
+        let (ct_a, _) = kp
+            .public_key()
             .try_encapsulate()
             .expect("encap a should succeed");
-        let (ct_b, _) = kp.public_key()
+        let (ct_b, _) = kp
+            .public_key()
             .try_encapsulate()
             .expect("encap b should succeed");
 
-        proptest::prop_assert_ne!(
+        assert_ne!(
             ct_a.to_bytes(),
             ct_b.to_bytes(),
             "two encap calls under same public key must produce distinct ciphertexts",
         );
     }
+}
 
-    /// Wire-format serialization is a perfect round-trip — `to_bytes`
-    /// followed by `from_bytes` yields a public key that decap'd-
-    /// against ciphertexts produces the same shared secret.
-    #[test]
-    fn wire_format_round_trip(_seed in any::<u64>()) {
+/// Wire-format serialization is a perfect round-trip — `to_bytes`
+/// followed by `from_bytes` yields a public key that decap'd-against
+/// ciphertexts produces the same shared secret.
+#[test]
+fn wire_format_round_trip() {
+    for _ in 0..ITERATIONS {
         let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
 
         let pk_bytes = kp.public_key().to_bytes();
@@ -101,11 +113,12 @@ proptest::proptest! {
         let ct_bytes = ciphertext.to_bytes();
         let recovered_ct = HybridKemCiphertext::from_bytes(&ct_bytes);
 
-        let decap_secret = kp.private_key()
+        let decap_secret = kp
+            .private_key()
             .try_decapsulate(&recovered_ct)
             .expect("decap recovered ct should succeed");
 
-        proptest::prop_assert_eq!(
+        assert_eq!(
             encap_secret.expose_secret(),
             decap_secret.expose_secret(),
             "wire-format round-trip must preserve KEM correctness",

--- a/crates/pulsar-kernel/tests/hybrid_kem_property.rs
+++ b/crates/pulsar-kernel/tests/hybrid_kem_property.rs
@@ -1,0 +1,114 @@
+//! Property tests for `pulsar_kernel::crypto::hybrid_kem`.
+//!
+//! Hybrid X25519+ML-KEM-768 KEM. Properties cover the
+//! security-critical hybrid-orchestration invariants:
+//!
+//! - Encap/decap round-trip across random hybrid keypairs
+//! - Distinct keypairs yield distinct public keys (probabilistic)
+//! - Distinct encap calls yield distinct ciphertexts under same
+//!   public key (because ephemeral X25519 + ML-KEM seeds are fresh
+//!   per call)
+//! - Wire-format `to_bytes` / `from_bytes` is a perfect round-trip
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use proptest::prelude::*;
+use pulsar_kernel::crypto::hybrid_kem::{
+    HybridKemCiphertext, HybridKemKeyPair, HybridKemPublicKey,
+};
+use secrecy::ExposeSecret;
+
+proptest::proptest! {
+    #![proptest_config(ProptestConfig {
+        // Hybrid keypair gen ~100 µs; encap + decap ~50 µs each.
+        // Per-case ≈ 250 µs × 32 cases × 4 properties ≈ 32 ms total.
+        cases: 32,
+        ..ProptestConfig::default()
+    })]
+
+    /// Encap/decap round-trip recovers the combined shared secret.
+    /// Driven by proptest entropy via the wrapper's CSPRNG path, so
+    /// each case exercises a fresh `(keypair, encap_seeds)` triple.
+    #[test]
+    fn encap_decap_round_trip(_seed in any::<u64>()) {
+        let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+        let (ciphertext, encap_secret) = kp.public_key()
+            .try_encapsulate()
+            .expect("encap should succeed");
+        let decap_secret = kp.private_key()
+            .try_decapsulate(&ciphertext)
+            .expect("decap should succeed");
+
+        proptest::prop_assert_eq!(
+            encap_secret.expose_secret(),
+            decap_secret.expose_secret(),
+            "hybrid encap shared secret must equal hybrid decap shared secret",
+        );
+    }
+
+    /// Distinct hybrid keypairs yield distinct public keys
+    /// (probabilistic). For two fresh CSPRNG-driven keypairs the
+    /// chance of identical X25519 OR ML-KEM public keys is bounded
+    /// by 2⁻²⁵⁶ + 2⁻⁹⁰⁰⁰ish, effectively zero.
+    #[test]
+    fn distinct_keypairs_yield_distinct_public_keys(_seed in any::<u64>()) {
+        let kp_a = HybridKemKeyPair::try_generate().expect("kp a should succeed");
+        let kp_b = HybridKemKeyPair::try_generate().expect("kp b should succeed");
+
+        proptest::prop_assert_ne!(
+            kp_a.public_key().to_bytes(),
+            kp_b.public_key().to_bytes(),
+            "two fresh hybrid keypairs must yield distinct public keys",
+        );
+    }
+
+    /// Distinct encap calls under the same public key yield distinct
+    /// ciphertexts. Both the X25519 ephemeral key and the ML-KEM
+    /// encap seed are fresh per call, so the resulting ciphertext
+    /// differs in BOTH halves.
+    #[test]
+    fn distinct_encap_calls_yield_distinct_ciphertexts(_seed in any::<u64>()) {
+        let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+
+        let (ct_a, _) = kp.public_key()
+            .try_encapsulate()
+            .expect("encap a should succeed");
+        let (ct_b, _) = kp.public_key()
+            .try_encapsulate()
+            .expect("encap b should succeed");
+
+        proptest::prop_assert_ne!(
+            ct_a.to_bytes(),
+            ct_b.to_bytes(),
+            "two encap calls under same public key must produce distinct ciphertexts",
+        );
+    }
+
+    /// Wire-format serialization is a perfect round-trip — `to_bytes`
+    /// followed by `from_bytes` yields a public key that decap'd-
+    /// against ciphertexts produces the same shared secret.
+    #[test]
+    fn wire_format_round_trip(_seed in any::<u64>()) {
+        let kp = HybridKemKeyPair::try_generate().expect("keypair should succeed");
+
+        let pk_bytes = kp.public_key().to_bytes();
+        let recovered_pk = HybridKemPublicKey::from_bytes(&pk_bytes);
+
+        let (ciphertext, encap_secret) = recovered_pk
+            .try_encapsulate()
+            .expect("encap against recovered pk should succeed");
+
+        let ct_bytes = ciphertext.to_bytes();
+        let recovered_ct = HybridKemCiphertext::from_bytes(&ct_bytes);
+
+        let decap_secret = kp.private_key()
+            .try_decapsulate(&recovered_ct)
+            .expect("decap recovered ct should succeed");
+
+        proptest::prop_assert_eq!(
+            encap_secret.expose_secret(),
+            decap_secret.expose_secret(),
+            "wire-format round-trip must preserve KEM correctness",
+        );
+    }
+}


### PR DESCRIPTION
## Summary

Third sub-phase of Phase 1.1.C. Lands the **hybrid X25519+ML-KEM-768 key-encapsulation mechanism** per Decision 2.58 — every Pulsar protocol that uses key encapsulation runs both KEMs in parallel and combines the shared secrets via HKDF-SHA-256. Defence-in-depth posture: a future quantum adversary cannot break the ML-KEM-768 share, and a future structural attack against ML-KEM-768 leaves the X25519 share at 128-bit-equivalent classical security. Phase 1.1.C.4 will land the symmetric Ed25519+ML-DSA-65 hybrid signature.

## Surfaces landed

- **`pulsar-kernel::crypto::hybrid_kem`** — `HybridKemKeyPair` (`try_generate`), `HybridKemPublicKey` (`from_bytes` / `to_bytes` / `validate` / `try_encapsulate`), `HybridKemPrivateKey` (`try_decapsulate`), `HybridKemCiphertext`. IETF X25519MLKEM768 wire format (1216 / 1120 bytes). HKDF-SHA-256 combiner with `pulsar-hybrid-kem-x25519-mlkem768-v1` salt.
- **`X25519PrivateKey::try_generate()`** + **`Ed25519PrivateKey::try_generate()`** — CSPRNG-driven keypair generation added to support the hybrid (and the upcoming hybrid signature in 1.1.C.4).

## Key-material handling

- Hybrid private key holds `(X25519PrivateKey, MlKem768PrivateKey)` — both inherit zeroize-on-drop from Phase 1.1.B.3 / Phase 1.1.C.1. No new private-key storage.
- Encapsulation generates an ephemeral X25519 keypair per call.
- Combined shared secret returned in `SecretBox<[u8]>`.

## Tests

14 new tests across 2 integration test files:

- `hybrid_kem_kat.rs` — 10 tests: sizes / round-trip / wire-format round-trips / distinct keypairs / validate / tampered X25519 small-order rejection / tampered ML-KEM divergent secret / tampered X25519 non-small-order divergent secret (validates combiner actually mixes X25519) / Debug redaction
- `hybrid_kem_property.rs` — 4 properties (32 cases): round-trip / distinct keypairs / distinct encap → distinct ciphertexts / wire-format perfect round-trip

## Quality gates

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p pulsar-kernel --all-targets -- -D warnings` ✓
- `cargo nextest run -p pulsar-kernel` — **178/178 PASS** (+14 from this phase)
- `cargo test -p pulsar-kernel --doc` ✓

## Test plan

- [x] `cargo nextest run -p pulsar-kernel`
- [x] `cargo clippy -p pulsar-kernel --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] GPG-signed commit (`F779A214...3D12DF7`)
- [ ] `/review` on this PR
- [ ] `/security-review` on this PR