### PR TITLE
Sprint 1.1.C.4 — hybrid Ed25519+ML-DSA-65 signature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,48 @@ and the project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
-### Sprint 1.1 — kernel crypto (Phase 1.1.C.3: hybrid X25519+ML-KEM-768 KEM, in progress)
+### Sprint 1.1 — kernel crypto (Phase 1.1.C.4: hybrid Ed25519+ML-DSA-65 signature, in progress)
+
+Fourth sub-phase of Phase 1.1.C — and the second hybrid construction. Lands `pulsar-kernel::crypto::hybrid_sig` per Decision 2.58: every signature scheme that anchors a long-term commitment runs Ed25519 + ML-DSA-65 in parallel and verifies REQUIRE BOTH to pass. Pairs with Phase 1.1.C.3's hybrid X25519+ML-KEM-768 KEM; together they complete Pulsar's hybrid-PQC surface for both key establishment and digital signatures. This sub-phase closes the cryptographic primitive surface for Sprint 1.1 — Phase 1.1.D adds Creusot contracts + the spec/crypto.tla TLA+ specification, and Phase 1.1.E adds benchmarks + the sprint exit gate.
+
+* **`pulsar-kernel::crypto::hybrid_sig`** — typed safe wrappers orchestrating the Ed25519 + ML-DSA-65 primitives shipped by Phase 1.1.B.3 and Phase 1.1.C.2. `HybridSigKeyPair::try_generate()` independently generates an Ed25519 keypair (32-byte CSPRNG seed) and an ML-DSA-65 keypair (32-byte CSPRNG seed) — the two share no entropy. `HybridSigPrivateKey::try_sign(message, context)` produces `(sig_ed25519, sig_mldsa)` over the same message; the Ed25519 share signs a prefix-transformed input, the ML-DSA share uses the native FIPS 204 § 5.2 context binding. `HybridSigPublicKey::verify(message, context, &signature)` returns `Ok(())` iff BOTH constituent verifications pass; either failure collapses to a single `Error::SignatureVerifyFailed`.
+* **Combining strategy: parallel + AND-verify** — the hybrid signature is the wire-format concatenation `sig_ed25519 || sig_mldsa` (64 + 3 309 = 3 373 bytes). Sign produces both signatures independently; verify requires BOTH to pass. Either tampered share fails the hybrid verification.
+* **Context binding via Ed25519 prefix transformation** — Ed25519 (RFC 8032) has no native context parameter; ML-DSA-65 (FIPS 204 § 5.2) does. To bind the same context to both halves, the Ed25519 share signs `HYBRID_LABEL || context_len_byte || context || message` where `HYBRID_LABEL = "pulsar-hybrid-sig-ed25519-mldsa65-v1"`. The single-byte length prefix ensures unambiguous parsing; the label provides domain separation against bare Ed25519 signatures using the same signing key — a hybrid Ed25519 share will NOT verify under a bare Ed25519 verifier on the raw message bytes (test pinned: `hybrid_sig_ed25519_share_not_valid_for_raw_message`). ML-DSA-65 receives `(message, context)` directly and applies its native FIPS 204 § 5.2 context binding internally.
+* **Wire format** — verification key `vk_ed25519 || vk_mldsa` (32 + 1 952 = 1 984 bytes), signature `sig_ed25519 || sig_mldsa` (64 + 3 309 = 3 373 bytes). `to_bytes` / `from_bytes` round-trip verified by tests. Signing-key wire-format length 4 064 bytes (32 + 4 032) — though held in memory as `(Ed25519PrivateKey, MlDsa65SigningKey)` rather than serialised.
+* **Constituent-primitive zeroization** — the hybrid private key holds an `Ed25519PrivateKey` (SecretBox-wrapped 32-byte seed) alongside an `MlDsa65SigningKey` (SecretBox-wrapped 4 032-byte private key). Both inherit the canonical Pulsar zeroize-on-drop posture from Phase 1.1.B.3 / Phase 1.1.C.2 — no new private-key storage introduced.
+* **Context length bound** — `context.len()` ≤ 255 enforced at both sign and verify entry points (FIPS 204 § 5.2 native bound + single-byte length prefix in the Ed25519 input transformation). Excess-length → `Error::InputTooLong`.
+* **Module re-exports** in `pulsar-kernel::crypto::mod` and `pulsar-kernel::prelude`: `HybridSigKeyPair`, `HybridSigPublicKey`, `HybridSigPrivateKey`, `HybridSigSignature`. The `sizes` sub-module is reachable via `pulsar_kernel::crypto::hybrid_sig::sizes`.
+
+**Tests** (18 new tests across two integration test files):
+
+* **`tests/hybrid_sig_kat.rs`** (14 tests):
+  - sizes match the hybrid Ed25519+ML-DSA-65 convention (1984 / 4064 / 3373 / 255) — pinned via constants
+  - sign/verify round-trip with empty context
+  - sign/verify round-trip with non-empty context (exercises FIPS 204 § 5.2 native binding + Ed25519 prefix transformation)
+  - verification-key wire format round-trip preserves both halves
+  - signature wire format round-trip preserves verifiability
+  - BOTH-must-pass — tampered Ed25519 share → `SignatureVerifyFailed`
+  - BOTH-must-pass — tampered ML-DSA share → `SignatureVerifyFailed` (Ed25519 share still valid in isolation, but hybrid rejects)
+  - tampered message → `SignatureVerifyFailed`
+  - context mismatch (sign with context A, verify with context B) → `SignatureVerifyFailed`
+  - cross-key rejection (signature from key A under verification key B) → `SignatureVerifyFailed`
+  - oversize context (256 bytes) at sign → `InputTooLong`
+  - oversize context (256 bytes) at verify → `InputTooLong`
+  - **domain separation invariant** — a hybrid signature's Ed25519 share does NOT verify under a bare Ed25519 verifier on the raw message bytes (validates HYBRID_LABEL + length-prefix transformation prevents downgrade attacks)
+  - `Debug` redaction on hybrid private key
+* **`tests/hybrid_sig_property.rs`** (4 iteration-tests, 16 iterations each — hybrid sign + verify cost ~500 µs):
+  - sign/verify round-trip across CSPRNG-driven keypairs
+  - distinct keypairs yield distinct verification keys
+  - distinct sign calls yield distinct signatures (ML-DSA-65 hedged signing draws fresh randomness per call; Ed25519 is deterministic; combined wire-format differs)
+  - wire-format `to_bytes` / `from_bytes` is a perfect round-trip preserving signature correctness
+
+Quality gates verified locally:
+  - cargo fmt --all -- --check ✓
+  - cargo clippy -p pulsar-kernel --all-targets -- -D warnings ✓
+  - cargo nextest run -p pulsar-kernel (196/196 PASS, +18 from this phase) ✓
+  - cargo test -p pulsar-kernel --doc ✓
+
+### Sprint 1.1 — kernel crypto (Phase 1.1.C.3: hybrid X25519+ML-KEM-768 KEM — merged 2026-04-28 as `df44b9eb`)
 
 Third sub-phase of Phase 1.1.C. Lands `pulsar-kernel::crypto::hybrid_kem` — the **hybrid X25519+ML-KEM-768 key-encapsulation mechanism** per Decision 2.58 (every Pulsar protocol that uses key encapsulation runs both KEMs in parallel and combines the shared secrets via HKDF-SHA-256). Defence-in-depth posture: a future quantum adversary cannot break the ML-KEM-768 share, and a future structural attack against ML-KEM-768 leaves the X25519 share at 128-bit-equivalent classical security. The two schemes share neither hardness assumption nor implementation surface. Phase 1.1.C.4 will land the symmetric Ed25519+ML-DSA-65 hybrid signature.
 

--- a/crates/pulsar-kernel/src/crypto/hybrid_sig.rs
+++ b/crates/pulsar-kernel/src/crypto/hybrid_sig.rs
@@ -119,8 +119,6 @@ pub mod sizes {
     /// Maximum context-string length (FIPS 204 § 5.2 + single-byte
     /// length prefix in the Ed25519 input transformation).
     pub const MAX_CONTEXT_LEN: usize = 255;
-    /// Ed25519 share offset within the verification key (`[0..32]`).
-    pub const ED25519_OFFSET: usize = 0;
     /// Ed25519 share length within the verification key.
     pub const ED25519_VK_LEN: usize = 32;
     /// ML-DSA-65 share offset within the verification key.

--- a/crates/pulsar-kernel/src/crypto/hybrid_sig.rs
+++ b/crates/pulsar-kernel/src/crypto/hybrid_sig.rs
@@ -1,0 +1,483 @@
+//! Hybrid post-quantum + classical digital signature.
+//!
+//! Per Decision 2.58 hybrid PQC posture from Sprint 1.1, every
+//! signature scheme that anchors a long-term commitment runs
+//! **Ed25519 + ML-DSA-65 in parallel** and verifies REQUIRE BOTH
+//! to pass. This sub-phase ships the safe Rust wrapper that
+//! orchestrates the two constituent primitives (security-reviewed
+//! in Phase 1.1.B.3 for Ed25519 and Phase 1.1.C.2 for ML-DSA-65).
+//!
+//! # Why hybrid signatures
+//!
+//! - **Quantum resistance** — ML-DSA-65 is FIPS 204's NIST-PQC
+//!   signature scheme. A future quantum adversary cannot forge the
+//!   ML-DSA half.
+//! - **Classical fallback** — Ed25519 is RFC 8032's elliptic-curve
+//!   digital-signature scheme with two decades of cryptanalytic
+//!   scrutiny. If a structural attack is discovered against
+//!   ML-DSA-65, the Ed25519 half still provides 128-bit-equivalent
+//!   security.
+//! - **Defence in depth via independent primitives** — the two
+//!   schemes share neither hardness assumption nor implementation
+//!   surface. A break against one does not propagate to the other.
+//! - **Conservative posture** — preserves classical-only verifiability
+//!   for legacy clients while gaining PQC protection. A bare Ed25519
+//!   verifier holding only the classical half can validate the
+//!   Ed25519 share independently (after applying the documented
+//!   prefix transformation).
+//!
+//! # Combining strategy: parallel + AND-verify
+//!
+//! `HybridSigPrivateKey::try_sign(message, context)` produces:
+//!
+//! - `sig_ed25519 = Ed25519::sign(sk_ed25519, prefix(context, message))`
+//! - `sig_mldsa   = ML-DSA-65::sign(sk_mldsa, message, context)`
+//!
+//! `HybridSigPublicKey::verify(message, context, &signature)`
+//! returns `Ok(())` iff BOTH:
+//!
+//! - `Ed25519::verify(vk_ed25519, prefix(context, message), sig.classical)` → `Ok`
+//! - `ML-DSA-65::verify(vk_mldsa, message, context, sig.pqc)` → `Ok`
+//!
+//! Either verification failure collapses to a single
+//! [`Error::SignatureVerifyFailed`] — no information leaked about
+//! which sub-step (or which underlying scheme) failed, mirroring
+//! the [`Ed25519PublicKey::verify`] and
+//! [`MlDsa65VerificationKey::verify`] postures.
+//!
+//! # Context binding via Ed25519 prefix transformation
+//!
+//! Ed25519 (RFC 8032) does not have a native context parameter.
+//! ML-DSA-65 (FIPS 204 § 5.2) does. To bind the same context to
+//! both halves of the hybrid signature, the wrapper transforms the
+//! Ed25519 input to:
+//!
+//! ```text
+//! ed25519_input = HYBRID_LABEL || context_len_byte || context || message
+//!               = "pulsar-hybrid-sig-ed25519-mldsa65-v1" || u8(|ctx|) || ctx || M
+//! ```
+//!
+//! The single-byte length prefix (`context_len_byte`) ensures the
+//! Ed25519 input is unambiguously parseable: a context-empty
+//! signature over message `M` is distinct from a context-of-length-
+//! ≤-255 signature over the same `M`. The HYBRID_LABEL provides
+//! domain separation against bare Ed25519 signatures using the same
+//! signing key — a hybrid Ed25519 sig will NOT verify under a bare
+//! Ed25519 verifier on the raw message bytes.
+//!
+//! ML-DSA-65 receives the original `(message, context)` pair and
+//! applies its native FIPS 204 § 5.2 context binding internally.
+//!
+//! # Wire format
+//!
+//! - **Verification key** = `vk_ed25519 || vk_mldsa`     (32  + 1 952 = 1 984 bytes)
+//! - **Signing key** = stored separately as `(Ed25519PrivateKey, MlDsa65SigningKey)`
+//!   — the wire format for serialisation is `sk_ed25519 || sk_mldsa` (32 + 4 032 = 4 064 bytes)
+//! - **Signature** = `sig_ed25519 || sig_mldsa`           (64  + 3 309 = 3 373 bytes)
+//!
+//! These layouts mirror the IETF X25519MLKEM768 / hybrid-sig
+//! convention (classical share first, PQC share second).
+//!
+//! # Context length bound
+//!
+//! `context.len()` must be ≤ 255 — this is the FIPS 204 § 5.2 bound
+//! AND the maximum value representable in the single-byte length
+//! prefix used by the Ed25519 input transformation. Excess-length
+//! contexts are rejected as [`Error::InputTooLong`] at both sign
+//! and verify entry points.
+//!
+//! # Key-material handling
+//!
+//! Following the canonical pattern from Phase 1.1.C.3 (hybrid KEM):
+//! the hybrid signing key holds an [`Ed25519PrivateKey`]
+//! (SecretBox-wrapped 32-byte seed) alongside an
+//! [`MlDsa65SigningKey`] (SecretBox-wrapped 4 032-byte private
+//! key). Both inherit the canonical Pulsar zeroize-on-drop posture
+//! from earlier phases — no new private-key storage introduced.
+
+use crate::crypto::ml_dsa::{
+    MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey,
+};
+use crate::crypto::signature::{Ed25519PrivateKey, Ed25519PublicKey, Ed25519Signature};
+use crate::error::{Error, Result};
+use zeroize::Zeroizing;
+
+/// Domain-separation label prefixed to the Ed25519 input. Versioned
+/// so a future transformation change can revise the label without
+/// colliding with stored signatures derived from the v1 scheme.
+const HYBRID_SIG_LABEL: &[u8] = b"pulsar-hybrid-sig-ed25519-mldsa65-v1";
+
+/// Hybrid Ed25519 + ML-DSA-65 fixed sizes — re-exposed as public
+/// constants for caller-side allocation sizing.
+pub mod sizes {
+    /// Hybrid verification-key length in bytes: `32 + 1952 = 1984`.
+    pub const VERIFICATION_KEY_LEN: usize = 32 + 1952;
+    /// Hybrid signing-key wire-format length in bytes: `32 + 4032 = 4064`.
+    pub const SIGNING_KEY_LEN: usize = 32 + 4032;
+    /// Hybrid signature length in bytes: `64 + 3309 = 3373`.
+    pub const SIGNATURE_LEN: usize = 64 + 3309;
+    /// Maximum context-string length (FIPS 204 § 5.2 + single-byte
+    /// length prefix in the Ed25519 input transformation).
+    pub const MAX_CONTEXT_LEN: usize = 255;
+    /// Ed25519 share offset within the verification key (`[0..32]`).
+    pub const ED25519_OFFSET: usize = 0;
+    /// Ed25519 share length within the verification key.
+    pub const ED25519_VK_LEN: usize = 32;
+    /// ML-DSA-65 share offset within the verification key.
+    pub const MLDSA_VK_OFFSET: usize = 32;
+    /// ML-DSA-65 share length within the verification key.
+    pub const MLDSA_VK_LEN: usize = 1952;
+    /// Ed25519 share length within the signature.
+    pub const ED25519_SIG_LEN: usize = 64;
+    /// ML-DSA-65 share offset within the signature (`[64..3373]`).
+    pub const MLDSA_SIG_OFFSET: usize = 64;
+    /// ML-DSA-65 share length within the signature.
+    pub const MLDSA_SIG_LEN: usize = 3309;
+}
+
+/// Build the Ed25519 input bytes from `(context, message)` per the
+/// hybrid scheme's prefix transformation:
+///
+/// ```text
+/// HYBRID_LABEL || context_len_byte || context || message
+/// ```
+///
+/// The result is a heap-allocated `Zeroizing<Vec<u8>>` so the
+/// transformed input is wiped on drop — though the inputs `context`
+/// and `message` are themselves public per the digital-signature
+/// threat model, the buffer is held briefly in memory and the
+/// zeroize-on-drop covers any incidental retention concerns.
+fn ed25519_input(context: &[u8], message: &[u8]) -> Zeroizing<Vec<u8>> {
+    debug_assert!(context.len() <= sizes::MAX_CONTEXT_LEN);
+    let mut buf = Vec::with_capacity(HYBRID_SIG_LABEL.len() + 1 + context.len() + message.len());
+    buf.extend_from_slice(HYBRID_SIG_LABEL);
+    // Length-prefix the context (single byte) so the Ed25519 input is
+    // unambiguously parseable. The cast is sound because the caller
+    // has already verified `context.len() <= 255`.
+    buf.push(u8::try_from(context.len()).unwrap_or(255));
+    buf.extend_from_slice(context);
+    buf.extend_from_slice(message);
+    Zeroizing::new(buf)
+}
+
+/// Hybrid (classical + post-quantum) verification (public) key.
+///
+/// Holds an [`Ed25519PublicKey`] alongside an [`MlDsa65VerificationKey`].
+/// Verification runs both schemes in parallel and requires BOTH to
+/// pass per Decision 2.58.
+#[derive(Clone)]
+pub struct HybridSigPublicKey {
+    classical: Ed25519PublicKey,
+    pqc: MlDsa65VerificationKey,
+}
+
+impl core::fmt::Debug for HybridSigPublicKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridSigPublicKey")
+            .field("classical", &self.classical)
+            .field("pqc", &self.pqc)
+            .finish()
+    }
+}
+
+impl HybridSigPublicKey {
+    /// Hybrid verification-key length in bytes (`32 + 1952 = 1984`).
+    pub const LEN: usize = sizes::VERIFICATION_KEY_LEN;
+
+    /// Construct from a 1 984-byte buffer in `vk_ed25519 || vk_mldsa`
+    /// wire format.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; Self::LEN]) -> Self {
+        let mut ed_bytes = [0_u8; sizes::ED25519_VK_LEN];
+        ed_bytes.copy_from_slice(&bytes[..sizes::ED25519_VK_LEN]);
+        let classical = Ed25519PublicKey::from_bytes(ed_bytes);
+
+        let mut mldsa_bytes = [0_u8; sizes::MLDSA_VK_LEN];
+        mldsa_bytes.copy_from_slice(&bytes[sizes::MLDSA_VK_OFFSET..]);
+        let pqc = MlDsa65VerificationKey::from_bytes(mldsa_bytes);
+
+        Self { classical, pqc }
+    }
+
+    /// Construct from individual Ed25519 + ML-DSA-65 verification
+    /// keys.
+    #[must_use]
+    pub const fn from_parts(classical: Ed25519PublicKey, pqc: MlDsa65VerificationKey) -> Self {
+        Self { classical, pqc }
+    }
+
+    /// Return the Ed25519 share.
+    #[must_use]
+    pub const fn classical(&self) -> &Ed25519PublicKey {
+        &self.classical
+    }
+
+    /// Return the ML-DSA-65 share.
+    #[must_use]
+    pub const fn pqc(&self) -> &MlDsa65VerificationKey {
+        &self.pqc
+    }
+
+    /// Serialize the hybrid verification key to wire format:
+    /// `vk_ed25519 || vk_mldsa`.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; Self::LEN] {
+        let mut out = [0_u8; Self::LEN];
+        out[..sizes::ED25519_VK_LEN].copy_from_slice(self.classical.as_bytes());
+        out[sizes::MLDSA_VK_OFFSET..].copy_from_slice(self.pqc.as_bytes());
+        out
+    }
+
+    /// Verify a hybrid signature over `message` with optional domain-
+    /// separation `context`. Returns `Ok(())` iff BOTH the Ed25519
+    /// share AND the ML-DSA-65 share verify under their respective
+    /// keys.
+    ///
+    /// Either verification failure collapses to a single
+    /// [`Error::SignatureVerifyFailed`] — no information leaked
+    /// about which sub-step failed.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InputTooLong`] — `context.len() > 255`.
+    /// - [`Error::SignatureVerifyFailed`] — either constituent
+    ///   signature is invalid for the (verification key, message,
+    ///   context) triple.
+    pub fn verify(
+        &self,
+        message: &[u8],
+        context: &[u8],
+        signature: &HybridSigSignature,
+    ) -> Result<()> {
+        if context.len() > sizes::MAX_CONTEXT_LEN {
+            return Err(Error::InputTooLong {
+                actual: context.len(),
+                max: sizes::MAX_CONTEXT_LEN,
+            });
+        }
+
+        // 1. Ed25519 verify over the prefix-transformed message.
+        let ed_input = ed25519_input(context, message);
+        self.classical
+            .verify(&ed_input, &signature.classical)
+            .map_err(|_| Error::SignatureVerifyFailed)?;
+
+        // 2. ML-DSA-65 verify over the original message + context.
+        self.pqc
+            .verify(message, context, &signature.pqc)
+            .map_err(|_| Error::SignatureVerifyFailed)?;
+
+        Ok(())
+    }
+}
+
+/// Hybrid (classical + post-quantum) signing (private) key.
+///
+/// Holds an [`Ed25519PrivateKey`] alongside an [`MlDsa65SigningKey`].
+/// Both inherit zeroize-on-drop semantics from their constituent
+/// SecretBox-backed storage; no new private-key storage introduced
+/// at the hybrid layer.
+pub struct HybridSigPrivateKey {
+    classical: Ed25519PrivateKey,
+    pqc: MlDsa65SigningKey,
+}
+
+impl core::fmt::Debug for HybridSigPrivateKey {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridSigPrivateKey")
+            .field("classical", &self.classical)
+            .field("pqc", &self.pqc)
+            .finish_non_exhaustive()
+    }
+}
+
+impl HybridSigPrivateKey {
+    /// Construct from individual Ed25519 + ML-DSA-65 signing keys.
+    #[must_use]
+    pub const fn from_parts(classical: Ed25519PrivateKey, pqc: MlDsa65SigningKey) -> Self {
+        Self { classical, pqc }
+    }
+
+    /// Return the Ed25519 share.
+    #[must_use]
+    pub const fn classical(&self) -> &Ed25519PrivateKey {
+        &self.classical
+    }
+
+    /// Return the ML-DSA-65 share.
+    #[must_use]
+    pub const fn pqc(&self) -> &MlDsa65SigningKey {
+        &self.pqc
+    }
+
+    /// Sign `message` with optional domain-separation `context` under
+    /// this hybrid signing key. Produces an [`HybridSigSignature`]
+    /// containing both the Ed25519 share (over the prefix-
+    /// transformed message) and the ML-DSA-65 share (over the
+    /// original message + context).
+    ///
+    /// ML-DSA-65 signing draws 32 bytes of CSPRNG randomness for the
+    /// FIPS 204 § 5.4 hedged signing mode. Ed25519 is fully
+    /// deterministic per RFC 8032 § 5.1.6 — no CSPRNG draw.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::InputTooLong`] — `context.len() > 255`.
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
+    ///   during ML-DSA-65 randomness generation.
+    /// - [`Error::SigningFailed`] — ML-DSA-65's rejection-sampling
+    ///   loop exceeded the maximum number of attempts (vanishingly
+    ///   rare; treat as fatal-but-transient).
+    pub fn try_sign(&self, message: &[u8], context: &[u8]) -> Result<HybridSigSignature> {
+        if context.len() > sizes::MAX_CONTEXT_LEN {
+            return Err(Error::InputTooLong {
+                actual: context.len(),
+                max: sizes::MAX_CONTEXT_LEN,
+            });
+        }
+
+        // 1. Ed25519 sign over the prefix-transformed message.
+        let ed_input = ed25519_input(context, message);
+        let ed_signature = self.classical.sign(&ed_input)?;
+
+        // 2. ML-DSA-65 sign over the original message + context.
+        let mldsa_signature = self.pqc.try_sign(message, context)?;
+
+        Ok(HybridSigSignature {
+            classical: ed_signature,
+            pqc: mldsa_signature,
+        })
+    }
+}
+
+/// Hybrid signature (3 373 bytes — `sig_ed25519 || sig_mldsa`).
+#[derive(Clone)]
+pub struct HybridSigSignature {
+    classical: Ed25519Signature,
+    pqc: MlDsa65Signature,
+}
+
+impl core::fmt::Debug for HybridSigSignature {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridSigSignature")
+            .field("classical", &self.classical)
+            .field("pqc", &self.pqc)
+            .finish()
+    }
+}
+
+impl HybridSigSignature {
+    /// Hybrid signature length in bytes (`64 + 3309 = 3373`).
+    pub const LEN: usize = sizes::SIGNATURE_LEN;
+
+    /// Construct from a 3 373-byte buffer in `sig_ed25519 ||
+    /// sig_mldsa` wire format.
+    #[must_use]
+    pub fn from_bytes(bytes: &[u8; Self::LEN]) -> Self {
+        let mut ed_bytes = [0_u8; sizes::ED25519_SIG_LEN];
+        ed_bytes.copy_from_slice(&bytes[..sizes::ED25519_SIG_LEN]);
+        let classical = Ed25519Signature::from_bytes(ed_bytes);
+
+        let mut mldsa_bytes = [0_u8; sizes::MLDSA_SIG_LEN];
+        mldsa_bytes.copy_from_slice(&bytes[sizes::MLDSA_SIG_OFFSET..]);
+        let pqc = MlDsa65Signature::from_bytes(mldsa_bytes);
+
+        Self { classical, pqc }
+    }
+
+    /// Construct from individual Ed25519 + ML-DSA-65 signatures.
+    #[must_use]
+    pub const fn from_parts(classical: Ed25519Signature, pqc: MlDsa65Signature) -> Self {
+        Self { classical, pqc }
+    }
+
+    /// Return the Ed25519 share.
+    #[must_use]
+    pub const fn classical(&self) -> &Ed25519Signature {
+        &self.classical
+    }
+
+    /// Return the ML-DSA-65 share.
+    #[must_use]
+    pub const fn pqc(&self) -> &MlDsa65Signature {
+        &self.pqc
+    }
+
+    /// Serialize the hybrid signature to wire format: `sig_ed25519
+    /// || sig_mldsa`.
+    #[must_use]
+    pub fn to_bytes(&self) -> [u8; Self::LEN] {
+        let mut out = [0_u8; Self::LEN];
+        out[..sizes::ED25519_SIG_LEN].copy_from_slice(self.classical.as_bytes());
+        out[sizes::MLDSA_SIG_OFFSET..].copy_from_slice(self.pqc.as_bytes());
+        out
+    }
+}
+
+/// Hybrid signature keypair — bundles an Ed25519 + ML-DSA-65
+/// keypair pair produced by a single keypair-generation flow.
+pub struct HybridSigKeyPair {
+    public_key: HybridSigPublicKey,
+    private_key: HybridSigPrivateKey,
+}
+
+impl core::fmt::Debug for HybridSigKeyPair {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        f.debug_struct("HybridSigKeyPair")
+            .field("public_key", &self.public_key)
+            .field("private_key", &self.private_key)
+            .finish()
+    }
+}
+
+impl HybridSigKeyPair {
+    /// Generate a fresh hybrid signature keypair using the OS CSPRNG.
+    ///
+    /// Independently generates an Ed25519 keypair (32-byte random
+    /// seed via [`Ed25519PrivateKey::try_generate`]) and an
+    /// ML-DSA-65 keypair (32-byte random seed via
+    /// [`MlDsa65KeyPair::try_generate`]). The two keypairs share no
+    /// entropy — keypair-isolation invariant from Decision 2.58.
+    ///
+    /// # Errors
+    ///
+    /// - [`Error::RngFailure`] — the OS CSPRNG returned an error
+    ///   during either constituent keypair generation.
+    pub fn try_generate() -> Result<Self> {
+        let classical_secret = Ed25519PrivateKey::try_generate()?;
+        let classical_public = classical_secret.public_key();
+
+        let mldsa_keypair = MlDsa65KeyPair::try_generate()?;
+        let (mldsa_verification, mldsa_signing) = mldsa_keypair.into_parts();
+
+        Ok(Self {
+            public_key: HybridSigPublicKey {
+                classical: classical_public,
+                pqc: mldsa_verification,
+            },
+            private_key: HybridSigPrivateKey {
+                classical: classical_secret,
+                pqc: mldsa_signing,
+            },
+        })
+    }
+
+    /// Return a reference to the hybrid verification key.
+    #[must_use]
+    pub const fn public_key(&self) -> &HybridSigPublicKey {
+        &self.public_key
+    }
+
+    /// Return a reference to the hybrid signing key.
+    #[must_use]
+    pub const fn private_key(&self) -> &HybridSigPrivateKey {
+        &self.private_key
+    }
+
+    /// Decompose the keypair into its constituent verification +
+    /// signing keys, transferring ownership.
+    #[must_use]
+    pub fn into_parts(self) -> (HybridSigPublicKey, HybridSigPrivateKey) {
+        (self.public_key, self.private_key)
+    }
+}

--- a/crates/pulsar-kernel/src/crypto/mod.rs
+++ b/crates/pulsar-kernel/src/crypto/mod.rs
@@ -64,6 +64,7 @@ pub mod hash;
 pub mod hkdf;
 pub mod hmac;
 pub mod hybrid_kem;
+pub mod hybrid_sig;
 pub mod kem;
 pub mod ml_dsa;
 pub mod ml_kem;
@@ -78,6 +79,9 @@ pub use hash::{sha256, sha384, sha512};
 pub use hmac::{HmacAlgorithm, HmacKey};
 pub use hybrid_kem::{
     HybridKemCiphertext, HybridKemKeyPair, HybridKemPrivateKey, HybridKemPublicKey,
+};
+pub use hybrid_sig::{
+    HybridSigKeyPair, HybridSigPrivateKey, HybridSigPublicKey, HybridSigSignature,
 };
 pub use kem::{X25519PrivateKey, X25519PublicKey};
 pub use ml_dsa::{MlDsa65KeyPair, MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey};

--- a/crates/pulsar-kernel/src/prelude.rs
+++ b/crates/pulsar-kernel/src/prelude.rs
@@ -8,7 +8,8 @@
 pub use crate::crypto::{
     AeadAlgorithm, AeadKey, Argon2idParams, Argon2idVerifyLimits, Ed25519PrivateKey,
     Ed25519PublicKey, Ed25519Signature, HashAlgorithm, Hasher, HmacAlgorithm, HmacKey,
-    HybridKemCiphertext, HybridKemKeyPair, HybridKemPrivateKey, HybridKemPublicKey, MlDsa65KeyPair,
+    HybridKemCiphertext, HybridKemKeyPair, HybridKemPrivateKey, HybridKemPublicKey,
+    HybridSigKeyPair, HybridSigPrivateKey, HybridSigPublicKey, HybridSigSignature, MlDsa65KeyPair,
     MlDsa65Signature, MlDsa65SigningKey, MlDsa65VerificationKey, MlKem768Ciphertext,
     MlKem768KeyPair, MlKem768PrivateKey, MlKem768PublicKey, X25519PrivateKey, X25519PublicKey,
 };

--- a/crates/pulsar-kernel/tests/hybrid_sig_kat.rs
+++ b/crates/pulsar-kernel/tests/hybrid_sig_kat.rs
@@ -1,0 +1,324 @@
+//! Known-answer + integration tests for `pulsar_kernel::crypto::hybrid_sig`.
+//!
+//! Hybrid Ed25519+ML-DSA-65 signature per Decision 2.58.
+//! Cryptographic correctness of the constituent primitives is
+//! asserted by the upstream test suites (HACL\* for Ed25519, libcrux
+//! for ML-DSA-65); these wrapper-level tests focus on the hybrid
+//! orchestration:
+//!
+//! - Sizes match the IETF hybrid-sig convention (1984 / 4064 / 3373)
+//! - Sign/verify round-trip succeeds for any (message, context)
+//! - Wire-format serialisation round-trip preserves both halves
+//! - BOTH-must-pass semantics: tampered Ed25519 share fails verify
+//! - BOTH-must-pass semantics: tampered ML-DSA share fails verify
+//! - FIPS 204 § 5.2 + Ed25519 prefix: context mismatch fails verify
+//! - Cross-key rejection: signatures from key A don't verify under key B
+//! - Oversize context (> 255 bytes) → `InputTooLong`
+//! - Hybrid signatures have HYBRID_LABEL domain separation against
+//!   bare Ed25519 — a hybrid sig's Ed25519 share does NOT verify
+//!   against the same message under a bare Ed25519 verifier
+
+#![allow(clippy::expect_used, clippy::unwrap_used, clippy::panic)]
+
+use pulsar_kernel::crypto::hybrid_sig::{
+    HybridSigKeyPair, HybridSigPublicKey, HybridSigSignature, sizes,
+};
+
+/// Sizes match the hybrid Ed25519+ML-DSA-65 convention.
+#[test]
+fn hybrid_sig_sizes_match_convention() {
+    assert_eq!(sizes::VERIFICATION_KEY_LEN, 1984);
+    assert_eq!(sizes::SIGNING_KEY_LEN, 4064);
+    assert_eq!(sizes::SIGNATURE_LEN, 3373);
+    assert_eq!(sizes::MAX_CONTEXT_LEN, 255);
+    assert_eq!(sizes::ED25519_VK_LEN, 32);
+    assert_eq!(sizes::MLDSA_VK_LEN, 1952);
+    assert_eq!(sizes::ED25519_SIG_LEN, 64);
+    assert_eq!(sizes::MLDSA_SIG_LEN, 3309);
+
+    assert_eq!(HybridSigPublicKey::LEN, 1984);
+    assert_eq!(HybridSigSignature::LEN, 3373);
+}
+
+/// Sign/verify round-trip — the verifier accepts an authentic hybrid
+/// signature produced by the matching signing key.
+#[test]
+fn hybrid_sig_sign_verify_round_trip() {
+    let kp = HybridSigKeyPair::try_generate().expect("hybrid keypair should succeed");
+
+    let message = b"Pulsar Phase 1.1.C.4 hybrid signature round-trip";
+    let context = b"";
+    let signature = kp
+        .private_key()
+        .try_sign(message, context)
+        .expect("hybrid sign should succeed");
+
+    kp.public_key()
+        .verify(message, context, &signature)
+        .expect("authentic hybrid signature must verify");
+}
+
+/// Sign/verify round-trip with a non-empty context exercises the
+/// FIPS 204 § 5.2 ML-DSA context binding AND the Ed25519 prefix
+/// transformation.
+#[test]
+fn hybrid_sig_sign_verify_round_trip_with_context() {
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+
+    let message = b"context-binding test";
+    let context = b"protocol-A";
+    let signature = kp
+        .private_key()
+        .try_sign(message, context)
+        .expect("sign should succeed");
+
+    kp.public_key()
+        .verify(message, context, &signature)
+        .expect("authentic signature with context must verify");
+}
+
+/// Verification-key wire format round-trip — `to_bytes` followed by
+/// `from_bytes` recovers the same verification key (byte-equal in
+/// both constituent halves).
+#[test]
+fn hybrid_sig_verification_key_serialization_round_trip() {
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let original_vk = kp.public_key().clone();
+
+    let serialized = original_vk.to_bytes();
+    assert_eq!(serialized.len(), 1984);
+    let recovered = HybridSigPublicKey::from_bytes(&serialized);
+
+    assert_eq!(
+        original_vk.classical().as_bytes(),
+        recovered.classical().as_bytes(),
+        "Ed25519 share must round-trip identically",
+    );
+    assert_eq!(
+        original_vk.pqc().as_bytes(),
+        recovered.pqc().as_bytes(),
+        "ML-DSA share must round-trip identically",
+    );
+}
+
+/// Signature wire format round-trip — recovered signature verifies
+/// the same as the original.
+#[test]
+fn hybrid_sig_signature_serialization_round_trip() {
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let message = b"signature serialization round-trip";
+    let signature = kp
+        .private_key()
+        .try_sign(message, b"")
+        .expect("sign should succeed");
+
+    let serialized = signature.to_bytes();
+    assert_eq!(serialized.len(), 3373);
+    let recovered = HybridSigSignature::from_bytes(&serialized);
+
+    // Both signatures should verify under the same verification key.
+    kp.public_key()
+        .verify(message, b"", &signature)
+        .expect("original should verify");
+    kp.public_key()
+        .verify(message, b"", &recovered)
+        .expect("wire-format-recovered should verify");
+}
+
+/// BOTH-must-pass semantics — tampering the Ed25519 share of the
+/// signature causes verification to fail with `SignatureVerifyFailed`.
+/// The ML-DSA share is left intact.
+#[test]
+fn hybrid_sig_verify_rejects_tampered_ed25519_share() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let message = b"Ed25519-tamper test";
+    let signature = kp
+        .private_key()
+        .try_sign(message, b"")
+        .expect("sign should succeed");
+
+    // Flip a bit in the Ed25519 share (offset 0 of the wire format).
+    let mut tampered_bytes = signature.to_bytes();
+    tampered_bytes[0] ^= 0x01;
+    let tampered = HybridSigSignature::from_bytes(&tampered_bytes);
+
+    match kp.public_key().verify(message, b"", &tampered) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for tampered Ed25519 share; got {other:?}"),
+    }
+}
+
+/// BOTH-must-pass semantics — tampering the ML-DSA share of the
+/// signature causes verification to fail with `SignatureVerifyFailed`.
+/// The Ed25519 share is left intact (still individually valid),
+/// but the BOTH-must-pass invariant rejects the hybrid signature.
+#[test]
+fn hybrid_sig_verify_rejects_tampered_mldsa_share() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let message = b"ML-DSA-tamper test";
+    let signature = kp
+        .private_key()
+        .try_sign(message, b"")
+        .expect("sign should succeed");
+
+    // Flip a bit in the ML-DSA share (offset 64 of the wire format).
+    let mut tampered_bytes = signature.to_bytes();
+    tampered_bytes[sizes::MLDSA_SIG_OFFSET] ^= 0x01;
+    let tampered = HybridSigSignature::from_bytes(&tampered_bytes);
+
+    match kp.public_key().verify(message, b"", &tampered) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for tampered ML-DSA share; got {other:?}"),
+    }
+}
+
+/// Verifying a tampered message under an authentic signature fails.
+#[test]
+fn hybrid_sig_verify_rejects_tampered_message() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let signature = kp
+        .private_key()
+        .try_sign(b"original message", b"")
+        .expect("sign should succeed");
+
+    match kp.public_key().verify(b"tampered message", b"", &signature) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for tampered message; got {other:?}"),
+    }
+}
+
+/// Verifying with a different context than was used at signing time
+/// fails. This exercises BOTH the ML-DSA § 5.2 native context
+/// binding AND the Ed25519 prefix transformation.
+#[test]
+fn hybrid_sig_verify_rejects_wrong_context() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let message = b"context-mismatch test";
+    let signature = kp
+        .private_key()
+        .try_sign(message, b"protocol-A")
+        .expect("sign should succeed");
+
+    match kp.public_key().verify(message, b"protocol-B", &signature) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for context mismatch; got {other:?}"),
+    }
+}
+
+/// Verifying under an unrelated verification key fails.
+#[test]
+fn hybrid_sig_verify_rejects_wrong_verification_key() {
+    use pulsar_kernel::error::Error;
+
+    let kp_a = HybridSigKeyPair::try_generate().expect("kp a should succeed");
+    let kp_b = HybridSigKeyPair::try_generate().expect("kp b should succeed");
+
+    let message = b"cross-key test";
+    let signature_a = kp_a
+        .private_key()
+        .try_sign(message, b"")
+        .expect("sign a should succeed");
+
+    match kp_b.public_key().verify(message, b"", &signature_a) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!("expected SignatureVerifyFailed for wrong key; got {other:?}"),
+    }
+}
+
+/// Signing with an oversize context (> 255 bytes) is rejected.
+#[test]
+fn hybrid_sig_sign_rejects_oversize_context() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let oversize = vec![0_u8; 256];
+    match kp.private_key().try_sign(b"any message", &oversize) {
+        Err(Error::InputTooLong {
+            actual: 256,
+            max: 255,
+        }) => {} // expected
+        other => panic!("expected InputTooLong; got {other:?}"),
+    }
+}
+
+/// Verifying with an oversize context (> 255 bytes) is rejected.
+#[test]
+fn hybrid_sig_verify_rejects_oversize_context() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let signature = kp
+        .private_key()
+        .try_sign(b"msg", b"")
+        .expect("sign should succeed");
+
+    let oversize = vec![0_u8; 256];
+    match kp.public_key().verify(b"msg", &oversize, &signature) {
+        Err(Error::InputTooLong {
+            actual: 256,
+            max: 255,
+        }) => {} // expected
+        other => panic!("expected InputTooLong; got {other:?}"),
+    }
+}
+
+/// Domain-separation invariant: a hybrid signature's Ed25519 share
+/// does NOT verify under a bare Ed25519 verifier on the raw message
+/// bytes. The hybrid scheme prefixes `HYBRID_LABEL ||
+/// context_len_byte || context` to the Ed25519 input, so a hybrid
+/// Ed25519 signature is structurally distinct from a bare Ed25519
+/// signature using the same signing key.
+///
+/// This invariant is important for the regulated-domain audit
+/// posture — it guarantees that a hybrid signature cannot be
+/// "downgraded" to a classical-only signature by stripping the
+/// PQC half and exposing the Ed25519 share.
+#[test]
+fn hybrid_sig_ed25519_share_not_valid_for_raw_message() {
+    use pulsar_kernel::error::Error;
+
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let message = b"domain-separation test";
+    let signature = kp
+        .private_key()
+        .try_sign(message, b"")
+        .expect("sign should succeed");
+
+    // Attempt to verify the hybrid's Ed25519 share against the RAW
+    // message under the bare Ed25519 verifier (i.e., without
+    // applying the hybrid prefix transformation). This must fail —
+    // the hybrid scheme signs the prefix-transformed input, so the
+    // raw-message verification cannot recover the same digest.
+    let bare_verifier = kp.public_key().classical();
+    match bare_verifier.verify(message, signature.classical()) {
+        Err(Error::SignatureVerifyFailed) => {} // expected
+        other => panic!(
+            "expected SignatureVerifyFailed (hybrid Ed25519 share must NOT verify against raw \
+             message under bare Ed25519); got {other:?}",
+        ),
+    }
+}
+
+/// `Debug` redaction on the hybrid private key.
+#[test]
+fn hybrid_sig_debug_redacts_private_key() {
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+
+    let private_debug = format!("{:?}", kp.private_key());
+    assert!(private_debug.contains("HybridSigPrivateKey"));
+    assert!(
+        private_debug.contains(".."),
+        "hybrid private-key Debug must use finish_non_exhaustive",
+    );
+
+    let public_debug = format!("{:?}", kp.public_key());
+    assert!(public_debug.contains("HybridSigPublicKey"));
+}

--- a/crates/pulsar-kernel/tests/hybrid_sig_property.rs
+++ b/crates/pulsar-kernel/tests/hybrid_sig_property.rs
@@ -1,0 +1,123 @@
+//! Iteration tests for `pulsar_kernel::crypto::hybrid_sig`.
+//!
+//! Hybrid Ed25519+ML-DSA-65 signature. Each test repeats its core
+//! invariant check across 16 randomly-generated CSPRNG-driven
+//! keypairs / sign calls — same coverage as a proptest property but
+//! without the single-input shrinking machinery (which would have
+//! nothing to shrink in this test surface anyway, since the wrapper
+//! does not yet expose seed-driven keypair / signing APIs for the
+//! hybrid). Phase 1.1.D's hybrid-vector pass will replace these
+//! with seed-driven proptest properties.
+//!
+//! Properties exercised:
+//!
+//! - Sign/verify round-trip across CSPRNG-driven keypairs
+//! - Distinct keypairs yield distinct verification keys (probabilistic)
+//! - Distinct sign calls yield distinct signatures under same key
+//!   (because ML-DSA's hedged signing draws fresh randomness per
+//!   call; Ed25519 is deterministic)
+//! - Wire-format `to_bytes` / `from_bytes` is a perfect round-trip
+
+#![allow(clippy::expect_used, clippy::unwrap_used)]
+
+use pulsar_kernel::crypto::hybrid_sig::{HybridSigKeyPair, HybridSigPublicKey, HybridSigSignature};
+
+/// Number of CSPRNG-driven iterations per test.
+///
+/// Hybrid keypair gen + sign + verify cost ~500 µs total (dominated
+/// by ML-DSA-65). Per-test ≈ 500 µs × 16 ≈ 8 ms.
+const ITERATIONS: usize = 16;
+
+/// Sign/verify round-trip recovers `Ok(())`.
+#[test]
+fn sign_verify_round_trip() {
+    for i in 0..ITERATIONS {
+        let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+        let message = format!("iteration-{i}").into_bytes();
+        let signature = kp
+            .private_key()
+            .try_sign(&message, b"")
+            .expect("sign should succeed");
+        kp.public_key()
+            .verify(&message, b"", &signature)
+            .expect("authentic signature must verify");
+    }
+}
+
+/// Distinct hybrid signature keypairs yield distinct verification
+/// keys (probabilistic). For two fresh CSPRNG-driven keypairs the
+/// chance of identical Ed25519 OR ML-DSA-65 verification keys is
+/// bounded by 2⁻²⁵⁶ + 2⁻¹⁵⁰⁰⁰ish, effectively zero.
+#[test]
+fn distinct_keypairs_yield_distinct_verification_keys() {
+    for _ in 0..ITERATIONS {
+        let kp_a = HybridSigKeyPair::try_generate().expect("kp a should succeed");
+        let kp_b = HybridSigKeyPair::try_generate().expect("kp b should succeed");
+
+        assert_ne!(
+            kp_a.public_key().to_bytes(),
+            kp_b.public_key().to_bytes(),
+            "two fresh hybrid keypairs must yield distinct verification keys",
+        );
+    }
+}
+
+/// Distinct sign calls under the same signing key yield distinct
+/// signatures. Ed25519 is deterministic per RFC 8032 § 5.1.6 so its
+/// share is identical across calls, but ML-DSA-65 is randomised by
+/// default per FIPS 204 § 5.4 (hedged mode draws fresh `rnd` per
+/// call), so the ML-DSA share differs — and therefore the
+/// concatenated wire-format signature differs.
+#[test]
+fn distinct_sign_calls_yield_distinct_signatures() {
+    let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+    let message = b"deterministic-vs-hedged signing test";
+
+    for _ in 0..ITERATIONS {
+        let sig_a = kp
+            .private_key()
+            .try_sign(message, b"")
+            .expect("sign a should succeed");
+        let sig_b = kp
+            .private_key()
+            .try_sign(message, b"")
+            .expect("sign b should succeed");
+
+        assert_ne!(
+            sig_a.to_bytes(),
+            sig_b.to_bytes(),
+            "two sign calls under same key must produce distinct signatures \
+             (ML-DSA-65's randomised signing changes per call)",
+        );
+
+        // Both signatures must verify under the same public key.
+        kp.public_key()
+            .verify(message, b"", &sig_a)
+            .expect("sig a must verify");
+        kp.public_key()
+            .verify(message, b"", &sig_b)
+            .expect("sig b must verify");
+    }
+}
+
+/// Wire-format serialisation is a perfect round-trip.
+#[test]
+fn wire_format_round_trip() {
+    for _ in 0..ITERATIONS {
+        let kp = HybridSigKeyPair::try_generate().expect("keypair should succeed");
+
+        let vk_bytes = kp.public_key().to_bytes();
+        let recovered_vk = HybridSigPublicKey::from_bytes(&vk_bytes);
+
+        let signature = kp
+            .private_key()
+            .try_sign(b"wire-format test", b"")
+            .expect("sign should succeed");
+        let sig_bytes = signature.to_bytes();
+        let recovered_sig = HybridSigSignature::from_bytes(&sig_bytes);
+
+        recovered_vk
+            .verify(b"wire-format test", b"", &recovered_sig)
+            .expect("wire-format-recovered sig must verify under wire-format-recovered vk");
+    }
+}


### PR DESCRIPTION
## Summary

Fourth sub-phase of Phase 1.1.C — second hybrid construction (after PR #408's hybrid X25519+ML-KEM-768 KEM). Lands the **hybrid post-quantum + classical digital-signature scheme** per Decision 2.58: every signature scheme that anchors a long-term commitment runs Ed25519 + ML-DSA-65 in parallel and verifies REQUIRE BOTH to pass. Together with PR #408 this completes Pulsar's hybrid-PQC surface for both KEM and signatures. Closes the cryptographic primitive surface for Sprint 1.1.

## Surfaces landed

- **`pulsar-kernel::crypto::hybrid_sig`** — `HybridSigKeyPair` / `HybridSigPublicKey` / `HybridSigPrivateKey` / `HybridSigSignature`. Sign produces both Ed25519 + ML-DSA-65 signatures over the same message; verify requires BOTH to pass (either failure → single `SignatureVerifyFailed`, no info leak).
- **Context binding via Ed25519 prefix transformation** — Ed25519 has no native context; the wrapper signs `HYBRID_LABEL || u8(|ctx|) || ctx || M` for the Ed25519 share. ML-DSA-65 receives `(M, ctx)` directly and uses FIPS 204 § 5.2 native binding. Domain-separates hybrid Ed25519 sigs from bare Ed25519 sigs (test pinned: `hybrid_sig_ed25519_share_not_valid_for_raw_message`).
- **Wire format** — `vk_ed25519 || vk_mldsa` (32 + 1952 = 1984 bytes), `sig_ed25519 || sig_mldsa` (64 + 3309 = 3373 bytes). `to_bytes` / `from_bytes` round-trips covered by tests.

## Tests

18 new tests across 2 integration test files:

- `hybrid_sig_kat.rs` — 14 tests: sizes / sign-verify round-trip (empty + non-empty context) / wire format round-trips / BOTH-must-pass on tampered Ed25519 share / BOTH-must-pass on tampered ML-DSA share / tampered message / context mismatch / cross-key rejection / oversize context (sign + verify) / **domain-separation invariant** (hybrid Ed25519 share doesn't verify under bare Ed25519 verifier on raw message — prevents downgrade attacks) / Debug redaction
- `hybrid_sig_property.rs` — 4 iteration-tests (16 iterations, ~500 µs/op): round-trip / distinct keypairs → distinct vks / distinct signs → distinct signatures (ML-DSA hedged) / wire-format round-trip preserves correctness

## Quality gates

- `cargo fmt --all -- --check` ✓
- `cargo clippy -p pulsar-kernel --all-targets -- -D warnings` ✓
- `cargo nextest run -p pulsar-kernel` — **196/196 PASS** (+18 from this phase)
- `cargo test -p pulsar-kernel --doc` ✓

## Test plan

- [x] `cargo nextest run -p pulsar-kernel`
- [x] `cargo clippy -p pulsar-kernel --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] GPG-signed commit (`F779A214...3D12DF7`)
- [ ] `/review` on this PR
- [ ] `/security-review` on this PR